### PR TITLE
Allow negative changeset IDs

### DIFF
--- a/include/cgimap/api06/handler_utils.hpp
+++ b/include/cgimap/api06/handler_utils.hpp
@@ -8,8 +8,8 @@
 
 namespace api06 {
 
-std::vector<osm_id_t> parse_id_list_params(request &req,
-                                           const std::string &param_name);
+std::vector<osm_nwr_id_t> parse_id_list_params(request &req,
+                                               const std::string &param_name);
 }
 
 #endif /* API06_HANDLER_UTILS_HPP */

--- a/include/cgimap/api06/node_handler.hpp
+++ b/include/cgimap/api06/node_handler.hpp
@@ -10,25 +10,25 @@ namespace api06 {
 
 class node_responder : public osm_current_responder {
 public:
-  node_responder(mime::type, osm_id_t, factory_ptr &);
+  node_responder(mime::type, osm_nwr_id_t, factory_ptr &);
   ~node_responder();
 
 private:
-  osm_id_t id;
+  osm_nwr_id_t id;
 
   void check_visibility();
 };
 
 class node_handler : public handler {
 public:
-  node_handler(request &req, osm_id_t id);
+  node_handler(request &req, osm_nwr_id_t id);
   ~node_handler();
 
   std::string log_name() const;
   responder_ptr_t responder(factory_ptr &x) const;
 
 private:
-  osm_id_t id;
+  osm_nwr_id_t id;
 };
 
 } // namespace api06

--- a/include/cgimap/api06/node_ways_handler.hpp
+++ b/include/cgimap/api06/node_ways_handler.hpp
@@ -10,25 +10,25 @@ namespace api06 {
 
 class node_ways_responder : public osm_current_responder {
 public:
-  node_ways_responder(mime::type, osm_id_t, factory_ptr &);
+  node_ways_responder(mime::type, osm_nwr_id_t, factory_ptr &);
   ~node_ways_responder();
 
 private:
-  osm_id_t id;
+  osm_nwr_id_t id;
 
   void check_visibility();
 };
 
 class node_ways_handler : public handler {
 public:
-  node_ways_handler(request &req, osm_id_t id);
+  node_ways_handler(request &req, osm_nwr_id_t id);
   ~node_ways_handler();
 
   std::string log_name() const;
   responder_ptr_t responder(factory_ptr &x) const;
 
 private:
-  osm_id_t id;
+  osm_nwr_id_t id;
 };
 
 } // namespace api06

--- a/include/cgimap/api06/nodes_handler.hpp
+++ b/include/cgimap/api06/nodes_handler.hpp
@@ -12,11 +12,11 @@ namespace api06 {
 
 class nodes_responder : public osm_current_responder {
 public:
-  nodes_responder(mime::type, std::vector<osm_id_t>, factory_ptr &);
+  nodes_responder(mime::type, std::vector<osm_nwr_id_t>, factory_ptr &);
   ~nodes_responder();
 
 private:
-  std::vector<osm_id_t> ids;
+  std::vector<osm_nwr_id_t> ids;
 };
 
 class nodes_handler : public handler {
@@ -28,9 +28,9 @@ public:
   responder_ptr_t responder(factory_ptr &x) const;
 
 private:
-  std::vector<osm_id_t> ids;
+  std::vector<osm_nwr_id_t> ids;
 
-  static std::vector<osm_id_t> validate_request(request &req);
+  static std::vector<osm_nwr_id_t> validate_request(request &req);
 };
 
 } // namespace api06

--- a/include/cgimap/api06/relation_full_handler.hpp
+++ b/include/cgimap/api06/relation_full_handler.hpp
@@ -10,25 +10,25 @@ namespace api06 {
 
 class relation_full_responder : public osm_current_responder {
 public:
-  relation_full_responder(mime::type, osm_id_t, factory_ptr &);
+  relation_full_responder(mime::type, osm_nwr_id_t, factory_ptr &);
   ~relation_full_responder();
 
 private:
-  osm_id_t id;
+  osm_nwr_id_t id;
 
   void check_visibility();
 };
 
 class relation_full_handler : public handler {
 public:
-  relation_full_handler(request &req, osm_id_t id);
+  relation_full_handler(request &req, osm_nwr_id_t id);
   ~relation_full_handler();
 
   std::string log_name() const;
   responder_ptr_t responder(factory_ptr &x) const;
 
 private:
-  osm_id_t id;
+  osm_nwr_id_t id;
 };
 
 } // namespace api06

--- a/include/cgimap/api06/relation_handler.hpp
+++ b/include/cgimap/api06/relation_handler.hpp
@@ -10,25 +10,25 @@ namespace api06 {
 
 class relation_responder : public osm_current_responder {
 public:
-  relation_responder(mime::type, osm_id_t, factory_ptr &);
+  relation_responder(mime::type, osm_nwr_id_t, factory_ptr &);
   ~relation_responder();
 
 private:
-  osm_id_t id;
+  osm_nwr_id_t id;
 
   void check_visibility();
 };
 
 class relation_handler : public handler {
 public:
-  relation_handler(request &req, osm_id_t id);
+  relation_handler(request &req, osm_nwr_id_t id);
   ~relation_handler();
 
   std::string log_name() const;
   responder_ptr_t responder(factory_ptr &x) const;
 
 private:
-  osm_id_t id;
+  osm_nwr_id_t id;
 };
 
 } // namespace api06

--- a/include/cgimap/api06/relations_handler.hpp
+++ b/include/cgimap/api06/relations_handler.hpp
@@ -13,11 +13,11 @@ namespace api06 {
 
 class relations_responder : public osm_current_responder {
 public:
-  relations_responder(mime::type, std::vector<osm_id_t>, factory_ptr &);
+  relations_responder(mime::type, std::vector<osm_nwr_id_t>, factory_ptr &);
   ~relations_responder();
 
 private:
-  std::vector<osm_id_t> ids;
+  std::vector<osm_nwr_id_t> ids;
 };
 
 class relations_handler : public handler {
@@ -29,9 +29,9 @@ public:
   responder_ptr_t responder(factory_ptr &x) const;
 
 private:
-  std::vector<osm_id_t> ids;
+  std::vector<osm_nwr_id_t> ids;
 
-  static std::vector<osm_id_t> validate_request(request &req);
+  static std::vector<osm_nwr_id_t> validate_request(request &req);
 };
 
 } // namespace api06

