### PR TITLE
Add travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: true
+language: cpp
+compiler: gcc
+addons:
+  postgresql: 9.1
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y libboost-dev libboost-date-time-dev libboost-filesystem-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libfcgi-dev libmemcached-dev libpqxx3-dev libxml2-dev postgis ruby
+  - gem install pg libxml-ruby
+script:
+  - ./autogen.sh
+  - ./configure --with-fcgi=/usr
+  - make
+  - make check


### PR DESCRIPTION
This adds the necessary configuration to have travis build and test cgimap.

To make it work you will also need to visit https://travis-ci.org/profile/zerebubuth and turn on travis for the openstreetmap-cgimap repository.