### PR TITLE
Move single- and multi-element calls out of experimental

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,9 +3,7 @@ SUBDIRS=src
 TESTS = 
 if ENABLE_APIDB
 TESTS += test/test_empty.rb test/test_map.rb test/test_anon.rb
-if ENABLE_EXPERIMENTAL
 TESTS += test/test_node.rb test/test_way.rb test/test_relation.rb
-endif
 endif
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = test/test.sh

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,18 +35,18 @@ ___map_SOURCES+=\
 endif
 
 ___map_SOURCES+=\
-	api06/map_handler.cpp
+	api06/map_handler.cpp \
+	api06/node_handler.cpp \
+	api06/nodes_handler.cpp \
+	api06/relation_handler.cpp \
+	api06/relations_handler.cpp \
+	api06/way_handler.cpp \
+	api06/ways_handler.cpp
 
 if ENABLE_EXPERIMENTAL
 ___map_SOURCES+=\
-	api06/node_handler.cpp \
-	api06/nodes_handler.cpp \
 	api06/relation_full_handler.cpp \
-	api06/relation_handler.cpp \
-	api06/relations_handler.cpp \
-	api06/way_full_handler.cpp \
-	api06/way_handler.cpp \
-	api06/ways_handler.cpp
+	api06/way_full_handler.cpp
 endif
 
 if ENABLE_API07

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -5,16 +5,18 @@
 /*** API 0.6 ***/
 #include "api06/map_handler.hpp"
 
-#ifdef ENABLE_EXPERIMENTAL
 #include "api06/node_handler.hpp"
 #include "api06/nodes_handler.hpp"
 
 #include "api06/way_handler.hpp"
 #include "api06/ways_handler.hpp"
-#include "api06/way_full_handler.hpp"
 
 #include "api06/relation_handler.hpp"
 #include "api06/relations_handler.hpp"
+
+#ifdef ENABLE_EXPERIMENTAL
+#include "api06/way_full_handler.hpp"
+
 #include "api06/relation_full_handler.hpp"
 #endif /* ENABLE_EXPERIMENTAL */
 
@@ -130,17 +132,18 @@ routes::routes()
 		r->add<map_handler>(root_ / "map");
 
 #ifdef ENABLE_EXPERIMENTAL
-		r->add<nodes_handler>(root_ / "nodes");
-		r->add<node_handler>(root_ / "node" / int_);
-
-		r->add<ways_handler>(root_ / "ways");
 		r->add<way_full_handler>(root_ / "way" / int_ / "full");
-		r->add<way_handler>(root_ / "way" / int_);
 
-		r->add<relations_handler>(root_ / "relations");
 		r->add<relation_full_handler>(root_ / "relation" / int_ / "full");
-		r->add<relation_handler>(root_ / "relation" / int_);
 #endif /* ENABLE_EXPERIMENTAL */
+
+		r->add<node_handler>(root_ / "node" / int_);
+		r->add<nodes_handler>(root_ / "nodes");
+		r->add<way_handler>(root_ / "way" / int_);
+		r->add<ways_handler>(root_ / "ways");
+		r->add<relation_handler>(root_ / "relation" / int_);
+		r->add<relations_handler>(root_ / "relations");
+
 	}
 
 #ifdef ENABLE_API07


### PR DESCRIPTION
## Known issues
- `make check` requires `--enable-experimental` because the ruby files test the `/way/id#/full` etc calls
- `HEAD` requests and 405 errors do not work properly. Fixed by #42 and #48, but these problems already impact the map? call without any noticeable complaints
## Test reports

With the merging of the branches above, all tests are passed for single- and multi-element calls. There are some differences from the rails port results:
- The rails port attempts to convert `asdf` to an ID in a request like `/nodes?nodes=asdf` and returns a 404 error, not a 400 error.
- The rails port does not always send a cache-control header on invalid requests
- The rails port throws 500 errors for IDs > 2^64
- When running under webbrick the rails port gives a `Content-Length: 0` header for HEAD requests which is wrong. This does not occur in production.

Except for the first, these are arguably bugs in the rails port. For the first, cgimap's response agrees with the documentation and I doubt anyone is relying on the rails port returning a 404 error on non-numeric IDs because a) it'd be nonsensical b) until recently the rails port returned 500 errors on some forms of invalid requests

One other untested difference is that cgimap does not allow caching of single-element results because it does not send a Last-Modified header.
