### PR TITLE
Quick hack to fix Content-Disposition header.

### DIFF
--- a/include/handler.hpp
+++ b/include/handler.hpp
@@ -25,6 +25,9 @@ public:
 	 virtual std::list<mime::type> types_available() const = 0;
 	 bool is_available(mime::type) const;
 
+  // quick hack to get "extra" response headers.
+  virtual std::string extra_response_headers() const;
+
 private:
 	 mime::type mime_type;
 };

--- a/include/osm_responder.hpp
+++ b/include/osm_responder.hpp
@@ -7,6 +7,7 @@
 
 #include <boost/optional.hpp>
 #include <boost/shared_ptr.hpp>
+#include <sstream>
 
 /**
  * utility class - use this as a base class when the derived class is going to
@@ -33,6 +34,9 @@ public:
 	 // formatter.
   void write(boost::shared_ptr<output_formatter> f, const std::string &generator);
 
+  // quick hack to add headers to the response
+  std::string extra_response_headers() const;
+
 protected:
 	 // current selection of elements to be written out
 	 data_selection &sel;
@@ -40,6 +44,12 @@ protected:
 	 // optional bounds element - this is only for information and has no effect on 
    // behaviour other than whether the bounds element gets written.
 	 boost::optional<bbox> bounds;
+
+  // quick hack to provide extra response headers like Content-Disposition.
+  std::ostringstream extra_headers;
+
+  // adds an extra response header.
+  void add_response_header(const std::string &);
 };
 
 #endif /* OSM_RESPONDER_HPP */

--- a/src/api06/map_handler.cpp
+++ b/src/api06/map_handler.cpp
@@ -35,6 +35,10 @@ map_responder::map_responder(mime::type mt, bbox b, data_selection &x)
     sel.select_relations_from_nodes();
     sel.select_relations_from_relations();
   }
