### PR TITLE
Add redirects to fcgi for other API calls in the sample config file

### DIFF
--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -21,13 +21,35 @@ mimetype.assign = (
 
 #debug.log-request-handling = "enable"
 
-$HTTP["url"] =~ "^/api/0\.6/map" {
-  server.error-handler-404 = "/dispatch.map"
-}
-$HTTP["url"] =~ "^/api/0\.6/map.json" {
-  server.error-handler-404 = "/dispatch.map"
-}
 
+
+$HTTP["request-method"] == "GET" {
+  $HTTP["url"] == "/api/0.6/map" {
+    server.error-handler-404 = "/dispatch.map"
+  }
+
+  # cgimap needs to be built with --enable-experimental --enable-api07
+  # to handle the URLs below
+
+  $HTTP["url"] == "/api/0.6/map.json" {
+    server.error-handler-404 = "/dispatch.map"
+  }
+  $HTTP["url"] =~ "^/api/0\.6/(node|relation|way)/[[:digit:]]+$" {
+    server.error-handler-404 = "/dispatch.map"
+  }
+  $HTTP["url"] =~ "^/api/0\.6/(relation|way)/[[:digit:]]+/full$" {
+    server.error-handler-404 = "/dispatch.map"
+  }
+  $HTTP["url"] == "/api/0.6/nodes" {
+    server.error-handler-404 = "/dispatch.map"
+  }
+  $HTTP["url"] == "/api/0.6/ways" {
+    server.error-handler-404 = "/dispatch.map"
+  }
+  $HTTP["url"] == "/api/0.6/relations" {
+    server.error-handler-404 = "/dispatch.map"
+  }
+}
 fastcgi.debug = 1
 
 fastcgi.server = ( ".map" =>


### PR DESCRIPTION
The sample lighttpd.conf file now supports all API calls handled with `--enable-experimental`.

The map call no longer uses a regex to match in the config file but a direct string match.
