### PR TITLE
Add API calls for specific historic versions of objects

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,6 +30,7 @@ cgimap_api06_include_HEADERS = \
 	include/cgimap/api06/handler_utils.hpp \
 	include/cgimap/api06/map_handler.hpp \
 	include/cgimap/api06/node_handler.hpp \
+	include/cgimap/api06/node_version_handler.hpp \
 	include/cgimap/api06/nodes_handler.hpp \
 	include/cgimap/api06/relation_full_handler.hpp \
 	include/cgimap/api06/relation_handler.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,7 @@ cgimap_api06_include_HEADERS = \
 	include/cgimap/api06/nodes_handler.hpp \
 	include/cgimap/api06/relation_full_handler.hpp \
 	include/cgimap/api06/relation_handler.hpp \
+	include/cgimap/api06/relation_version_handler.hpp \
 	include/cgimap/api06/relations_handler.hpp \
 	include/cgimap/api06/way_full_handler.hpp \
 	include/cgimap/api06/way_handler.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,7 @@ cgimap_api06_include_HEADERS = \
 	include/cgimap/api06/relations_handler.hpp \
 	include/cgimap/api06/way_full_handler.hpp \
 	include/cgimap/api06/way_handler.hpp \
+	include/cgimap/api06/way_version_handler.hpp \
 	include/cgimap/api06/ways_handler.hpp
 
 if ENABLE_APIDB

--- a/include/cgimap/api06/node_version_handler.hpp
+++ b/include/cgimap/api06/node_version_handler.hpp
@@ -1,0 +1,36 @@
+#ifndef API06_NODE_VERSION_HANDLER_HPP
+#define API06_NODE_VERSION_HANDLER_HPP
+
+#include "cgimap/handler.hpp"
+#include "cgimap/osm_current_responder.hpp"
+#include "cgimap/request.hpp"
+#include <string>
+
+namespace api06 {
+
+class node_version_responder : public osm_current_responder {
+public:
+  node_version_responder(mime::type, osm_nwr_id_t, osm_nwr_id_t, factory_ptr &);
+  ~node_version_responder();
+
+private:
+  osm_nwr_id_t id;
+  osm_nwr_id_t v;
+};
+
+class node_version_handler : public handler {
+public:
+  node_version_handler(request &req, osm_nwr_id_t id, osm_nwr_id_t v);
+  ~node_version_handler();
+
+  std::string log_name() const;
+  responder_ptr_t responder(factory_ptr &x) const;
+
+private:
+  osm_nwr_id_t id;
+  osm_nwr_id_t v;
+};
+
+} // namespace api06
+
+#endif /* API06_NODE_VERSION_HANDLER_HPP */

