### PR TITLE
Switch travis to container mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
-sudo: true
+sudo: false
 language: cpp
 compiler: gcc
 addons:
   postgresql: 9.1
+  apt:
+    packages:
+      - libboost-dev
+      - libboost-date-time-dev
+      - libboost-filesystem-dev
+      - libboost-program-options-dev
+      - libboost-regex-dev
+      - libboost-system-dev
+      - libfcgi-dev
+      - libmemcached-dev
+      - libpqxx3-dev
+      - libxml2-dev
+      - ruby
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libboost-dev libboost-date-time-dev libboost-filesystem-dev libboost-program-options-dev libboost-regex-dev libboost-system-dev libfcgi-dev libmemcached-dev libpqxx3-dev libxml2-dev postgis ruby
   - gem install pg libxml-ruby
 script:
   - ./autogen.sh


### PR DESCRIPTION
This (which makes travis jobs run on the newer container based infrastructure) was waiting on them whitelisting one of the packages, which is now done.