--- a/include/cgimap/api06/way_full_handler.hpp
+++ b/include/cgimap/api06/way_full_handler.hpp
@@ -10,25 +10,25 @@ namespace api06 {
 
 class way_full_responder : public osm_current_responder {
 public:
-  way_full_responder(mime::type, osm_id_t, factory_ptr &);
+  way_full_responder(mime::type, osm_nwr_id_t, factory_ptr &);
   ~way_full_responder();
 
 private:
-  osm_id_t id;
+  osm_nwr_id_t id;
 
   void check_visibility();
 };
 
 class way_full_handler : public handler {
 public:
-  way_full_handler(request &req, osm_id_t id);
+  way_full_handler(request &req, osm_nwr_id_t id);
   ~way_full_handler();
 
   std::string log_name() const;
   responder_ptr_t responder(factory_ptr &x) const;
 
 private:
-  osm_id_t id;
+  osm_nwr_id_t id;
 };
 
 } // namespace api06

--- a/include/cgimap/api06/way_handler.hpp
+++ b/include/cgimap/api06/way_handler.hpp
@@ -10,25 +10,25 @@ namespace api06 {
 
 class way_responder : public osm_current_responder {
 public:
-  way_responder(mime::type, osm_id_t, factory_ptr &);
+  way_responder(mime::type, osm_nwr_id_t, factory_ptr &);
   ~way_responder();
 
 private:
-  osm_id_t id;
+  osm_nwr_id_t id;
 
   void check_visibility();
 };
 
 class way_handler : public handler {
 public:
-  way_handler(request &req, osm_id_t id);
+  way_handler(request &req, osm_nwr_id_t id);
   ~way_handler();
 
   std::string log_name() const;
   responder_ptr_t responder(factory_ptr &x) const;
 
 private:
-  osm_id_t id;
+  osm_nwr_id_t id;
 };
 
 } // namespace api06

--- a/include/cgimap/api06/ways_handler.hpp
+++ b/include/cgimap/api06/ways_handler.hpp
@@ -12,11 +12,11 @@ namespace api06 {
 
 class ways_responder : public osm_current_responder {
 public:
-  ways_responder(mime::type, std::vector<osm_id_t>, factory_ptr &);
+  ways_responder(mime::type, std::vector<osm_nwr_id_t>, factory_ptr &);
   ~ways_responder();
 
 private:
-  std::vector<osm_id_t> ids;
+  std::vector<osm_nwr_id_t> ids;
 };
 
 class ways_handler : public handler {
@@ -28,9 +28,9 @@ public:
   responder_ptr_t responder(factory_ptr &x) const;
 
 private:
-  std::vector<osm_id_t> ids;
+  std::vector<osm_nwr_id_t> ids;
 
-  static std::vector<osm_id_t> validate_request(request &req);
+  static std::vector<osm_nwr_id_t> validate_request(request &req);
 };
 
 } // namespace api06

--- a/include/cgimap/backend/apidb/changeset.hpp
+++ b/include/cgimap/backend/apidb/changeset.hpp
@@ -13,11 +13,11 @@
 struct changeset {
   bool data_public;
   std::string display_name;
-  osm_id_t user_id;
+  osm_user_id_t user_id;
 
-  changeset(bool dp, const std::string &dn, osm_id_t id);
+  changeset(bool dp, const std::string &dn, osm_user_id_t id);
 };
 
-changeset *fetch_changeset(pqxx::transaction_base &w, osm_id_t id);
+changeset *fetch_changeset(pqxx::transaction_base &w, osm_changeset_id_t id);
 
 #endif /* CHANGESET_HPP */

--- a/include/cgimap/backend/apidb/quad_tile.hpp
+++ b/include/cgimap/backend/apidb/quad_tile.hpp
@@ -4,7 +4,7 @@
 #include <vector>
 #include "cgimap/types.hpp"
 
-std::vector<osm_id_t> tiles_for_area(double minlat, double minlon, double maxlat,
-                                     double maxlon);
+std::vector<tile_id_t> tiles_for_area(double minlat, double minlon, double maxlat,
+                                      double maxlon);
 
 #endif /* QUAD_TILE_HPP */

--- a/include/cgimap/backend/apidb/readonly_pgsql_selection.hpp
+++ b/include/cgimap/backend/apidb/readonly_pgsql_selection.hpp
@@ -18,20 +18,20 @@
 class readonly_pgsql_selection : public data_selection {
 public:
   readonly_pgsql_selection(pqxx::connection &conn,
-                           cache<osm_id_t, changeset> &changeset_cache);
+                           cache<osm_changeset_id_t, changeset> &changeset_cache);
   ~readonly_pgsql_selection();
 
   void write_nodes(output_formatter &formatter);
   void write_ways(output_formatter &formatter);
   void write_relations(output_formatter &formatter);
 
-  visibility_t check_node_visibility(osm_id_t id);
-  visibility_t check_way_visibility(osm_id_t id);
-  visibility_t check_relation_visibility(osm_id_t id);
+  visibility_t check_node_visibility(osm_nwr_id_t id);
+  visibility_t check_way_visibility(osm_nwr_id_t id);
+  visibility_t check_relation_visibility(osm_nwr_id_t id);
 
-  int select_nodes(const std::vector<osm_id_t> &);
-  int select_ways(const std::vector<osm_id_t> &);
-  int select_relations(const std::vector<osm_id_t> &);
+  int select_nodes(const std::vector<osm_nwr_id_t> &);
+  int select_ways(const std::vector<osm_nwr_id_t> &);
+  int select_relations(const std::vector<osm_nwr_id_t> &);
   int select_nodes_from_bbox(const bbox &bounds, int max_nodes);
   void select_nodes_from_relations();
   void select_ways_from_nodes();
@@ -58,7 +58,7 @@ public:
     pqxx::quiet_errorhandler m_errorhandler, m_cache_errorhandler;
 #endif
     pqxx::nontransaction m_cache_tx;
-    cache<osm_id_t, changeset> m_cache;
+    cache<osm_changeset_id_t, changeset> m_cache;
   };
 
 private:
@@ -68,8 +68,8 @@ private:
   pqxx::work w;
 
   // the set of selected nodes, ways and relations
-  std::set<osm_id_t> sel_nodes, sel_ways, sel_relations;
-  cache<osm_id_t, changeset> &cc;
+  std::set<osm_nwr_id_t> sel_nodes, sel_ways, sel_relations;
+  cache<osm_changeset_id_t, changeset> &cc;
 };
 
 #endif /* READONLY_PGSQL_SELECTION_HPP */