--- a/include/cgimap/api06/node_version_handler.hpp
+++ b/include/cgimap/api06/node_version_handler.hpp
@@ -10,7 +10,7 @@ namespace api06 {
 
 class node_version_responder : public osm_current_responder {
 public:
-  node_version_responder(mime::type, osm_nwr_id_t, osm_nwr_id_t, factory_ptr &);
+  node_version_responder(mime::type, osm_nwr_id_t, osm_version_t, factory_ptr &);
   ~node_version_responder();
 
 private:
@@ -20,7 +20,7 @@ private:
 
 class node_version_handler : public handler {
 public:
-  node_version_handler(request &req, osm_nwr_id_t id, osm_nwr_id_t v);
+  node_version_handler(request &req, osm_nwr_id_t id, osm_version_t v);
   ~node_version_handler();
 
   std::string log_name() const;
@@ -28,7 +28,7 @@ public:
 
 private:
   osm_nwr_id_t id;
-  osm_nwr_id_t v;
+  osm_version_t v;
 };
 
 } // namespace api06

--- a/include/cgimap/api06/relation_version_handler.hpp
+++ b/include/cgimap/api06/relation_version_handler.hpp
@@ -1,0 +1,38 @@
+#ifndef API06_RELATION_VERSION_HANDLER_HPP
+#define API06_RELATION_VERSION_HANDLER_HPP
+
+#include "cgimap/handler.hpp"
+#include "cgimap/osm_current_responder.hpp"
+#include "cgimap/request.hpp"
+#include <string>
+
+namespace api06 {
+
+class relation_version_responder : public osm_current_responder {
+public:
+  relation_version_responder(mime::type, osm_nwr_id_t, osm_version_t v, factory_ptr &);
+  ~relation_version_responder();
+
+private:
+  osm_nwr_id_t id;
+  osm_version_t v;
+
+  void check_visibility();
+};
+
+class relation_version_handler : public handler {
+public:
+  relation_version_handler(request &req, osm_nwr_id_t id, osm_version_t v);
+  ~relation_version_handler();
+
+  std::string log_name() const;
+  responder_ptr_t responder(factory_ptr &x) const;
+
+private:
+  osm_nwr_id_t id;
+  osm_version_t v;
+};
+
+} // namespace api06
+
+#endif /* API06_RELATION_VERSION_HANDLER_HPP */

--- a/include/cgimap/api06/way_version_handler.hpp
+++ b/include/cgimap/api06/way_version_handler.hpp
@@ -1,0 +1,38 @@
+#ifndef API06_WAY_VERSION_HANDLER_HPP
+#define API06_WAY_VERSION_HANDLER_HPP
+
+#include "cgimap/handler.hpp"
+#include "cgimap/osm_current_responder.hpp"
+#include "cgimap/request.hpp"
+#include <string>
+
+namespace api06 {
+
+class way_version_responder : public osm_current_responder {
+public:
+  way_version_responder(mime::type, osm_nwr_id_t, osm_version_t, factory_ptr &);
+  ~way_version_responder();
+
+private:
+  osm_nwr_id_t id;
+  osm_version_t v;
+
+  void check_visibility();
+};
+
+class way_version_handler : public handler {
+public:
+  way_version_handler(request &req, osm_nwr_id_t id, osm_version_t v);
+  ~way_version_handler();
+
+  std::string log_name() const;
+  responder_ptr_t responder(factory_ptr &x) const;
+
+private:
+  osm_nwr_id_t id;
+  osm_version_t v;
+};
+
+} // namespace api06
+
+#endif /* API06_WAY_VERSION_HANDLER_HPP */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -144,6 +144,7 @@ libcgimap_core_la_SOURCES+=\
 	api06/relation_handler.cpp \
 	api06/relations_handler.cpp \
 	api06/way_handler.cpp \
+	api06/way_version_handler.cpp \
 	api06/ways_handler.cpp \
 	api06/relation_full_handler.cpp \
 	api06/way_full_handler.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -139,6 +139,7 @@ libcgimap_core_la_SOURCES+=\
 	api06/map_handler.cpp \
 	api06/handler_utils.cpp \
 	api06/node_handler.cpp \
+	api06/node_version_handler.cpp \
 	api06/nodes_handler.cpp \
 	api06/relation_handler.cpp \
 	api06/relations_handler.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -142,6 +142,7 @@ libcgimap_core_la_SOURCES+=\
 	api06/node_version_handler.cpp \
 	api06/nodes_handler.cpp \
 	api06/relation_handler.cpp \
+	api06/relation_version_handler.cpp \
 	api06/relations_handler.cpp \
 	api06/way_handler.cpp \
 	api06/way_version_handler.cpp \

--- a/src/api06/node_version_handler.cpp
+++ b/src/api06/node_version_handler.cpp
@@ -8,7 +8,7 @@ using std::vector;
 
 namespace api06 {
 
-node_version_responder::node_version_responder(mime::type mt, osm_nwr_id_t id_, osm_nwr_id_t v_, factory_ptr &w_)
+node_version_responder::node_version_responder(mime::type mt, osm_nwr_id_t id_, osm_version_t v_, factory_ptr &w_)
     : osm_current_responder(mt, w_), id(id_), v(v_) {
   vector<osm_edition_t> historic_ids;
   historic_ids.push_back(std::make_pair(id, v));
@@ -23,7 +23,7 @@ node_version_responder::node_version_responder(mime::type mt, osm_nwr_id_t id_, 
 
 node_version_responder::~node_version_responder() {}
 
-node_version_handler::node_version_handler(request &, osm_nwr_id_t id_, osm_nwr_id_t v_) : id(id_), v(v_) {}
+node_version_handler::node_version_handler(request &, osm_nwr_id_t id_, osm_version_t v_) : id(id_), v(v_) {}
 
 node_version_handler::~node_version_handler() {}
 

--- a/src/api06/node_version_handler.cpp
+++ b/src/api06/node_version_handler.cpp
@@ -1,0 +1,36 @@
+#include "cgimap/api06/node_version_handler.hpp"
+#include "cgimap/http.hpp"
+
+#include <sstream>
+
+using std::stringstream;
+using std::vector;
+
+namespace api06 {
+
+node_version_responder::node_version_responder(mime::type mt, osm_nwr_id_t id_, osm_nwr_id_t v_, factory_ptr &w_)
+    : osm_current_responder(mt, w_), id(id_), v(v_) {
+  vector<osm_edition_t> historic_ids;
+  historic_ids.push_back(std::make_pair(id, v));
+  if (sel->supports_historical_versions()) {
+    if (sel->select_historical_nodes(historic_ids) == 0) {
+       throw http::not_found("");
+    }
+  } else {
+   throw http::server_error("Data source does not support historical versions.");
+  }
+}
+
+node_version_responder::~node_version_responder() {}
+
+node_version_handler::node_version_handler(request &, osm_nwr_id_t id_, osm_nwr_id_t v_) : id(id_), v(v_) {}
+
+node_version_handler::~node_version_handler() {}
+
+std::string node_version_handler::log_name() const { return "node"; }
+
+responder_ptr_t node_version_handler::responder(factory_ptr &w) const {
+  return responder_ptr_t(new node_version_responder(mime_type, id, v, w));
+}
+
+} // namespace api06

--- a/src/api06/relation_version_handler.cpp
+++ b/src/api06/relation_version_handler.cpp
@@ -1,0 +1,37 @@
+#include "cgimap/api06/relation_version_handler.hpp"
+#include "cgimap/http.hpp"
+
+#include <sstream>
+
+using std::stringstream;
+using std::vector;
+
+namespace api06 {
+
+relation_version_responder::relation_version_responder(mime::type mt, osm_nwr_id_t id_, 
+                                       osm_version_t v_, factory_ptr &w_)
+    : osm_current_responder(mt, w_), id(id_), v(v_) {
+  vector<osm_edition_t> historic_ids;
+  historic_ids.push_back(std::make_pair(id, v));
+  if (sel->supports_historical_versions()) {
+    if (sel->select_historical_relations(historic_ids) == 0) {
+       throw http::not_found("");
+    }
+  } else {
+   throw http::server_error("Data source does not support historical versions.");
+  }
+}
+
+relation_version_responder::~relation_version_responder() {}
+
+relation_version_handler::relation_version_handler(request &, osm_nwr_id_t id_, osm_version_t v_) : id(id_), v(v_) {}
+
+relation_version_handler::~relation_version_handler() {}
+
+std::string relation_version_handler::log_name() const { return "relation"; }
+
+responder_ptr_t relation_version_handler::responder(factory_ptr &x) const {
+  return responder_ptr_t(new relation_version_responder(mime_type, id, v, x));
+}
+
+} // namespace api06

--- a/src/api06/way_version_handler.cpp
+++ b/src/api06/way_version_handler.cpp
@@ -1,0 +1,36 @@
+#include "cgimap/api06/way_version_handler.hpp"
+#include "cgimap/http.hpp"
+
+#include <sstream>
+
+using std::stringstream;
+using std::vector;
+
+namespace api06 {
+
+way_version_responder::way_version_responder(mime::type mt, osm_nwr_id_t id_, osm_version_t v_, factory_ptr &w_)
+    : osm_current_responder(mt, w_), id(id_), v(v_) {
+  vector<osm_edition_t> historic_ids;
+  historic_ids.push_back(std::make_pair(id, v));
+  if (sel->supports_historical_versions()) {
+    if (sel->select_historical_ways(historic_ids) == 0) {
+       throw http::not_found("");
+    }
+  } else {
+   throw http::server_error("Data source does not support historical versions.");
+  }
+}
+
+way_version_responder::~way_version_responder() {}
+
+way_version_handler::way_version_handler(request &, osm_nwr_id_t id_, osm_version_t v_) : id(id_), v(v_) {}
+
+way_version_handler::~way_version_handler() {}
+
+std::string way_version_handler::log_name() const { return "way"; }
+
+responder_ptr_t way_version_handler::responder(factory_ptr &x) const {
+  return responder_ptr_t(new way_version_responder(mime_type, id, v, x));
+}
+
+} // namespace api06

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -6,6 +6,7 @@
 #include "cgimap/api06/map_handler.hpp"
 
 #include "cgimap/api06/node_handler.hpp"
+#include "cgimap/api06/node_version_handler.hpp"
 #include "cgimap/api06/nodes_handler.hpp"
 
 #include "cgimap/api06/way_handler.hpp"
@@ -144,6 +145,8 @@ routes::routes()
 #ifdef ENABLE_EXPERIMENTAL
     r->add<node_ways_handler>(root_ / "node" / osm_id_ / "ways");
 #endif /* ENABLE_EXPERIMENTAL */
+    // make sure that node_version_handler is listed before node_handler
+    r->add<node_version_handler>(root_ / "node" / osm_id_ / osm_id_ );
     r->add<node_handler>(root_ / "node" / osm_id_);
     r->add<nodes_handler>(root_ / "nodes");
 
@@ -205,7 +208,6 @@ handler_ptr_t routes::operator()(request &req) const {
   // full path from request handler
   string path = get_request_path(req);
   handler_ptr_t hptr;
-
   // check the prefix
   if (path.compare(0, common_prefix.size(), common_prefix) == 0) {
     hptr = route_resource(req, string(path, common_prefix.size()), r);

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -15,6 +15,7 @@
 #include "cgimap/api06/ways_handler.hpp"
 
 #include "cgimap/api06/relation_handler.hpp"
+#include "cgimap/api06/relation_version_handler.hpp"
 #include "cgimap/api06/relation_full_handler.hpp"
 #include "cgimap/api06/relations_handler.hpp"
 
@@ -157,6 +158,7 @@ routes::routes()
     r->add<ways_handler>(root_ / "ways");
 
     r->add<relation_full_handler>(root_ / "relation" / osm_id_ / "full");
+    r->add<relation_version_handler>(root_ / "relation" / osm_id_ / osm_id_ );
     r->add<relation_handler>(root_ / "relation" / osm_id_);
     r->add<relations_handler>(root_ / "relations");
 

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -10,6 +10,7 @@
 #include "cgimap/api06/nodes_handler.hpp"
 
 #include "cgimap/api06/way_handler.hpp"
+#include "cgimap/api06/way_version_handler.hpp"
 #include "cgimap/api06/way_full_handler.hpp"
 #include "cgimap/api06/ways_handler.hpp"
 
@@ -145,12 +146,13 @@ routes::routes()
 #ifdef ENABLE_EXPERIMENTAL
     r->add<node_ways_handler>(root_ / "node" / osm_id_ / "ways");
 #endif /* ENABLE_EXPERIMENTAL */
-    // make sure that node_version_handler is listed before node_handler
+    // make sure that *_version_handler is listed before matching *_handler
     r->add<node_version_handler>(root_ / "node" / osm_id_ / osm_id_ );
     r->add<node_handler>(root_ / "node" / osm_id_);
     r->add<nodes_handler>(root_ / "nodes");
 
     r->add<way_full_handler>(root_ / "way" / osm_id_ / "full");
+    r->add<way_version_handler>(root_ / "way" / osm_id_ / osm_id_ );
     r->add<way_handler>(root_ / "way" / osm_id_);
     r->add<ways_handler>(root_ / "ways");
 

--- a/test/node.testcore/node_version.case
+++ b/test/node.testcore/node_version.case
@@ -1,0 +1,11 @@
+# node call with a specific version number
+Request-Method: GET
+Request-URI: /api/0.6/node/3/1
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition:
+---
+<osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <node id="3" version="1" changeset="3" lat="0.0000000" lon="0.0000000" user="foo" uid="1" visible="true" timestamp="2012-09-25T00:00:59Z"/>
+</osm>

--- a/test/node.testcore/node_version.case
+++ b/test/node.testcore/node_version.case
@@ -1,4 +1,4 @@
-# node call with a specific version number
+# node call with a specific version number pointing to an existing version
 Request-Method: GET
 Request-URI: /api/0.6/node/3/1
 ---

--- a/test/node.testcore/node_version_deleted.case
+++ b/test/node.testcore/node_version_deleted.case
@@ -1,0 +1,11 @@
+# node call with a specific version number pointing to a deleted version
+Request-Method: GET
+Request-URI: /api/0.6/node/3/2
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition:
+---
+<osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <node id="3" version="2" changeset="3" user="foo" uid="1" visible="false" timestamp="2012-09-25T00:01:00Z"/>
+</osm>

--- a/test/node.testcore/node_version_missing.case
+++ b/test/node.testcore/node_version_missing.case
@@ -1,0 +1,6 @@
+# node call with a specific version number where the version does not exist
+Request-Method: GET
+Request-URI: /api/0.6/node/3/3
+---
+Status: 404 Not Found
+---

--- a/test/relation.testcore/relation_version.case
+++ b/test/relation.testcore/relation_version.case
@@ -1,4 +1,4 @@
-# relation call with a specific version number
+# relation call with a specific version number pointing to an existing version
 Request-Method: GET
 Request-URI: /api/0.6/relation/2/1
 ---

--- a/test/relation.testcore/relation_version.case
+++ b/test/relation.testcore/relation_version.case
@@ -1,0 +1,14 @@
+# relation call with a specific version number
+Request-Method: GET
+Request-URI: /api/0.6/relation/2/1
+---
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition:
+Status: 200 OK
+---
+<osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <relation id="2" version="1" changeset="3" user="foo" uid="1" visible="true" timestamp="2013-01-12T00:00:00Z">
+    <member type="node" ref="2" role="stop"/>
+    <tag k="foo" v="bar"/>
+  </relation>
+</osm>

--- a/test/relation.testcore/relation_version_deleted.case
+++ b/test/relation.testcore/relation_version_deleted.case
@@ -1,0 +1,11 @@
+# relation call with a specific version number pointing to a deleted version
+Request-Method: GET
+Request-URI: /api/0.6/relation/2/2
+---
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition:
+Status: 200 OK
+---
+<osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <relation id="2" version="2" changeset="3" user="foo" uid="1" visible="false" timestamp="2013-01-12T00:00:00Z"/>
+</osm>

--- a/test/relation.testcore/relation_version_missing.case
+++ b/test/relation.testcore/relation_version_missing.case
@@ -1,0 +1,6 @@
+# relation call with a specific version number pointing to a nonexistent version
+Request-Method: GET
+Request-URI: /api/0.6/relation/2/3
+---
+Status: 404 Not Found
+---

--- a/test/way.testcore/way_version.case
+++ b/test/way.testcore/way_version.case
@@ -1,4 +1,4 @@
-# way call with a specific version number
+# way call with a specific version number pointing to an existing version
 Request-Method: GET
 Request-URI: /api/0.6/way/2/1
 ---

--- a/test/way.testcore/way_version.case
+++ b/test/way.testcore/way_version.case
@@ -1,0 +1,18 @@
+# ways call with a specific version number
+Request-Method: GET
+Request-URI: /api/0.6/way/2/1
+---
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition:
+Status: 200 OK
+---
+<osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <way id="2" version="1" changeset="3" user="foo" uid="1" visible="true" timestamp="2012-12-01T00:00:00Z">
+    <nd ref="1"/>
+    <nd ref="3"/>
+    <nd ref="2"/>
+    <nd ref="1"/>
+    <tag k="building" v="yes"/>
+    <tag k="name" v="Bar"/>
+  </way>
+</osm>

--- a/test/way.testcore/way_version.case
+++ b/test/way.testcore/way_version.case
@@ -1,4 +1,4 @@
-# ways call with a specific version number
+# way call with a specific version number
 Request-Method: GET
 Request-URI: /api/0.6/way/2/1
 ---

--- a/test/way.testcore/way_version_deleted.case
+++ b/test/way.testcore/way_version_deleted.case
@@ -1,0 +1,11 @@
+# way call with a specific version number that points to a deleted version
+Request-Method: GET
+Request-URI: /api/0.6/way/2/2
+---
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition:
+Status: 200 OK
+---
+<osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <way id="2" version="2" changeset="3" user="foo" uid="1" visible="false" timestamp="2012-12-01T00:00:00Z"/>
+</osm>

--- a/test/way.testcore/way_version_missing.case
+++ b/test/way.testcore/way_version_missing.case
@@ -1,0 +1,6 @@
+# way call with a specific version number that points to a nonexistent version
+Request-Method: GET
+Request-URI: /api/0.6/way/2/3
+---
+Status: 404 Not Found
+---


### PR DESCRIPTION
This pull requests adds support (and tests) for requests of the form /.../{node|way|relation}/[id]/[version]
