### PR TITLE
Only set m_first_query on queries that could put initial data in the tables

### DIFF
--- a/include/backend/apidb/writeable_pgsql_selection.hpp
+++ b/include/backend/apidb/writeable_pgsql_selection.hpp
@@ -69,7 +69,7 @@ private:
 
   // true if a query hasn't been run yet, i.e: it's possible to
   // assume that all the temporary tables are empty.
-  bool m_first_query;
+  bool m_tables_empty;
 };
 
 #endif /* WRITEABLE_PGSQL_SELECTION_HPP */


### PR DESCRIPTION
Not that it really matters with the current cgimap API calls because m_first_query is never true on calls that don't put initial data into tables, but it seems odd to set the flag on queries that we know won't add any data to the tmp_tables.
