### PR TITLE
Add unknown route handler in lighttpd configuration

### DIFF
--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -7,6 +7,9 @@ server.port = 31337
 # selecting modules
 server.modules = ( "mod_access", "mod_rewrite", "mod_fastcgi" )
 
+# handling unknown routes
+server.error-handler-404   = "/dispatch.map"
+
 # include, relative to dirname of main config file
 #include "mime.types.conf"
 


### PR DESCRIPTION
Fixes #52, routes the unknown call to the cgimap to display a verbose message. I haven't included the code to return an error message as it is being handled in #125. 