### PR TITLE
Short-circuit empty areas on the map? call

### DIFF
--- a/src/api06/map_handler.cpp
+++ b/src/api06/map_handler.cpp
@@ -27,12 +27,14 @@ map_responder::map_responder(mime::type mt, bbox b, data_selection &x)
 				    "Either request a smaller area, or use planet.osm")
 			     % MAX_NODES).str());
   }
-
-  sel.select_ways_from_nodes();
-  sel.select_nodes_from_way_nodes();
-  sel.select_relations_from_ways();
-  sel.select_relations_from_nodes();
-  sel.select_relations_from_relations();
+  // Short-circuit empty areas
+  if (num_nodes > 0) {
+    sel.select_ways_from_nodes();
+    sel.select_nodes_from_way_nodes();
+    sel.select_relations_from_ways();
+    sel.select_relations_from_nodes();
+    sel.select_relations_from_relations();
+  }
 }
 
 map_responder::~map_responder() {

--- a/src/api07/map_handler.cpp
+++ b/src/api07/map_handler.cpp
@@ -29,12 +29,14 @@ map_responder::map_responder(mime::type mt, bbox b, data_selection &x)
 				    "Either request a smaller area, or use planet.osm")
 			     % MAX_NODES).str());
   }
-
-  sel.select_ways_from_nodes();
-  sel.select_nodes_from_way_nodes();
-  sel.select_relations_from_ways();
-  sel.select_relations_from_nodes();
-  sel.select_relations_from_relations();
+  // Short-circuit empty areas
+  if (num_nodes > 0) {
+    sel.select_ways_from_nodes();
+    sel.select_nodes_from_way_nodes();
+    sel.select_relations_from_ways();
+    sel.select_relations_from_nodes();
+    sel.select_relations_from_relations();
+  }
 }
 
 map_responder::~map_responder() {


### PR DESCRIPTION
If there are 0 nodes in the bbox then all the subsequent SQL will have
no effect, so we can just skip it.

My test log is probably empty area heavy compared to the api.osm.org traffic, but I got a 6.1% speed increase, which is pretty substantial.
