### PR TITLE
Add libboost-filesystem-dev to dependencies

### DIFF
--- a/README
+++ b/README
@@ -37,7 +37,8 @@ using the following command:
 
     sudo apt-get install libxml2-dev libpqxx3-dev libfcgi-dev \
       libboost-dev libboost-regex-dev libboost-program-options-dev \
-      libboost-date-time-dev libmemcached-dev
+      libboost-date-time-dev libboost-filesystem-dev \
+      libmemcached-dev
 
 The build system used is GNU Make, using pkg-config to provide some of
 the flags.


### PR DESCRIPTION
Curiously it fails with a misleading error (configure: error: Could not link against boost_date_time-mt !) but that's not too important.