--- a/include/cgimap/backend/apidb/writeable_pgsql_selection.hpp
+++ b/include/cgimap/backend/apidb/writeable_pgsql_selection.hpp
@@ -15,20 +15,20 @@
 class writeable_pgsql_selection : public data_selection {
 public:
   writeable_pgsql_selection(pqxx::connection &conn,
-                            cache<osm_id_t, changeset> &changeset_cache);
+                            cache<osm_changeset_id_t, changeset> &changeset_cache);
   ~writeable_pgsql_selection();
 
   void write_nodes(output_formatter &formatter);
   void write_ways(output_formatter &formatter);
   void write_relations(output_formatter &formatter);
 
-  visibility_t check_node_visibility(osm_id_t id);
-  visibility_t check_way_visibility(osm_id_t id);
-  visibility_t check_relation_visibility(osm_id_t id);
+  visibility_t check_node_visibility(osm_nwr_id_t id);
+  visibility_t check_way_visibility(osm_nwr_id_t id);
+  visibility_t check_relation_visibility(osm_nwr_id_t id);
 
-  int select_nodes(const std::vector<osm_id_t> &);
-  int select_ways(const std::vector<osm_id_t> &);
-  int select_relations(const std::vector<osm_id_t> &);
+  int select_nodes(const std::vector<osm_nwr_id_t> &);
+  int select_ways(const std::vector<osm_nwr_id_t> &);
+  int select_relations(const std::vector<osm_nwr_id_t> &);
   int select_nodes_from_bbox(const bbox &bounds, int max_nodes);
   void select_nodes_from_relations();
   void select_ways_from_nodes();
@@ -55,7 +55,7 @@ public:
     pqxx::quiet_errorhandler m_errorhandler, m_cache_errorhandler;
 #endif
     pqxx::nontransaction m_cache_tx;
-    cache<osm_id_t, changeset> m_cache;
+    cache<osm_changeset_id_t, changeset> m_cache;
   };
 
 private:
@@ -63,7 +63,7 @@ private:
   // this *is* read-only, it may create temporary tables.
   pqxx::work w;
 
-  cache<osm_id_t, changeset> cc;
+  cache<osm_changeset_id_t, changeset> cc;
 
   // true if a query hasn't been run yet, i.e: it's possible to
   // assume that all the temporary tables are empty.

--- a/include/cgimap/backend/pgsnapshot/snapshot_selection.hpp
+++ b/include/cgimap/backend/pgsnapshot/snapshot_selection.hpp
@@ -18,13 +18,13 @@ public:
   void write_ways(output_formatter &formatter);
   void write_relations(output_formatter &formatter);
 
-  visibility_t check_node_visibility(osm_id_t id);
-  visibility_t check_way_visibility(osm_id_t id);
-  visibility_t check_relation_visibility(osm_id_t id);
+  visibility_t check_node_visibility(osm_nwr_id_t id);
+  visibility_t check_way_visibility(osm_nwr_id_t id);
+  visibility_t check_relation_visibility(osm_nwr_id_t id);
 
-  int select_nodes(const std::vector<osm_id_t> &);
-  int select_ways(const std::vector<osm_id_t> &);
-  int select_relations(const std::vector<osm_id_t> &);
+  int select_nodes(const std::vector<osm_nwr_id_t> &);
+  int select_ways(const std::vector<osm_nwr_id_t> &);
+  int select_relations(const std::vector<osm_nwr_id_t> &);
   int select_nodes_from_bbox(const bbox &bounds, int max_nodes);
   void select_nodes_from_relations();
   void select_ways_from_nodes();

--- a/include/cgimap/data_selection.hpp
+++ b/include/cgimap/data_selection.hpp
@@ -32,27 +32,27 @@ public:
   /******************* information functions *******************/
 
   // check if the node is visible, deleted or has never existed
-  virtual visibility_t check_node_visibility(osm_id_t id) = 0;
+  virtual visibility_t check_node_visibility(osm_nwr_id_t id) = 0;
 
   // check if the way is visible, deleted or has never existed
-  virtual visibility_t check_way_visibility(osm_id_t id) = 0;
+  virtual visibility_t check_way_visibility(osm_nwr_id_t id) = 0;
 
   // check if the relation is visible, deleted or has never existed
-  virtual visibility_t check_relation_visibility(osm_id_t id) = 0;
+  virtual visibility_t check_relation_visibility(osm_nwr_id_t id) = 0;
 
   /******************* manipulation functions ******************/
 
   /// select the nodes in the vector, returning the number of nodes
   /// which are selected now which weren't selected before.
-  virtual int select_nodes(const std::vector<osm_id_t> &) = 0;
+  virtual int select_nodes(const std::vector<osm_nwr_id_t> &) = 0;
 
   /// select the ways in the vector, returning the number of ways
   /// which are selected now which weren't selected before.
-  virtual int select_ways(const std::vector<osm_id_t> &) = 0;
+  virtual int select_ways(const std::vector<osm_nwr_id_t> &) = 0;
 
   /// select the relations in the vector, returning the number of
   /// relations which are selected now which weren't selected before.
-  virtual int select_relations(const std::vector<osm_id_t> &) = 0;
+  virtual int select_relations(const std::vector<osm_nwr_id_t> &) = 0;
 
   /// given a bounding box, select nodes within that bbox up to a limit of
   /// max_nodes

--- a/include/cgimap/json_factory.hpp
+++ b/include/cgimap/json_factory.hpp
@@ -14,7 +14,7 @@ public:
   ~json_factory();
   json_writer &create_writer(boost::shared_ptr<output_buffer> &out,
                              bool indent = true);
-  json_formatter &create_formatter(cache<osm_id_t, changeset> &changeset_cache);
+  json_formatter &create_formatter(cache<osm_changeset_id_t, changeset> &changeset_cache);
 
 private:
   boost::shared_ptr<json_writer> writer;

