### PR TITLE
Accept empty responses in tests

### DIFF
--- a/test/test_functions.rb
+++ b/test/test_functions.rb
@@ -26,7 +26,6 @@ def test_request(method, uri, env = {})
     sin.close
     headers, data = sout.read.split("\r\n\r\n")
     assert(headers.nil?, false, "FCGI should have returned headers.")
-    assert(data.nil?, false, "FCGI should have returned data.")
     headers = Hash[*headers.split("\r\n").collect_concat{|l| k,v = l.split(": "); [k,v]}]
     
     assert(thr.value.success?, true, "FCGI exited successfully.")


### PR DESCRIPTION
cgimap and the rails port return an empty response for some error
replies (e.g. 404 and 410). Make the test framework accept this.

If a test is expecting content, the nature of the content is tested
in the checks.

Fixes issues I introduced in zerebubuth/openstreetmap-cgimap#26
