### PR TITLE
Use the number of selected ways/relations in full calls

### DIFF
--- a/src/api06/relation_full_handler.cpp
+++ b/src/api06/relation_full_handler.cpp
@@ -11,13 +11,15 @@ namespace api06 {
 
 relation_full_responder::relation_full_responder(mime::type mt_, osm_id_t id_, data_selection &w_) 
   : osm_responder(mt_, w_), id(id_) {
-	list<osm_id_t> ids;
+  list<osm_id_t> ids;
+  ids.push_back(id);
 
-  check_visibility();
+  if (sel.select_relations(ids) == 0) {
+    throw http::not_found("");
+  } else {
+    check_visibility();
+  }
 
-	ids.push_back(id);
-
-	sel.select_relations(ids);
   sel.select_nodes_from_relations();
   sel.select_ways_from_relations();
   sel.select_nodes_from_way_nodes();

--- a/src/api06/way_full_handler.cpp
+++ b/src/api06/way_full_handler.cpp
@@ -10,14 +10,16 @@ using std::list;
 namespace api06 {
 
 way_full_responder::way_full_responder(mime::type mt_, osm_id_t id_, data_selection &w_) 
-	: osm_responder(mt_, w_), id(id_) {
-	list<osm_id_t> ids;
+  : osm_responder(mt_, w_), id(id_) {
+  list<osm_id_t> ids;
+  ids.push_back(id);
 
-  check_visibility();
+  if (sel.select_ways(ids) == 0) {
+    throw http::not_found("");
+  } else {
+    check_visibility();
+  }
 
-	ids.push_back(id);
-
-	sel.select_ways(ids);
   sel.select_nodes_from_way_nodes();
 }
 


### PR DESCRIPTION
This is a slight optimization for queries against deleted nodes
as it avoids a select, but it is a significant improvement for
backends like pgsnapshot with no history because now no queries are
needed to check for non-existent ways

Passes all tests. Also replaces some tabs with spaces.