--- a/include/cgimap/output_formatter.hpp
+++ b/include/cgimap/output_formatter.hpp
@@ -20,16 +20,18 @@ enum element_type {
 struct element_info {
   element_info();
   element_info(const element_info &);
-  element_info(osm_id_t id_, osm_id_t version_, osm_id_t changeset_,
+  element_info(osm_nwr_id_t id_, osm_nwr_id_t version_,
+               osm_changeset_id_t changeset_,
                const std::string &timestamp_,
-               const boost::optional<osm_id_t> &uid_,
+               const boost::optional<osm_user_id_t> &uid_,
                const boost::optional<std::string> &display_name_,
                bool visible_);
   // Standard meanings
-  osm_id_t id, version, changeset;
+  osm_nwr_id_t id, version;
+  osm_changeset_id_t changeset;
   std::string timestamp;
   // Anonymous objects will not have uids or display names
-  boost::optional<osm_id_t> uid;
+  boost::optional<osm_user_id_t> uid;
   boost::optional<std::string> display_name;
   // If an object has been deleted
   bool visible;
@@ -37,11 +39,11 @@ struct element_info {
 
 struct member_info {
   element_type type;
-  osm_id_t ref;
+  osm_nwr_id_t ref;
   std::string role;
 };
 
-typedef std::list<osm_id_t> nodes_t;
+typedef std::list<osm_nwr_id_t> nodes_t;
 typedef std::list<member_info> members_t;
 typedef std::list<std::pair<std::string, std::string> > tags_t;
 

--- a/include/cgimap/router.hpp
+++ b/include/cgimap/router.hpp
@@ -123,7 +123,7 @@ private:
  * match an OSM ID, returning it in the match tuple.
  */
 struct match_osm_id : public ops<match_osm_id> {
-  typedef list<osm_id_t> match_type;
+  typedef list<osm_nwr_id_t> match_type;
   match_osm_id();
   match_type match(part_iterator &begin, const part_iterator &end) const;
 };

--- a/include/cgimap/types.hpp
+++ b/include/cgimap/types.hpp
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 typedef uint64_t osm_user_id_t;
-typedef uint64_t osm_changeset_id_t;
+typedef int64_t osm_changeset_id_t;
 typedef uint64_t osm_nwr_id_t;
 typedef uint32_t tile_id_t;
 

--- a/include/cgimap/types.hpp
+++ b/include/cgimap/types.hpp
@@ -3,6 +3,9 @@
 
 #include <stdint.h>
 
-typedef uint64_t osm_id_t;
+typedef uint64_t osm_user_id_t;
+typedef uint64_t osm_changeset_id_t;
+typedef uint64_t osm_nwr_id_t;
+typedef uint32_t tile_id_t;
 
 #endif /* TYPES_HPP */

--- a/include/cgimap/xml_writer.hpp
+++ b/include/cgimap/xml_writer.hpp
@@ -36,6 +36,8 @@ public:
   void attribute(const std::string &name, int value);
   void attribute(const std::string &name, unsigned long int value);
   void attribute(const std::string &name, unsigned long long int value);
+  void attribute(const std::string &name, long int value);
+  void attribute(const std::string &name, long long int value);
   void attribute(const std::string &name, bool value);
 
   // write a child text element

--- a/src/api06/handler_utils.cpp
+++ b/src/api06/handler_utils.cpp
@@ -18,12 +18,12 @@ namespace al = boost::algorithm;
 
 namespace api06 {
 
-vector<osm_id_t> parse_id_list_params(request &req, const string &param_name) {
+vector<osm_nwr_id_t> parse_id_list_params(request &req, const string &param_name) {
   string decoded = http::urldecode(get_query_string(req));
   const map<string, string> params = http::parse_params(decoded);
   map<string, string>::const_iterator itr = params.find(param_name);
 
-  vector<osm_id_t> myids;
+  vector<osm_nwr_id_t> myids;
 
   if (itr != params.end()) {
     // just check for blank string, which shouldn't be converted.
@@ -33,7 +33,7 @@ vector<osm_id_t> parse_id_list_params(request &req, const string &param_name) {
       try {
         for (vector<string>::iterator itr = strs.begin(); itr != strs.end();
              ++itr) {
-          osm_id_t id = lexical_cast<osm_id_t>(*itr);
+          osm_nwr_id_t id = lexical_cast<osm_nwr_id_t>(*itr);
           myids.push_back(id);
         }
       } catch (const bad_lexical_cast &) {
@@ -48,7 +48,7 @@ vector<osm_id_t> parse_id_list_params(request &req, const string &param_name) {
 
   // ensure list of IDs is unique
   std::sort(myids.begin(), myids.end());
-  vector<osm_id_t>::iterator new_end = std::unique(myids.begin(), myids.end());
+  vector<osm_nwr_id_t>::iterator new_end = std::unique(myids.begin(), myids.end());
   myids.erase(new_end, myids.end());
 
   return myids;

--- a/src/api06/node_handler.cpp
+++ b/src/api06/node_handler.cpp
@@ -8,9 +8,9 @@ using std::vector;
 
 namespace api06 {
 
-node_responder::node_responder(mime::type mt, osm_id_t id_, factory_ptr &w_)
+node_responder::node_responder(mime::type mt, osm_nwr_id_t id_, factory_ptr &w_)
     : osm_current_responder(mt, w_), id(id_) {
-  vector<osm_id_t> ids;
+  vector<osm_nwr_id_t> ids;
   ids.push_back(id);
 
   if (sel->select_nodes(ids) == 0) {
@@ -22,7 +22,7 @@ node_responder::node_responder(mime::type mt, osm_id_t id_, factory_ptr &w_)
 
 node_responder::~node_responder() {}
 
-node_handler::node_handler(request &, osm_id_t id_) : id(id_) {}
+node_handler::node_handler(request &, osm_nwr_id_t id_) : id(id_) {}
 
 node_handler::~node_handler() {}
 

--- a/src/api06/node_ways_handler.cpp
+++ b/src/api06/node_ways_handler.cpp
@@ -8,10 +8,10 @@ using std::vector;
 
 namespace api06 {
 
-node_ways_responder::node_ways_responder(mime::type mt, osm_id_t id_,
+node_ways_responder::node_ways_responder(mime::type mt, osm_nwr_id_t id_,
                                          factory_ptr &w_)
     : osm_current_responder(mt, w_), id(id_) {
-  vector<osm_id_t> ids;
+  vector<osm_nwr_id_t> ids;
   ids.push_back(id);
 
   if (sel->select_nodes(ids) == 0) {
@@ -24,7 +24,7 @@ node_ways_responder::node_ways_responder(mime::type mt, osm_id_t id_,
 
 node_ways_responder::~node_ways_responder() {}
 
-node_ways_handler::node_ways_handler(request &, osm_id_t id_) : id(id_) {}
+node_ways_handler::node_ways_handler(request &, osm_nwr_id_t id_) : id(id_) {}
 
 node_ways_handler::~node_ways_handler() {}
 

--- a/src/api06/nodes_handler.cpp
+++ b/src/api06/nodes_handler.cpp
@@ -12,7 +12,7 @@ using std::string;
 
 namespace api06 {
 
-nodes_responder::nodes_responder(mime::type mt, vector<osm_id_t> ids_,
+nodes_responder::nodes_responder(mime::type mt, vector<osm_nwr_id_t> ids_,
                                  factory_ptr &w_)
     : osm_current_responder(mt, w_), ids(ids_) {
 
@@ -32,7 +32,7 @@ std::string nodes_handler::log_name() const {
   stringstream msg;
   msg << "nodes?nodes=";
   std::copy(ids.begin(), ids.end(),
-            infix_ostream_iterator<osm_id_t>(msg, ", "));
+            infix_ostream_iterator<osm_nwr_id_t>(msg, ", "));
   return msg.str();
 }
 
@@ -44,8 +44,8 @@ responder_ptr_t nodes_handler::responder(factory_ptr &x) const {
  * Validates an FCGI request, returning the valid list of ids or
  * throwing an error if there was no valid list of node ids.
  */
-vector<osm_id_t> nodes_handler::validate_request(request &req) {
-  vector<osm_id_t> ids = parse_id_list_params(req, "nodes");
+vector<osm_nwr_id_t> nodes_handler::validate_request(request &req) {
+  vector<osm_nwr_id_t> ids = parse_id_list_params(req, "nodes");
 
   if (ids.size() < 1) {
     throw http::bad_request("The parameter nodes is required, and must be "

--- a/src/api06/relation_full_handler.cpp
+++ b/src/api06/relation_full_handler.cpp
@@ -9,10 +9,10 @@ using std::vector;
 
 namespace api06 {
 
-relation_full_responder::relation_full_responder(mime::type mt_, osm_id_t id_,
+relation_full_responder::relation_full_responder(mime::type mt_, osm_nwr_id_t id_,
                                                  factory_ptr &w_)
     : osm_current_responder(mt_, w_), id(id_) {
-  vector<osm_id_t> ids;
+  vector<osm_nwr_id_t> ids;
   ids.push_back(id);
 
   if (sel->select_relations(ids) == 0) {
@@ -45,7 +45,7 @@ void relation_full_responder::check_visibility() {
   }
 }
 
-relation_full_handler::relation_full_handler(request &, osm_id_t id_)
+relation_full_handler::relation_full_handler(request &, osm_nwr_id_t id_)
     : id(id_) {
   logger::message(
       (boost::format("starting relation/full handler with id = %1%") % id)

--- a/src/api06/relation_handler.cpp
+++ b/src/api06/relation_handler.cpp
@@ -8,10 +8,10 @@ using std::vector;
 
 namespace api06 {
 
-relation_responder::relation_responder(mime::type mt, osm_id_t id_,
+relation_responder::relation_responder(mime::type mt, osm_nwr_id_t id_,
                                        factory_ptr &w_)
     : osm_current_responder(mt, w_), id(id_) {
-  vector<osm_id_t> ids;
+  vector<osm_nwr_id_t> ids;
   ids.push_back(id);
 
   if (sel->select_relations(ids) == 0) {
@@ -23,7 +23,7 @@ relation_responder::relation_responder(mime::type mt, osm_id_t id_,
 
 relation_responder::~relation_responder() {}
 
-relation_handler::relation_handler(request &, osm_id_t id_) : id(id_) {}
+relation_handler::relation_handler(request &, osm_nwr_id_t id_) : id(id_) {}
 
 relation_handler::~relation_handler() {}
 

--- a/src/api06/relations_handler.cpp
+++ b/src/api06/relations_handler.cpp
@@ -12,7 +12,7 @@ using std::string;
 
 namespace api06 {
 
-relations_responder::relations_responder(mime::type mt, vector<osm_id_t> ids_,
+relations_responder::relations_responder(mime::type mt, vector<osm_nwr_id_t> ids_,
                                          factory_ptr &s_)
     : osm_current_responder(mt, s_), ids(ids_) {
   size_t num_selected = sel->select_relations(ids_);
@@ -32,7 +32,7 @@ std::string relations_handler::log_name() const {
   stringstream msg;
   msg << "relations?relations=";
   std::copy(ids.begin(), ids.end(),
-            infix_ostream_iterator<osm_id_t>(msg, ", "));
+            infix_ostream_iterator<osm_nwr_id_t>(msg, ", "));
   return msg.str();
 }
 
@@ -44,8 +44,8 @@ responder_ptr_t relations_handler::responder(factory_ptr &x) const {
  * Validates an FCGI request, returning the valid list of ids or
  * throwing an error if there was no valid list of node ids.
  */
-vector<osm_id_t> relations_handler::validate_request(request &req) {
-  vector<osm_id_t> myids = parse_id_list_params(req, "relations");
+vector<osm_nwr_id_t> relations_handler::validate_request(request &req) {
+  vector<osm_nwr_id_t> myids = parse_id_list_params(req, "relations");
 
   if (myids.size() < 1) {
     throw http::bad_request("The parameter relations is required, and must be "

--- a/src/api06/way_full_handler.cpp
+++ b/src/api06/way_full_handler.cpp
@@ -9,10 +9,10 @@ using std::vector;
 
 namespace api06 {
 
-way_full_responder::way_full_responder(mime::type mt_, osm_id_t id_,
+way_full_responder::way_full_responder(mime::type mt_, osm_nwr_id_t id_,
                                        factory_ptr &w_)
     : osm_current_responder(mt_, w_), id(id_) {
-  vector<osm_id_t> ids;
+  vector<osm_nwr_id_t> ids;
   ids.push_back(id);
 
   if (sel->select_ways(ids) == 0) {
@@ -42,7 +42,7 @@ void way_full_responder::check_visibility() {
   }
 }
 
-way_full_handler::way_full_handler(request &, osm_id_t id_) : id(id_) {
+way_full_handler::way_full_handler(request &, osm_nwr_id_t id_) : id(id_) {
   logger::message(
       (boost::format("starting way/full handler with id = %1%") % id).str());
 }

--- a/src/api06/way_handler.cpp
+++ b/src/api06/way_handler.cpp
@@ -8,9 +8,9 @@ using std::vector;
 
 namespace api06 {
 
-way_responder::way_responder(mime::type mt, osm_id_t id_, factory_ptr &w_)
+way_responder::way_responder(mime::type mt, osm_nwr_id_t id_, factory_ptr &w_)
     : osm_current_responder(mt, w_), id(id_) {
-  vector<osm_id_t> ids;
+  vector<osm_nwr_id_t> ids;
   ids.push_back(id);
 
   if (sel->select_ways(ids) == 0) {
@@ -22,7 +22,7 @@ way_responder::way_responder(mime::type mt, osm_id_t id_, factory_ptr &w_)
 
 way_responder::~way_responder() {}
 
-way_handler::way_handler(request &, osm_id_t id_) : id(id_) {}
+way_handler::way_handler(request &, osm_nwr_id_t id_) : id(id_) {}
 
 way_handler::~way_handler() {}
 

--- a/src/api06/ways_handler.cpp
+++ b/src/api06/ways_handler.cpp
@@ -12,7 +12,7 @@ using std::string;
 
 namespace api06 {
 
-ways_responder::ways_responder(mime::type mt, vector<osm_id_t> ids_,
+ways_responder::ways_responder(mime::type mt, vector<osm_nwr_id_t> ids_,
                                factory_ptr &w_)
     : osm_current_responder(mt, w_), ids(ids_) {
   size_t num_selected = sel->select_ways(ids_);
@@ -31,7 +31,7 @@ std::string ways_handler::log_name() const {
   stringstream msg;
   msg << "ways?ways=";
   std::copy(ids.begin(), ids.end(),
-            infix_ostream_iterator<osm_id_t>(msg, ", "));
+            infix_ostream_iterator<osm_nwr_id_t>(msg, ", "));
   return msg.str();
 }
 
@@ -43,8 +43,8 @@ responder_ptr_t ways_handler::responder(factory_ptr &x) const {
  * Validates an FCGI request, returning the valid list of ids or
  * throwing an error if there was no valid list of way ids.
  */
-vector<osm_id_t> ways_handler::validate_request(request &req) {
-  vector<osm_id_t> myids = parse_id_list_params(req, "ways");
+vector<osm_nwr_id_t> ways_handler::validate_request(request &req) {
+  vector<osm_nwr_id_t> myids = parse_id_list_params(req, "ways");
 
   if (myids.size() < 1) {
     throw http::bad_request("The parameter ways is required, and must be "

--- a/src/backend/apidb/changeset.cpp
+++ b/src/backend/apidb/changeset.cpp
@@ -6,10 +6,10 @@
 using std::string;
 using boost::format;
 
-changeset::changeset(bool dp, const string &dn, osm_id_t id)
+changeset::changeset(bool dp, const string &dn, osm_user_id_t id)
     : data_public(dp), display_name(dn), user_id(id) {}
 
-changeset *fetch_changeset(pqxx::transaction_base &w, osm_id_t id) {
+changeset *fetch_changeset(pqxx::transaction_base &w, osm_changeset_id_t id) {
   pqxx::result res =
       w.exec("select u.data_public, u.display_name, u.id from users u "
              "join changesets c on u.id=c.user_id where c.id=" +
@@ -37,6 +37,6 @@ changeset *fetch_changeset(pqxx::transaction_base &w, osm_id_t id) {
     return new changeset(false, "", 0);
   } else {
     return new changeset(res[0][0].as<bool>(), res[0][1].as<string>(),
-                         osm_id_t(user_id));
+                         osm_user_id_t(user_id));
   }
 }

--- a/src/backend/apidb/quad_tile.cpp
+++ b/src/backend/apidb/quad_tile.cpp
@@ -27,19 +27,19 @@ inline unsigned int lat2y(double lat) {
   return round((lat + 90.0) * 65535.0 / 180.0);
 }
 
-std::vector<osm_id_t> tiles_for_area(double minlat, double minlon, double maxlat,
+std::vector<tile_id_t> tiles_for_area(double minlat, double minlon, double maxlat,
                                    double maxlon) {
   const unsigned int minx = lon2x(minlon);
   const unsigned int maxx = lon2x(maxlon);
   const unsigned int miny = lat2y(minlat);
   const unsigned int maxy = lat2y(maxlat);
-  set<unsigned int> tiles;
+  set<tile_id_t> tiles;
 
-  for (unsigned int x = minx; x <= maxx; x++) {
-    for (unsigned int y = miny; y <= maxy; y++) {
+  for (tile_id_t x = minx; x <= maxx; x++) {
+    for (tile_id_t y = miny; y <= maxy; y++) {
       tiles.insert(xy2tile(x, y));
     }
   }
 
-  return std::vector<osm_id_t>(tiles.begin(), tiles.end());
+  return std::vector<tile_id_t>(tiles.begin(), tiles.end());
 }

--- a/src/backend/pgsnapshot/snapshot_selection.cpp
+++ b/src/backend/pgsnapshot/snapshot_selection.cpp
@@ -25,21 +25,21 @@ using std::stringstream;
 using std::vector;
 
 namespace pqxx {
-template <> struct string_traits<vector<osm_id_t> > {
-  static const char *name() { return "vector<osm_id_t>"; }
+template <> struct string_traits<vector<osm_nwr_id_t> > {
+  static const char *name() { return "vector<osm_nwr_id_t>"; }
   static bool has_null() { return false; }
-  static bool is_null(const vector<osm_id_t> &) { return false; }
+  static bool is_null(const vector<osm_nwr_id_t> &) { return false; }
   static stringstream null() {
     internal::throw_null_conversion(name());
     // No, dear compiler, we don't need a return here.
     throw 0;
   }
-  static void from_string(const char[], vector<osm_id_t> &) {}
-  static std::string to_string(const vector<osm_id_t> &ids) {
+  static void from_string(const char[], vector<osm_nwr_id_t> &) {}
+  static std::string to_string(const vector<osm_nwr_id_t> &ids) {
     stringstream ostr;
     ostr << "{";
     std::copy(ids.begin(), ids.end(),
-              infix_ostream_iterator<osm_id_t>(ostr, ","));
+              infix_ostream_iterator<osm_nwr_id_t>(ostr, ","));
     ostr << "}";
     return ostr.str();
   }
@@ -65,12 +65,12 @@ std::string connect_db_str(const po::variables_map &options) {
 }
 
 void extract_elem(const pqxx::result::tuple &row, element_info &elem) {
-  elem.id = row["id"].as<osm_id_t>();
+  elem.id = row["id"].as<osm_nwr_id_t>();
   elem.version = row["version"].as<int>();
   elem.timestamp = row["timestamp"].c_str();
-  elem.changeset = row["changeset_id"].as<osm_id_t>();
+  elem.changeset = row["changeset_id"].as<osm_changeset_id_t>();
   if (!row["uid"].is_null()) {
-    elem.uid = row["uid"].as<osm_id_t>();
+    elem.uid = row["uid"].as<osm_user_id_t>();
   } else {
     elem.uid = boost::none;
   }
@@ -95,7 +95,7 @@ void extract_nodes(const pqxx::result &res, nodes_t &nodes) {
   nodes.clear();
   for (pqxx::result::const_iterator itr = res.begin(); itr != res.end();
        ++itr) {
-    nodes.push_back((*itr)[0].as<osm_id_t>());
+    nodes.push_back((*itr)[0].as<osm_nwr_id_t>());
   }
 }
 
@@ -128,7 +128,7 @@ void extract_members(const pqxx::result &res, members_t &members) {
   for (pqxx::result::const_iterator itr = res.begin(); itr != res.end();
        ++itr) {
     member.type = type_from_name((*itr)["member_type"].c_str());
-    member.ref = (*itr)["member_id"].as<osm_id_t>();
+    member.ref = (*itr)["member_id"].as<osm_nwr_id_t>();
     member.role = (*itr)["member_role"].c_str();
     members.push_back(member);
   }
@@ -226,29 +226,29 @@ void snapshot_selection::write_relations(output_formatter &formatter) {
 }
 
 data_selection::visibility_t
-    snapshot_selection::check_node_visibility(osm_id_t) {
+    snapshot_selection::check_node_visibility(osm_nwr_id_t) {
   return data_selection::exists;
 }
 
 data_selection::visibility_t
-    snapshot_selection::check_way_visibility(osm_id_t) {
+    snapshot_selection::check_way_visibility(osm_nwr_id_t) {
   return data_selection::exists;
 }
 
 data_selection::visibility_t
-    snapshot_selection::check_relation_visibility(osm_id_t) {
+    snapshot_selection::check_relation_visibility(osm_nwr_id_t) {
   return data_selection::exists;
 }
 
-int snapshot_selection::select_nodes(const std::vector<osm_id_t> &ids) {
+int snapshot_selection::select_nodes(const std::vector<osm_nwr_id_t> &ids) {
   return w.prepared("add_nodes_list")(ids).exec().affected_rows();
 }
 
-int snapshot_selection::select_ways(const std::vector<osm_id_t> &ids) {
+int snapshot_selection::select_ways(const std::vector<osm_nwr_id_t> &ids) {
   return w.prepared("add_ways_list")(ids).exec().affected_rows();
 }
 
-int snapshot_selection::select_relations(const std::vector<osm_id_t> &ids) {
+int snapshot_selection::select_relations(const std::vector<osm_nwr_id_t> &ids) {
   return w.prepared("add_relations_list")(ids).exec().affected_rows();
 }
 

--- a/src/json_factory.cpp
+++ b/src/json_factory.cpp
@@ -11,7 +11,7 @@ json_writer &json_factory::create_writer(boost::shared_ptr<output_buffer> &out,
 }
 
 json_formatter &
-json_factory::create_formatter(cache<osm_id_t, changeset> &changeset_cache) {
+json_factory::create_formatter(cache<osm_changeset_id_t, changeset> &changeset_cache) {
   formatter = new json_formatter(*writer, changeset_cache);
   return *formatter;
 }

--- a/src/output_formatter.cpp
+++ b/src/output_formatter.cpp
@@ -10,9 +10,10 @@ element_info::element_info(const element_info &other)
     timestamp(other.timestamp), uid(other.uid), display_name(other.display_name),
     visible(other.visible) {}
 
-element_info::element_info(osm_id_t id_, osm_id_t version_, osm_id_t changeset_,
+element_info::element_info(osm_nwr_id_t id_, osm_nwr_id_t version_,
+                           osm_changeset_id_t changeset_,
                            const std::string &timestamp_,
-                           const boost::optional<osm_id_t> &uid_,
+                           const boost::optional<osm_user_id_t> &uid_,
                            const boost::optional<std::string> &display_name_,
                            bool visible_)
   : id(id_), version(version_), changeset(changeset_),

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -29,7 +29,7 @@ match_osm_id::match_type match_osm_id::match(part_iterator &begin,
   if (begin != end) {
     try {
       std::string bit = *begin;
-      // note that osm_id_t is actually unsigned, so we lose a bit of
+      // note that osm_nwr_id_t is actually unsigned, so we lose a bit of
       // precision here, but it's OK since IDs are postgres 'bigint' types
       // which are also signed, so element 2^63 is unlikely to exist.
       int64_t x = boost::lexical_cast<int64_t>(bit);

--- a/src/xml_writer.cpp
+++ b/src/xml_writer.cpp
@@ -124,7 +124,7 @@ void xml_writer::attribute(const std::string &name, double value) {
 
 void xml_writer::attribute(const std::string &name, unsigned long int value) {
   int rc = xmlTextWriterWriteFormatAttribute(
-      pimpl->writer, BAD_CAST name.c_str(), "%ld", value);
+      pimpl->writer, BAD_CAST name.c_str(), "%lu", value);
   if (rc < 0) {
     throw write_error("cannot write osm_id_t(unsigned long int) attribute.");
   }
@@ -133,9 +133,26 @@ void xml_writer::attribute(const std::string &name, unsigned long int value) {
 void xml_writer::attribute(const std::string &name,
                            unsigned long long int value) {
   int rc = xmlTextWriterWriteFormatAttribute(
-      pimpl->writer, BAD_CAST name.c_str(), "%lld", value);
+      pimpl->writer, BAD_CAST name.c_str(), "%llu", value);
   if (rc < 0) {
     throw write_error("cannot write osm_id_t(unsigned long long int) attribute.");
+  }
+}
+
+void xml_writer::attribute(const std::string &name, long int value) {
+  int rc = xmlTextWriterWriteFormatAttribute(
+      pimpl->writer, BAD_CAST name.c_str(), "%ld", value);
+  if (rc < 0) {
+    throw write_error("cannot write osm_id_t(long int) attribute.");
+  }
+}
+
+void xml_writer::attribute(const std::string &name,
+                           long long int value) {
+  int rc = xmlTextWriterWriteFormatAttribute(
+      pimpl->writer, BAD_CAST name.c_str(), "%lld", value);
+  if (rc < 0) {
+    throw write_error("cannot write osm_id_t(long long int) attribute.");
   }
 }
 

--- a/src/xml_writer.cpp
+++ b/src/xml_writer.cpp
@@ -126,7 +126,7 @@ void xml_writer::attribute(const std::string &name, unsigned long int value) {
   int rc = xmlTextWriterWriteFormatAttribute(
       pimpl->writer, BAD_CAST name.c_str(), "%ld", value);
   if (rc < 0) {
-    throw write_error("cannot write osm_id_t attribute.");
+    throw write_error("cannot write osm_id_t(unsigned long int) attribute.");
   }
 }
 
@@ -135,7 +135,7 @@ void xml_writer::attribute(const std::string &name,
   int rc = xmlTextWriterWriteFormatAttribute(
       pimpl->writer, BAD_CAST name.c_str(), "%lld", value);
   if (rc < 0) {
-    throw write_error("cannot write long long int attribute.");
+    throw write_error("cannot write osm_id_t(unsigned long long int) attribute.");
   }
 }
 

--- a/test/test_apidb_backend.cpp
+++ b/test/test_apidb_backend.cpp
@@ -301,7 +301,7 @@ void test_single_nodes(boost::shared_ptr<data_selection> sel) {
     throw std::runtime_error("Node 2 should be visible, but isn't");
   }
 
-  std::vector<osm_id_t> ids;
+  std::vector<osm_nwr_id_t> ids;
   ids.push_back(1);
   ids.push_back(2);
   ids.push_back(3);
@@ -367,7 +367,7 @@ void test_dup_nodes(boost::shared_ptr<data_selection> sel) {
     throw std::runtime_error("Node 1 should be visible, but isn't");
   }
 
-  std::vector<osm_id_t> ids;
+  std::vector<osm_nwr_id_t> ids;
   ids.push_back(1);
   ids.push_back(1);
   ids.push_back(1);

--- a/test/test_apidb_backend.cpp
+++ b/test/test_apidb_backend.cpp
@@ -394,6 +394,40 @@ void test_dup_nodes(boost::shared_ptr<data_selection> sel) {
     f.m_nodes[0], "first node written");
 }
 
+void test_negative_changeset_ids(boost::shared_ptr<data_selection> sel) {
+  assert_equal<data_selection::visibility_t>(
+    sel->check_node_visibility(6), data_selection::exists,
+    "node 6 visibility");
+  assert_equal<data_selection::visibility_t>(
+    sel->check_node_visibility(7), data_selection::exists,
+    "node 7 visibility");
+
+  std::vector<osm_nwr_id_t> ids;
+  ids.push_back(6);
+  ids.push_back(7);
+  if (sel->select_nodes(ids) != 2) {
+    throw std::runtime_error("Selecting 2 nodes failed");
+  }
+
+  test_formatter f;
+  sel->write_nodes(f);
+  assert_equal<size_t>(f.m_nodes.size(), 2, "number of nodes written");
+  assert_equal<test_formatter::node_t>(
+    test_formatter::node_t(
+      element_info(6, 1, 0, "2016-04-16T15:09:00Z", boost::none, boost::none, true),
+      9.0, 9.0,
+      tags_t()
+      ),
+    f.m_nodes[0], "first node written");
+  assert_equal<test_formatter::node_t>(
+    test_formatter::node_t(
+      element_info(7, 1, -1, "2016-04-16T15:09:00Z", boost::none, boost::none, true),
+      9.0, 9.0,
+      tags_t()
+      ),
+    f.m_nodes[1], "second node written");
+}
+
 } // anonymous namespace
 
 int main(int, char **) {
@@ -406,6 +440,9 @@ int main(int, char **) {
 
     tdb.run(boost::function<void(boost::shared_ptr<data_selection>)>(
         &test_dup_nodes));
+
+    tdb.run(boost::function<void(boost::shared_ptr<data_selection>)>(
+        &test_negative_changeset_ids));
 
   } catch (const test_database::setup_error &e) {
     std::cout << "Unable to set up test database: " << e.what() << std::endl;

--- a/test/test_apidb_backend.sql
+++ b/test/test_apidb_backend.sql
@@ -1,11 +1,18 @@
 -- add a public and non-public user for testing.
 INSERT INTO users (id, email, pass_crypt, creation_time, display_name, data_public)
-VALUES (1, 'user_1@example.com', '', '2013-11-14T02:10:00Z', 'user_1', true),
+-- note the user with ID -1 is equivalent to one that osmosis would add when
+-- writing an apidb from a planet file or extract.
+VALUES (-1, 'osmosis@osmosis.com', '', '2016-04-16T15:09:00Z', 'osmosis', false),
+       (1, 'user_1@example.com', '', '2013-11-14T02:10:00Z', 'user_1', true),
        (2, 'user_2@example.com', '', '2013-11-14T02:10:00Z', 'user_2', false);
 
 -- give the users some changesets
 INSERT INTO changesets (id, user_id, created_at, closed_at)
-VALUES (1, 1, '2013-11-14T02:10:00Z', '2013-11-14T03:10:00Z'),
+-- note the changesets with IDs -1 and 0 are equivalent to ones that osmosis
+-- creates when reading PBF files?
+VALUES (-1, -1, '2016-04-16T15:09:00Z', '2016-04-16T15:09:00Z'),
+       (0, -1, '2016-04-16T15:09:00Z', '2016-04-16T15:09:00Z'),
+       (1, 1, '2013-11-14T02:10:00Z', '2013-11-14T03:10:00Z'),
        (2, 1, '2013-11-14T02:10:00Z', '2013-11-14T03:10:00Z'),
        (3, 1, '2013-11-14T02:10:00Z', '2013-11-14T03:10:00Z'),
        (4, 2, '2013-11-14T02:10:00Z', '2013-11-14T03:10:00Z');
@@ -15,4 +22,7 @@ INSERT INTO current_nodes (id, latitude, longitude, changeset_id, visible, "time
 VALUES (1,       0,       0, 1, true,  '2013-11-14T02:10:00Z', 3221225472, 1),
        (2, 1000000, 1000000, 1, true,  '2013-11-14T02:10:01Z', 3221227032, 1),
        (3,       0,       0, 2, false, '2015-03-02T18:27:00Z', 3221225472, 2),
-       (4,       0,       0, 4, true,  '2015-03-02T19:25:00Z', 3221225472, 1);
+       (4,       0,       0, 4, true,  '2015-03-02T19:25:00Z', 3221225472, 1),
+       -- note: node 5 intentionally missing
+       (6, 90000000, 90000000,  0, true,  '2016-04-16T15:09:00Z', 3229120632, 1),
+       (7, 90000000, 90000000, -1, true,  '2016-04-16T15:09:00Z', 3229120632, 1);

--- a/test/test_parse_id_list.cpp
+++ b/test/test_parse_id_list.cpp
@@ -51,11 +51,11 @@ int main(int argc, char *argv[]) {
 
   // the container returned from parse_id_list_params should not contain
   // any duplicates.
-  std::vector<osm_id_t> ids = api06::parse_id_list_params(req, "nodes");
+  std::vector<osm_nwr_id_t> ids = api06::parse_id_list_params(req, "nodes");
   if (ids.size() != 1) {
     std::cerr << "Parsing " << query_str << " as a list of nodes should "
               << "discard duplicates, but got: {";
-    BOOST_FOREACH(osm_id_t id, ids) {
+    BOOST_FOREACH(osm_nwr_id_t id, ids) {
       std::cerr << id << ", ";
     }
     std::cerr << "}\n";


### PR DESCRIPTION
This PR separates the different types of IDs (node/way/relation, user, changeset, tile) into different typedefs and makes the changeset ID signed. This should enable cgimap to deal with databases where Osmosis has made a "-1" changeset, which it seems to do when reading PBF files.

@frankxu2004 could you check out this branch and see if it fixes #105, please?
