### PR TITLE
Eliminate num_nodes on map? calls

### DIFF
--- a/include/backend/apidb/readonly_pgsql_selection.hpp
+++ b/include/backend/apidb/readonly_pgsql_selection.hpp
@@ -32,7 +32,7 @@ public:
 	 void select_nodes(const std::list<osm_id_t> &);
 	 void select_ways(const std::list<osm_id_t> &);
 	 void select_relations(const std::list<osm_id_t> &);
-	 void select_nodes_from_bbox(const bbox &bounds, int max_nodes);
+	 int select_nodes_from_bbox(const bbox &bounds, int max_nodes);
 	 void select_nodes_from_relations();
 	 void select_ways_from_nodes();
 	 void select_ways_from_relations();

--- a/include/backend/apidb/writeable_pgsql_selection.hpp
+++ b/include/backend/apidb/writeable_pgsql_selection.hpp
@@ -29,7 +29,7 @@ public:
 	 void select_nodes(const std::list<osm_id_t> &);
 	 void select_ways(const std::list<osm_id_t> &);
 	 void select_relations(const std::list<osm_id_t> &);
-	 void select_nodes_from_bbox(const bbox &bounds, int max_nodes);
+	 int select_nodes_from_bbox(const bbox &bounds, int max_nodes);
 	 void select_nodes_from_relations();
 	 void select_ways_from_nodes();
 	 void select_ways_from_relations();

--- a/include/data_selection.hpp
+++ b/include/data_selection.hpp
@@ -65,7 +65,7 @@ public:
 	 virtual void select_relations(const std::list<osm_id_t> &) = 0;
 
    /// given a bounding box, select nodes within that bbox up to a limit of max_nodes
-	 virtual void select_nodes_from_bbox(const bbox &bounds, int max_nodes) = 0;
+	 virtual int select_nodes_from_bbox(const bbox &bounds, int max_nodes) = 0;
 
    /// selects the node members of any already selected relations
 	 virtual void select_nodes_from_relations() = 0;

--- a/src/api06/map_handler.cpp
+++ b/src/api06/map_handler.cpp
@@ -19,10 +19,8 @@ map_responder::map_responder(mime::type mt, bbox b, data_selection &x)
   : osm_responder(mt, x, boost::optional<bbox>(b)) {
   // create temporary tables of nodes, ways and relations which
   // are in or used by elements in the bbox
-  sel.select_nodes_from_bbox(b, MAX_NODES);
+  int num_nodes = sel.select_nodes_from_bbox(b, MAX_NODES);
 
-  // check how many nodes we got
-  int num_nodes = sel.num_nodes();
   // TODO: make configurable parameter?
   if (num_nodes > MAX_NODES) {
     throw http::bad_request((format("You requested too many nodes (limit is %1%). "

--- a/src/backend/apidb/readonly_pgsql_selection.cpp
+++ b/src/backend/apidb/readonly_pgsql_selection.cpp
@@ -34,7 +34,7 @@ check_table_visibility(pqxx::work &w, osm_id_t id, const char *table) {
    }	
 }
 
-inline void
+inline int
 insert_results_of(pqxx::work &w, std::stringstream &query, set<osm_id_t> &elems) {
    pqxx::result res = w.exec(query);
 
@@ -43,6 +43,7 @@ insert_results_of(pqxx::work &w, std::stringstream &query, set<osm_id_t> &elems)
       const osm_id_t id = (*itr)["id"].as<osm_id_t>();
       elems.insert(id);
    }
+   return res.affected_rows();
 }
 
 void extract_elem(const pqxx::result::tuple &row, element_info &elem) {
@@ -318,7 +319,7 @@ readonly_pgsql_selection::select_relations(const std::list<osm_id_t> &ids) {
    }
 }
 
-void 
+int
 readonly_pgsql_selection::select_nodes_from_bbox(const bbox &bounds, int max_nodes) {
    const set<unsigned int> tiles = 
       tiles_for_area(bounds.minlat, bounds.minlon, 
@@ -363,8 +364,8 @@ readonly_pgsql_selection::select_nodes_from_bbox(const bbox &bounds, int max_nod
   
    logger::message("Filling sel_nodes from bbox");
    logger::message(query.str());
-  
-   insert_results_of(w, query, sel_nodes);
+
+   return insert_results_of(w, query, sel_nodes);
 }
 
 void 

--- a/src/backend/apidb/writeable_pgsql_selection.cpp
+++ b/src/backend/apidb/writeable_pgsql_selection.cpp
@@ -242,7 +242,7 @@ writeable_pgsql_selection::select_relations(const std::list<osm_id_t> &ids) {
    w.prepared("add_relations_list")(ids).exec();
 }
 
-void 
+int
 writeable_pgsql_selection::select_nodes_from_bbox(const bbox &bounds, int max_nodes) {
    const set<unsigned int> tiles = 
       tiles_for_area(bounds.minlat, bounds.minlon, 
@@ -290,7 +290,7 @@ writeable_pgsql_selection::select_nodes_from_bbox(const bbox &bounds, int max_no
    logger::message(query.str());
    
    // assume this throws if it fails?
-   w.exec(query);
+   return w.exec(query).affected_rows();
 }
 
 void 


### PR DESCRIPTION
By using the number of rows that postgresql returns after an insert we can avoid a sequential scan on tmp_nodes.

This should increase speed, and benchmarking showed a 0.7% increase in speed over a small testsuite. It's not a huge gain and it would be a lower percentage on a larger dataset with more disk access, but every bit helps.
