### PR TITLE
Don't output lat/lon for deleted nodes

### DIFF
--- a/src/json_formatter.cpp
+++ b/src/json_formatter.cpp
@@ -114,9 +114,10 @@ json_formatter::write_node(const element_info &elem, double lon, double lat, con
   writer->start_object();
   
   write_common(elem);
-  writer->object_key("lat"); writer->entry_double(lat);
-  writer->object_key("lon"); writer->entry_double(lon);
-
+  if (elem.visible) {
+    writer->object_key("lat"); writer->entry_double(lat);
+    writer->object_key("lon"); writer->entry_double(lon);
+  }
   write_tags(tags);
 
   writer->end_object();  

--- a/src/xml_formatter.cpp
+++ b/src/xml_formatter.cpp
@@ -108,9 +108,10 @@ void
 xml_formatter::write_node(const element_info &elem, double lon, double lat, const tags_t &tags) {
   writer->start("node");
   write_common(elem);
-  writer->attribute("lat", lat);
-  writer->attribute("lon", lon);
-
+  if (elem.visible) {
+    writer->attribute("lat", lat);
+    writer->attribute("lon", lon);
+  }
   write_tags(tags);
 
   writer->end();


### PR DESCRIPTION
The API changed during the redaction to not output lat/lon for deleted nodes.

This changes cgimap to catch up with that change.

Fixes #30
