### PR TITLE
Fix reject unknown api calls with 404

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -74,7 +74,7 @@ endif
 TESTS = test/map.testcore test/node.testcore test/anon.testcore test/way.testcore test/relation.testcore
 TESTS += test/empty.testcore test/way_full.testcore test/relation_full.testcore
 TESTS += test/test_parse_id_list test/test_oauth test/test_http test/test_parse_time
-TESTS += test/changesets.testcore
+TESTS += test/changesets.testcore test/routes.testcore
 if ENABLE_EXPERIMENTAL
 TESTS += test/node_ways.testcore
 endif

--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -7,6 +7,9 @@ server.port = 31337
 # selecting modules
 server.modules = ( "mod_access", "mod_rewrite", "mod_fastcgi" )
 
+# handling unknown routes
+server.error-handler-404   = "/dispatch.map"
+
 # include, relative to dirname of main config file
 #include "mime.types.conf"
 

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -78,8 +78,11 @@ struct router {
                    handler_ptr_t &ptr) {
       try {
         list<string>::const_iterator begin = parts.begin();
+        auto sequence = r.match(begin, parts.end());
+        if(begin!=parts.end())
+          throw match::error();
         ptr.reset(
-            invoke(func, make_cons(ref(params), r.match(begin, parts.end()))));
+            invoke(func, make_cons(ref(params), sequence)));
         return true;
       } catch (const match::error &e) {
         return false;

--- a/test/routes.testcore/data.osm
+++ b/test/routes.testcore/data.osm
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<osm version="0.6" generator="by hand">
+  <node id="1" version="1" changeset="1" lat="0.0" lon="0.0" user="foo" uid="1" visible="true" timestamp="2012-09-25T00:00:00Z"/>
+  <node id="2" version="8" changeset="3" lat="1.0" lon="1.0" user="foo" uid="1" visible="true" timestamp="2012-10-01T00:00:00Z">
+    <tag k="foo" v="bar1"/>
+    <tag k="bar" v="bar2"/>
+    <tag k="baz" v="bar3"/>
+  </node>
+  <node id="3" version="2" changeset="3" lat="0.0" lon="0.0" user="foo" uid="1" visible="true" timestamp="2012-09-25T00:01:00Z"/>
+
+  <way id="1" version="1" changeset="1" user="foo" uid="1" visible="true" timestamp="2012-12-01T00:00:00Z">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+    <nd ref="1"/>
+    <tag k="highway" v="motorway"/>
+    <tag k="name" v="Foo"/>
+  </way>
+
+  <way id="2" version="1" changeset="3" user="foo" uid="1" visible="true" timestamp="2012-12-01T00:00:00Z">
+    <nd ref="1"/>
+    <nd ref="3"/>
+    <nd ref="2"/>
+    <nd ref="1"/>
+    <tag k="building" v="yes"/>
+    <tag k="name" v="Bar"/>
+  </way>
+
+  <way id="2" version="2" changeset="3" user="foo" uid="1" visible="false" timestamp="2012-12-01T00:00:00Z"/>
+
+  <way id="8589934592" visible="true" version="1" changeset="4" timestamp="2013-10-20T00:00:00Z" user="user_4" uid="4"/>
+  <way id="9223372036854775807" visible="true" version="1" changeset="4" timestamp="2013-10-20T00:00:00Z" user="user_4" uid="4"/>
+</osm>

--- a/test/routes.testcore/way_id_extra.case
+++ b/test/routes.testcore/way_id_extra.case
@@ -1,0 +1,8 @@
+# the '/foo' on the end of the URL isn't a valid URL and should return a
+# 404 response rather than falling back to /api/0.6/way/1 and ignoring the
+# '/foo' on the end.
+Request-Method: GET
+Request-URI: /api/0.6/way/1/foo
+---
+Status: 404 Not Found
+---


### PR DESCRIPTION
Fixes #52. 
Solved it by checking if the request path has been matched/iterated completely. I think we can use the existing router with this fix for now until we have a new router.

Should I add the test cases as shown in 52-unknown-api-calls?

Let me know if I have to fix my code style/syntax.

Thanks!