### PR TITLE
Fix HTTP error messages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -74,7 +74,7 @@ endif
 TESTS = test/map.testcore test/node.testcore test/anon.testcore test/way.testcore test/relation.testcore
 TESTS += test/empty.testcore test/way_full.testcore test/relation_full.testcore
 TESTS += test/test_parse_id_list test/test_oauth test/test_http test/test_parse_time
-TESTS += test/changesets.testcore
+TESTS += test/changesets.testcore test/message.testcore
 if ENABLE_EXPERIMENTAL
 TESTS += test/node_ways.testcore
 endif

--- a/src/api06/changeset_handler.cpp
+++ b/src/api06/changeset_handler.cpp
@@ -23,7 +23,9 @@ changeset_responder::changeset_responder(mime::type mt, osm_changeset_id_t id_,
   }
 
   if (sel->select_changesets(ids) == 0) {
-    throw http::not_found("");
+    std::ostringstream error;
+    error << "Changeset " << id << " was not found.";
+    throw http::not_found(error.str());
   }
 
   if (include_discussion) {

--- a/src/api06/node_handler.cpp
+++ b/src/api06/node_handler.cpp
@@ -14,7 +14,9 @@ node_responder::node_responder(mime::type mt, osm_nwr_id_t id_, factory_ptr &w_)
   ids.push_back(id);
 
   if (sel->select_nodes(ids) == 0) {
-    throw http::not_found("");
+    std::ostringstream error;
+    error << "Node " << id << " was not found.";
+    throw http::not_found(error.str());
   } else {
     check_visibility();
   }

--- a/src/api06/node_ways_handler.cpp
+++ b/src/api06/node_ways_handler.cpp
@@ -15,7 +15,9 @@ node_ways_responder::node_ways_responder(mime::type mt, osm_nwr_id_t id_,
   ids.push_back(id);
 
   if (sel->select_nodes(ids) == 0) {
-    throw http::not_found("");
+    std::ostringstream error;
+    error << "Node " << id << " was not found.";
+    throw http::not_found(error.str());
   } else {
     sel->select_ways_from_nodes();
     check_visibility();

--- a/src/api06/relation_full_handler.cpp
+++ b/src/api06/relation_full_handler.cpp
@@ -16,7 +16,9 @@ relation_full_responder::relation_full_responder(mime::type mt_, osm_nwr_id_t id
   ids.push_back(id);
 
   if (sel->select_relations(ids) == 0) {
-    throw http::not_found("");
+    std::ostringstream error;
+    error << "Relation " << id << " was not found.";
+    throw http::not_found(error.str());
   } else {
     check_visibility();
   }
@@ -33,8 +35,11 @@ void relation_full_responder::check_visibility() {
   switch (sel->check_relation_visibility(id)) {
 
   case data_selection::non_exist:
-    // TODO: fix error message / throw structure to emit better error message
-    throw http::not_found("");
+  {
+    std::ostringstream error;
+    error << "Relation " << id << " was not found.";
+    throw http::not_found(error.str());
+  }
 
   case data_selection::deleted:
     // TODO: fix error message / throw structure to emit better error message

--- a/src/api06/relation_handler.cpp
+++ b/src/api06/relation_handler.cpp
@@ -15,7 +15,9 @@ relation_responder::relation_responder(mime::type mt, osm_nwr_id_t id_,
   ids.push_back(id);
 
   if (sel->select_relations(ids) == 0) {
-    throw http::not_found("");
+    std::ostringstream error;
+    error << "Relation " << id << " was not found.";
+    throw http::not_found(error.str());
   } else {
     check_visibility();
   }

--- a/src/api06/way_full_handler.cpp
+++ b/src/api06/way_full_handler.cpp
@@ -16,7 +16,9 @@ way_full_responder::way_full_responder(mime::type mt_, osm_nwr_id_t id_,
   ids.push_back(id);
 
   if (sel->select_ways(ids) == 0) {
-    throw http::not_found("");
+    std::ostringstream error;
+    error << "Way " << id << " was not found.";
+    throw http::not_found(error.str());
   } else {
     check_visibility();
   }
@@ -30,8 +32,11 @@ void way_full_responder::check_visibility() {
   switch (sel->check_way_visibility(id)) {
 
   case data_selection::non_exist:
-    // TODO: fix error message / throw structure to emit better error message
-    throw http::not_found("");
+  {
+    std::ostringstream error;
+    error << "Way " << id << " was not found.";
+    throw http::not_found(error.str());
+  }
 
   case data_selection::deleted:
     // TODO: fix error message / throw structure to emit better error message

--- a/src/api06/way_handler.cpp
+++ b/src/api06/way_handler.cpp
@@ -14,7 +14,9 @@ way_responder::way_responder(mime::type mt, osm_nwr_id_t id_, factory_ptr &w_)
   ids.push_back(id);
 
   if (sel->select_ways(ids) == 0) {
-    throw http::not_found("");
+    std::ostringstream error;
+    error << "Way " << id << " was not found.";
+    throw http::not_found(error.str());
   } else {
     check_visibility();
   }

--- a/src/process_request.cpp
+++ b/src/process_request.cpp
@@ -48,11 +48,18 @@ void respond_error(const http::exception &e, request &r) {
     r.put(ostr.str());
 
   } else {
+    std::string message(e.what());
+    std::ostringstream message_size;
+    message_size << message.size();
+
     r.status(e.code());
-    r.add_header("Content-Type", "text/html");
-    r.add_header("Content-Length", "0");
-    r.add_header("Error", e.what());
+    r.add_header("Content-Type", "text/plain");
+    r.add_header("Content-Length", message_size.str());
+    r.add_header("Error", message);
     r.add_header("Cache-Control", "no-cache");
+
+    // output the message as well
+    r.put(message);
   }
 
   r.finish();

--- a/src/process_request.cpp
+++ b/src/process_request.cpp
@@ -29,6 +29,18 @@ namespace po = boost::program_options;
 
 namespace {
 
+// Rails responds to ActiveRecord::RecordNotFound with an empty HTML document.
+// Arguably, this isn't very useful. But it looks like we might be able to get
+// more information soon:
+// https://github.com/zerebubuth/openstreetmap-cgimap/pull/125#issuecomment-272720417
+void respond_404(const http::not_found &e, request &r) {
+  r.status(e.code());
+  r.add_header("Content-Type", "text/html; charset=utf-8");
+  r.add_header("Content-Length", "0");
+  r.add_header("Cache-Control", "no-cache");
+  r.put("");
+}
+
 void respond_error(const http::exception &e, request &r) {
   logger::message(format("Returning with http error %1% with reason %2%") %
                   e.code() % e.what());
@@ -352,9 +364,16 @@ void process_request(request &req, rate_limiter &limiter,
                     (end_time - start_time).total_milliseconds() %
                     bytes_written);
 
+  } catch (const http::not_found &e) {
+    // most errors are passed back giving the client a choice of whether to
+    // receive it as a standard HTTP error or a 200 OK with the body as an XML
+    // encoded description of the error. not found errors are special - they're
+    // passed back just as empty HTML documents.
+    respond_404(e, req);
+
   } catch (const http::exception &e) {
     // errors here occur before we've started writing the response
-    // so we\ can send something helpful back to the client.
+    // so we can send something helpful back to the client.
     respond_error(e, req);
 
   } catch (const std::exception &e) {

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -223,6 +223,8 @@ handler_ptr_t routes::operator()(request &req) const {
 
   } else {
     // doesn't match prefix...
-    throw http::not_found(path);
+    std::ostringstream error;
+    error << "Path does not match any known routes: " << path;
+    throw http::not_found(error.str());
   }
 }

--- a/test/map.testcore/bad_bbox_001.case
+++ b/test/map.testcore/bad_bbox_001.case
@@ -1,7 +1,9 @@
 Request-Method: GET
 Request-URI: /api/0.6/map
 ---
-Content-Length: 0
+Content-Length: 88
 Error: The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat.
 Status: 400 Bad Request
+Content-Type: text/plain
 ---
+The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat.

--- a/test/map.testcore/bad_bbox_002.case
+++ b/test/map.testcore/bad_bbox_002.case
@@ -1,7 +1,9 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=
 ---
-Content-Length: 0
+Content-Length: 88
 Error: The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat.
 Status: 400 Bad Request
+Content-Type: text/plain
 ---
+The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat.

--- a/test/map.testcore/bad_bbox_003.case
+++ b/test/map.testcore/bad_bbox_003.case
@@ -1,7 +1,9 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=0,0,0
 ---
-Content-Length: 0
+Content-Length: 88
 Error: The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat.
 Status: 400 Bad Request
+Content-Type: text/plain
 ---
+The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat.

--- a/test/map.testcore/bad_bbox_004.case
+++ b/test/map.testcore/bad_bbox_004.case
@@ -1,7 +1,9 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=0.1,0.1,-0.1,-0.1
 ---
-Content-Length: 0
+Content-Length: 118
 Error: The latitudes must be between -90 and 90, longitudes between -180 and 180 and the minima must be less than the maxima.
 Status: 400 Bad Request
+Content-Type: text/plain
 ---
+The latitudes must be between -90 and 90, longitudes between -180 and 180 and the minima must be less than the maxima.

--- a/test/map.testcore/bad_bbox_005.case
+++ b/test/map.testcore/bad_bbox_005.case
@@ -1,7 +1,9 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=179.9,0,180.1,0.1
 ---
-Content-Length: 0
+Content-Length: 118
 Error: The latitudes must be between -90 and 90, longitudes between -180 and 180 and the minima must be less than the maxima.
 Status: 400 Bad Request
+Content-Type: text/plain
 ---
+The latitudes must be between -90 and 90, longitudes between -180 and 180 and the minima must be less than the maxima.

--- a/test/map.testcore/bad_bbox_006.case
+++ b/test/map.testcore/bad_bbox_006.case
@@ -1,7 +1,9 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=-180.1,0,-179.9,0.1
 ---
-Content-Length: 0
+Content-Length: 118
 Error: The latitudes must be between -90 and 90, longitudes between -180 and 180 and the minima must be less than the maxima.
 Status: 400 Bad Request
+Content-Type: text/plain
 ---
+The latitudes must be between -90 and 90, longitudes between -180 and 180 and the minima must be less than the maxima.

--- a/test/map.testcore/bad_bbox_007.case
+++ b/test/map.testcore/bad_bbox_007.case
@@ -1,7 +1,9 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=0,89.9,0.1,90.1
 ---
-Content-Length: 0
+Content-Length: 118
 Error: The latitudes must be between -90 and 90, longitudes between -180 and 180 and the minima must be less than the maxima.
 Status: 400 Bad Request
+Content-Type: text/plain
 ---
+The latitudes must be between -90 and 90, longitudes between -180 and 180 and the minima must be less than the maxima.

--- a/test/map.testcore/bad_bbox_008.case
+++ b/test/map.testcore/bad_bbox_008.case
@@ -1,7 +1,9 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=0,-90.1,0.1,-89.9
 ---
-Content-Length: 0
+Content-Length: 118
 Error: The latitudes must be between -90 and 90, longitudes between -180 and 180 and the minima must be less than the maxima.
 Status: 400 Bad Request
+Content-Type: text/plain
 ---
+The latitudes must be between -90 and 90, longitudes between -180 and 180 and the minima must be less than the maxima.

--- a/test/message.testcore/data.osm
+++ b/test/message.testcore/data.osm
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<osm version="0.6" generator="by hand"/>

--- a/test/message.testcore/map_400.case
+++ b/test/message.testcore/map_400.case
@@ -1,0 +1,9 @@
+Request-Method: GET
+Request-URI: /api/0.6/map
+---
+Content-Length: 88
+Error: The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat.
+Status: 400 Bad Request
+Content-Type: text/plain
+---
+The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat.

--- a/test/message.testcore/map_400_xml.case
+++ b/test/message.testcore/map_400_xml.case
@@ -1,0 +1,12 @@
+Request-Method: GET
+Request-URI: /api/0.6/map
+HTTP-X-Error-Format: xml
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+---
+<?xml version="1.0" encoding="utf-8" ?>
+<osmError>
+  <status>400 Bad Request</status>
+  <message>The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat.</message>
+</osmError>

--- a/test/message.testcore/node_404.case
+++ b/test/message.testcore/node_404.case
@@ -4,8 +4,7 @@ Request-Method: GET
 Request-URI: /api/0.6/node/1
 ---
 Status: 404 Not Found
-Error: Node 1 was not found.
-Content-Type: text/plain
-Content-Length: 21
+!Error:
+Content-Type: text/html; charset=utf-8
+Content-Length: 0
 ---
-Node 1 was not found.

--- a/test/message.testcore/node_404.case
+++ b/test/message.testcore/node_404.case
@@ -1,0 +1,11 @@
+# requesting a missing node should result in a "Not Found" message, and the same
+# message repeated in the HTML body.
+Request-Method: GET
+Request-URI: /api/0.6/node/1
+---
+Status: 404 Not Found
+Error: Node 1 was not found.
+Content-Type: text/plain
+Content-Length: 21
+---
+Node 1 was not found.

--- a/test/message.testcore/node_404_xml.case
+++ b/test/message.testcore/node_404_xml.case
@@ -1,0 +1,16 @@
+# Adding a request X-Error-Format: xml header should result in the error being
+# returned in an XML document, and the return status being 200 OK. This is
+# mainly a legacy thing to handle clients (e.g: Flash) which weren't able to
+# handle HTTP statuses other than 200 and 404.
+Request-Method: GET
+Request-URI: /api/0.6/node/1
+HTTP-X-Error-Format: xml
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+---
+<?xml version="1.0" encoding="utf-8" ?>
+<osmError>
+  <status>404 Not Found</status>
+  <message>Node 1 was not found.</message>
+</osmError>

--- a/test/message.testcore/node_404_xml.case
+++ b/test/message.testcore/node_404_xml.case
@@ -1,16 +1,16 @@
-# Adding a request X-Error-Format: xml header should result in the error being
-# returned in an XML document, and the return status being 200 OK. This is
-# mainly a legacy thing to handle clients (e.g: Flash) which weren't able to
-# handle HTTP statuses other than 200 and 404.
+# Adding a request X-Error-Format: xml header would normally result in the
+# error being returned in an XML document, and the return status being 200 OK.
+# This is mainly a legacy thing to handle clients (e.g: Flash) which weren't
+# able to handle HTTP statuses other than 200 and 404.
+#
+# HOWEVER, that seems to be bypassed for 404s, which ignore the X-Error-Format
+# header.
 Request-Method: GET
 Request-URI: /api/0.6/node/1
 HTTP-X-Error-Format: xml
 ---
-Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Status: 404 Not Found
+!Error:
+Content-Type: text/html; charset=utf-8
+Content-Length: 0
 ---
-<?xml version="1.0" encoding="utf-8" ?>
-<osmError>
-  <status>404 Not Found</status>
-  <message>Node 1 was not found.</message>
-</osmError>

--- a/test/test_core.cpp
+++ b/test/test_core.cpp
@@ -430,7 +430,8 @@ void check_response(std::istream &expected, std::istream &actual) {
   if (expected_headers.count("Content-Type") > 0) {
     const std::string content_type =
         expected_headers.find("Content-Type")->second;
-    if (content_type.substr(0, 8) == "text/xml") {
+    if (content_type.substr(0, 8) == "text/xml" ||
+        content_type.substr(0, 9) == "text/html") {
       check_content_body_xml(expected, actual);
 
     } else if (content_type.substr(0, 9) == "text/json") {


### PR DESCRIPTION
Thanks to @mmd-osm for pointing this out in #124.

It looks like this sort of worked as of #83, although returning HTML rather than plain text as the Rails code does. That was sort of fixed in 1d0e06f2bdcbb5efc5ec7908e79d5d4e65fd139f to match the behaviour of _most_ of the Rails errors: which is to print a blank string as the error. Unfortunately, the side effect was disabling display in the body of all messages.

This branch tries to fix this, first by printing the error messages in the response body and secondly by providing error messages for all the various `not_found` cases.

This is a departure from strict compatibility with the Rails code. However, most of the `not_found` messages that the Rails code generates are translations from `ActiveRecord::RecordNotFound`. If I remember correctly, at the time of writing it was difficult to tell exactly _what_ hadn't been found, although I see that [more information might be available now](http://api.rubyonrails.org/classes/ActiveRecord/RecordNotFound.html). I think the best thing is to provide a meaningful error message in cgimap, and I'll try to come up with a similar patch for the Rails code.

@tomhughes what do you think?