+
+  // map calls typically have a Content-Disposition header saying that
+  // what's coming back is an attachment.
+  add_response_header("Content-Disposition: attachment; filename=\"map.osm\"");
 }
 
 map_responder::~map_responder() {

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -22,6 +22,11 @@ responder::resource_type() const {
 	return mime_type;
 }
 
+std::string
+responder::extra_response_headers() const {
+  return "";
+}
+
 handler::handler(mime::type default_type) 
 	: mime_type(default_type) {
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -254,12 +254,13 @@ process_get_request(FCGX_Request &request, routes &route,
   FCGX_FPrintF(request.out,
 	       "Status: 200 OK\r\n"
 	       "Content-Type: %s; charset=utf-8\r\n"
-	       "Content-Disposition: attachment; filename=\"map.osm\"\r\n"
+               "%s"
 	       "Content-Encoding: %s\r\n"
 	       "Cache-Control: no-cache\r\n"
 	       "%s"
 	       "\r\n", 
                mime::to_string(o_formatter->mime_type()).c_str(),
+               responder->extra_response_headers().c_str(),
                encoding->name().c_str(), cors_headers.c_str());
   
   try {
@@ -322,11 +323,13 @@ process_head_request(FCGX_Request &request, routes &route,
   FCGX_FPrintF(request.out,
 	       "Status: 200 OK\r\n"
 	       "Content-Type: text/xml; charset=utf-8\r\n"
-	       "Content-Disposition: attachment; filename=\"map.osm\"\r\n"
+               "%s"
 	       "Content-Encoding: %s\r\n"
 	       "Cache-Control: no-cache\r\n"
 	       "%s"
-	       "\r\n", encoding->name().c_str(), cors_headers.c_str());
+	       "\r\n", 
+               responder->extra_response_headers().c_str(),
+               encoding->name().c_str(), cors_headers.c_str());
 
   return boost::make_tuple(request_name, 0);
 }

--- a/src/osm_responder.cpp
+++ b/src/osm_responder.cpp
@@ -39,3 +39,12 @@ osm_responder::write(shared_ptr<output_formatter> formatter, const std::string &
 
   formatter->end_document();
 }
+
+void osm_responder::add_response_header(const std::string &line) {
+  extra_headers << line << "\r\n";
+}
+
+std::string osm_responder::extra_response_headers() const {
+  return extra_headers.str();
+}
+

--- a/test/test_map.rb
+++ b/test/test_map.rb
@@ -33,6 +33,7 @@ end
 test_request('GET', '/api/0.6/map?bbox=-0.01,-0.01,-0.0005,-0.0005') do |headers, data|
   assert(headers["Status"], "200 OK", "Response status code.")
   assert(headers["Content-Type"], "text/xml; charset=utf-8", "Response content type.")
+  assert(headers["Content-Disposition"], "attachment; filename=\"map.osm\"", "Response content disposition.")
 
   doc = XML::Parser.string(data).parse
   assert(doc.root.name, "osm", "Document root element.")

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -12,6 +12,7 @@ load_osm_file("#{File.dirname(__FILE__)}/test_node.osm", conn)
 test_request("GET", "/api/0.6/node/1", "HTTP_ACCEPT" => "text/xml") do |headers, data|
   assert(headers["Status"], "200 OK", "Response status code.")
   assert(headers["Content-Type"], "text/xml; charset=utf-8", "Response content type.")
+  assert(headers.has_key?("Content-Disposition"), false, "Response content disposition header.")
 
   doc = XML::Parser.string(data).parse
   assert(doc.root.name, "osm", "Document root element.")
@@ -73,6 +74,7 @@ end
 test_request("GET", "/api/0.6/nodes?nodes=1,2,3", "HTTP_ACCEPT" => "text/xml") do |headers, data|
   assert(headers["Status"], "200 OK", "Response status code.")
   assert(headers["Content-Type"], "text/xml; charset=utf-8", "Response content type.")
+  assert(headers.has_key?("Content-Disposition"), false, "Response content disposition header.")
 
   doc = XML::Parser.string(data).parse
   assert(doc.root.name, "osm", "Document root element.")

--- a/test/test_relation.rb
+++ b/test/test_relation.rb
@@ -14,6 +14,7 @@ load_osm_file("#{File.dirname(__FILE__)}/test_relation.osm", conn)
 test_request("GET", "/api/0.6/relation/1", "HTTP_ACCEPT" => "text/xml") do |headers, data|
   assert(headers["Status"], "200 OK", "Response status code.")
   assert(headers["Content-Type"], "text/xml; charset=utf-8", "Response content type.")
+  assert(headers.has_key?("Content-Disposition"), false, "Response content disposition header.")
 
   doc = XML::Parser.string(data).parse
   assert(doc.root.name, "osm", "Document root element.")
@@ -45,6 +46,7 @@ end
 test_request("GET", "/api/0.6/relations?relations=1,2", "HTTP_ACCEPT" => "text/xml") do |headers, data|
   assert(headers["Status"], "200 OK", "Response status code.")
   assert(headers["Content-Type"], "text/xml; charset=utf-8", "Response content type.")
+  assert(headers.has_key?("Content-Disposition"), false, "Response content disposition header.")
 
   doc = XML::Parser.string(data).parse
   assert(doc.root.name, "osm", "Document root element.")

--- a/test/test_relation_full.rb
+++ b/test/test_relation_full.rb
@@ -14,6 +14,7 @@ load_osm_file("#{File.dirname(__FILE__)}/test_relation.osm", conn)
 test_request("GET", "/api/0.6/relation/1/full", "HTTP_ACCEPT" => "text/xml") do |headers, data|
   assert(headers["Status"], "200 OK", "Response status code.")
   assert(headers["Content-Type"], "text/xml; charset=utf-8", "Response content type.")
+  assert(headers.has_key?("Content-Disposition"), false, "Response content disposition header.")
 
   doc = XML::Parser.string(data).parse
   assert(doc.root.name, "osm", "Document root element.")

--- a/test/test_way.rb
+++ b/test/test_way.rb
@@ -12,6 +12,7 @@ load_osm_file("#{File.dirname(__FILE__)}/test_way.osm", conn)
 test_request("GET", "/api/0.6/way/1", "HTTP_ACCEPT" => "text/xml") do |headers, data|
   assert(headers["Status"], "200 OK", "Response status code.")
   assert(headers["Content-Type"], "text/xml; charset=utf-8", "Response content type.")
+  assert(headers.has_key?("Content-Disposition"), false, "Response content disposition header.")
 
   doc = XML::Parser.string(data).parse
   assert(doc.root.name, "osm", "Document root element.")
@@ -58,6 +59,7 @@ end
 test_request("GET", "/api/0.6/ways?ways=1,2", "HTTP_ACCEPT" => "text/xml") do |headers, data|
   assert(headers["Status"], "200 OK", "Response status code.")
   assert(headers["Content-Type"], "text/xml; charset=utf-8", "Response content type.")
+  assert(headers.has_key?("Content-Disposition"), false, "Response content disposition header.")
 
   doc = XML::Parser.string(data).parse
   assert(doc.root.name, "osm", "Document root element.")

--- a/test/test_way_full.rb
+++ b/test/test_way_full.rb
@@ -13,6 +13,7 @@ load_osm_file("#{File.dirname(__FILE__)}/test_way.osm", conn)
 test_request("GET", "/api/0.6/way/1/full", "HTTP_ACCEPT" => "text/xml") do |headers, data|
   assert(headers["Status"], "200 OK", "Response status code.")
   assert(headers["Content-Type"], "text/xml; charset=utf-8", "Response content type.")
+  assert(headers.has_key?("Content-Disposition"), false, "Response content disposition header.")
 
   doc = XML::Parser.string(data).parse
   assert(doc.root.name, "osm", "Document root element.")


### PR DESCRIPTION
Added some tests for it as well, which pass. This might be the simplest solution to #39, although a "full" solution might have to wait until `library_split` is ready.
