### PR TITLE
Move db-specific option logic to backends

### DIFF
--- a/src/backend/apidb/apidb.cpp
+++ b/src/backend/apidb/apidb.cpp
@@ -23,7 +23,6 @@ struct apidb_backend : public backend {
       ("username", po::value<string>(), "database user name")
       ("password", po::value<string>(), "database password")
       ("charset", po::value<string>()->default_value("utf8"), "database character set")
-      ("port", po::value<int>(), "port number to use")
       ("readonly", "use the database in read-only mode")
       ("cachesize", po::value<size_t>()->default_value(CACHE_SIZE), "maximum size of changeset cache")
       ;
@@ -36,6 +35,10 @@ struct apidb_backend : public backend {
   shared_ptr<data_selection::factory> create(const po::variables_map &opts) {
     // database type
     bool db_is_writeable = opts.count("readonly") == 0;
+
+    if (opts.count("dbname") == 0) {
+      throw std::runtime_error("database name not specified");
+    }
 
     shared_ptr<data_selection::factory> factory;
     if (db_is_writeable) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,6 +180,7 @@ get_options(int argc, char **argv, po::variables_map &options) {
     ("memcache", po::value<string>(), "memcache server specification")
     ("ratelimit", po::value<int>(), "average number of bytes/s to allow each client")
     ("maxdebt", po::value<int>(), "maximum debt (in Mb) to allow each client before rate limiting")
+    ("port", po::value<int>(), "port number to use")
     ;
 
   // add the backend options to the options description
@@ -192,10 +193,6 @@ get_options(int argc, char **argv, po::variables_map &options) {
   if (options.count("help")) {
     std::cout << desc << std::endl;
     exit(1);
-  }
-
-  if (options.count("dbname") == 0) {
-    throw runtime_error("database name not specified");
   }
 
   if (options.count("daemon") != 0 && options.count("port") == 0) {


### PR DESCRIPTION
Also move --port which is not a backend option out of the backends
