### PR TITLE
Remove the relations_from_way_nodes SQL.

### DIFF
--- a/include/backend/apidb/readonly_pgsql_selection.hpp
+++ b/include/backend/apidb/readonly_pgsql_selection.hpp
@@ -39,7 +39,6 @@ public:
 	 void select_relations_from_ways();
 	 void select_nodes_from_way_nodes();
 	 void select_relations_from_nodes();
-	 void select_relations_from_way_nodes();
 	 void select_relations_from_relations();
   void select_relations_members_of_relations();
 

--- a/include/backend/apidb/writeable_pgsql_selection.hpp
+++ b/include/backend/apidb/writeable_pgsql_selection.hpp
@@ -36,7 +36,6 @@ public:
 	 void select_relations_from_ways();
 	 void select_nodes_from_way_nodes();
 	 void select_relations_from_nodes();
-	 void select_relations_from_way_nodes();
 	 void select_relations_from_relations();
   void select_relations_members_of_relations();
 

--- a/include/data_selection.hpp
+++ b/include/data_selection.hpp
@@ -85,10 +85,6 @@ public:
    /// select relations which include selected nodes 
 	 virtual void select_relations_from_nodes() = 0;
 	 
-   /// update relations to include relations which have node members
-	 /// which are used in already selected ways.
-	 virtual void select_relations_from_way_nodes() = 0;
-	 
    /// select relations which include selected relations
 	 virtual void select_relations_from_relations() = 0;
 

--- a/src/api06/map_handler.cpp
+++ b/src/api06/map_handler.cpp
@@ -34,7 +34,6 @@ map_responder::map_responder(mime::type mt, bbox b, data_selection &x)
   sel.select_nodes_from_way_nodes();
   sel.select_relations_from_ways();
   sel.select_relations_from_nodes();
-  sel.select_relations_from_way_nodes();
   sel.select_relations_from_relations();
 }
 

--- a/src/api07/map_handler.cpp
+++ b/src/api07/map_handler.cpp
@@ -34,7 +34,6 @@ map_responder::map_responder(mime::type mt, bbox b, data_selection &x)
   sel.select_nodes_from_way_nodes();
   sel.select_relations_from_ways();
   sel.select_relations_from_nodes();
-  sel.select_relations_from_way_nodes();
   sel.select_relations_from_relations();
 }
 

--- a/src/backend/apidb/readonly_pgsql_selection.cpp
+++ b/src/backend/apidb/readonly_pgsql_selection.cpp
@@ -450,19 +450,6 @@ readonly_pgsql_selection::select_relations_from_nodes() {
 }
 
 void 
-readonly_pgsql_selection::select_relations_from_way_nodes() {
-   if (!sel_ways.empty()) {
-      stringstream query;
-      query << "select distinct relation_id as id from current_relation_members rm "
-         "where rm.member_type='Node' and rm.member_id in (select distinct "
-         "node_id from current_way_nodes where way_id in (";
-      std::copy(sel_ways.begin(), sel_ways.end(), infix_ostream_iterator<osm_id_t>(query, ","));
-      query << "))";
-      insert_results_of(w, query, sel_relations);
-   }
-}
-
-void 
 readonly_pgsql_selection::select_relations_from_relations() {
    if (!sel_relations.empty()) {
       stringstream query;

--- a/src/backend/apidb/writeable_pgsql_selection.cpp
+++ b/src/backend/apidb/writeable_pgsql_selection.cpp
@@ -331,11 +331,6 @@ writeable_pgsql_selection::select_relations_from_nodes() {
 }
 
 void 
-writeable_pgsql_selection::select_relations_from_way_nodes() {
-   w.prepared("relations_from_way_nodes").exec();
-}
-
-void 
 writeable_pgsql_selection::select_relations_from_relations() {
    w.prepared("relations_from_relations").exec();
 }
@@ -444,12 +439,6 @@ writeable_pgsql_selection::factory::factory(pqxx::connection &conn)
       "insert into tmp_relations select distinct rm.relation_id from "
       "current_relation_members rm where rm.member_type='Relation' and "
       "rm.member_id in (select id from tmp_relations) and rm.relation_id "
-      "not in (select id from tmp_relations)");
-   m_connection.prepare("relations_from_way_nodes",
-      "insert into tmp_relations select distinct rm.relation_id from "
-      "current_relation_members rm where rm.member_type='Node' and "
-      "rm.member_id in (select distinct node_id from current_way_nodes "
-      "where way_id in (select id from tmp_ways)) and rm.relation_id "
       "not in (select id from tmp_relations)");
 }
 


### PR DESCRIPTION
This SQL added relations that were parents of any nodes that were children
of included ways, but those nodes are already included by nodes_from_way_nodes
and the relations then get included by relations_from_nodes.

I've tested this with `make check` and with a couple of subway stop nodes and turn restriction nodes.

This should give a reasonable increase of performance because joining against way_nodes is expensive.
