### PR TITLE
Use mod_rewrite instead of error handlers to redirect to cgimap

### DIFF
--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -24,31 +24,12 @@ mimetype.assign = (
 
 
 $HTTP["request-method"] == "GET" {
-  $HTTP["url"] == "/api/0.6/map" {
-    server.error-handler-404 = "/dispatch.map"
-  }
-
-  # cgimap needs to be built with --enable-experimental --enable-api07
-  # to handle the URLs below
-
-  $HTTP["url"] == "/api/0.6/map.json" {
-    server.error-handler-404 = "/dispatch.map"
-  }
-  $HTTP["url"] =~ "^/api/0\.6/(node|relation|way)/[[:digit:]]+$" {
-    server.error-handler-404 = "/dispatch.map"
-  }
-  $HTTP["url"] =~ "^/api/0\.6/(relation|way)/[[:digit:]]+/full$" {
-    server.error-handler-404 = "/dispatch.map"
-  }
-  $HTTP["url"] == "/api/0.6/nodes" {
-    server.error-handler-404 = "/dispatch.map"
-  }
-  $HTTP["url"] == "/api/0.6/ways" {
-    server.error-handler-404 = "/dispatch.map"
-  }
-  $HTTP["url"] == "/api/0.6/relations" {
-    server.error-handler-404 = "/dispatch.map"
-  }
+  url.rewrite-once = (
+    "^/api/0\.6/map(\.json)?(\?(.*))?$" => "/dispatch.map",
+    "^/api/0\.6/(node|way|relation)/[[:digit:]]+$" => "/dispatch.map",
+    "^/api/0\.6/(way|relation)/[[:digit:]]+/full$" => "/dispatch.map",
+    "^/api/0\.6/(nodes|ways|relations)(\?(.*))?$" => "/dispatch.map",
+  )
 }
 fastcgi.debug = 1
 


### PR DESCRIPTION
Using rewrites is a simpler method then relying on 404 errors and redirecting

Note: For my setup I also have this in the config file to redirect other responses to the api.osm.org servers

```
$HTTP["url"] =~ "/api/.*" {
        proxy.server = ( "" => (        ( "host" => "193.63.75.100"),
                                        ( "host" => "193.63.75.99"),
                                        ( "host" => "193.63.75.103") ) )
}
```
