### PR TITLE
Add support for changeset downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ test/test_apidb_backend_nodes
 test/test_apidb_backend_oauth
 test/test_apidb_backend_historic
 test/test_apidb_backend_changesets
+test/test_apidb_backend_changeset_downloads
 test/test_parse_id_list
 test/test_http
 test/test_oauth

--- a/Makefile.am
+++ b/Makefile.am
@@ -91,7 +91,8 @@ TESTS += \
 	test/test_apidb_backend_nodes \
 	test/test_apidb_backend_oauth \
 	test/test_apidb_backend_historic \
-	test/test_apidb_backend_changesets
+	test/test_apidb_backend_changesets \
+	test/test_apidb_backend_changeset_downloads
 endif
 TEST_EXTENSIONS = .testcore
 TESTCORE_LOG_COMPILER = test/test_core

--- a/README
+++ b/README
@@ -22,7 +22,11 @@ Currently, CGImap implements:
 * single node, way and relation fetches,
 * multiple node, way and relation fetches,
 * the "full" way and relation calls and
-* changset metadata downloads, including discussions.
+* changset metadata downloads, including discussions,
+* single node, way and relation history calls,
+* single node, way and relation specific version fetches,
+* multiple node, way and relation specific version fetches,
+* changeset downloads.
 
 Note that changeset metadata isn't the same thing as the changeset
 download (i.e: `osmChange` data).
@@ -35,11 +39,11 @@ CGImap uses a PostgreSQL server for either the APIDB or PGsnapshot backends. A m
 CGImap depends on the following libraries. Versions used during
 development are in brackets. Other versions may work, but YMMV.
 
-* libxml2     (2.9.1+dfsg1-3ubuntu4.7)
-* libpqxx-4.0 (4.0.1+dfsg-3ubuntu1)
-* libfcgi     (2.4.0-8.1ubuntu5)
-* libboost    (1.54.0-4ubuntu3.1)
-* libcrypto++ (5.6.1-8)
+* libxml2     (2.9.3+dfsg1-1ubuntu0.2)
+* libpqxx-4.0 (4.0.1+dfsg-3ubuntu2)
+* libfcgi     (2.4.0-8.3)
+* libboost    (1.58.0+dfsg-5ubuntu3.1)
+* libcrypto++ (5.6.1-9)
 
 If you're running a Debian or Ubuntu system these can be installed
 using the following command:

--- a/include/cgimap/api06/changeset_download_handler.hpp
+++ b/include/cgimap/api06/changeset_download_handler.hpp
@@ -1,0 +1,34 @@
+#ifndef API06_CHANGESET_DOWNLOAD_HANDLER_HPP
+#define API06_CHANGESET_DOWNLOAD_HANDLER_HPP
+
+#include "cgimap/handler.hpp"
+#include "cgimap/osmchange_responder.hpp"
+#include "cgimap/request.hpp"
+#include <string>
+
+namespace api06 {
+
+class changeset_download_responder : public osmchange_responder {
+public:
+  changeset_download_responder(mime::type, osm_changeset_id_t, data_selection_ptr &);
+  ~changeset_download_responder();
+
+private:
+  osm_changeset_id_t id;
+};
+
+class changeset_download_handler : public handler {
+public:
+  changeset_download_handler(request &req, osm_changeset_id_t id);
+  ~changeset_download_handler();
+
+  std::string log_name() const;
+  responder_ptr_t responder(data_selection_ptr &x) const;
+
+private:
+  osm_changeset_id_t id;
+};
+
+} // namespace api06
+
+#endif /* API06_CHANGESET_DOWNLOAD_HANDLER_HPP */

--- a/include/cgimap/backend/apidb/readonly_pgsql_selection.hpp
+++ b/include/cgimap/backend/apidb/readonly_pgsql_selection.hpp
@@ -55,6 +55,7 @@ public:
   int select_ways_with_history(const std::vector<osm_nwr_id_t> &);
   int select_relations_with_history(const std::vector<osm_nwr_id_t> &);
   void set_redactions_visible(bool);
+  int select_historical_by_changesets(const std::vector<osm_changeset_id_t> &);
 
   /**
    * a factory for the creation of read-only selections, so it

--- a/include/cgimap/backend/apidb/writeable_pgsql_selection.hpp
+++ b/include/cgimap/backend/apidb/writeable_pgsql_selection.hpp
@@ -52,6 +52,7 @@ public:
   int select_ways_with_history(const std::vector<osm_nwr_id_t> &);
   int select_relations_with_history(const std::vector<osm_nwr_id_t> &);
   void set_redactions_visible(bool);
+  int select_historical_by_changesets(const std::vector<osm_changeset_id_t> &);
 
   /**
    * abstracts the creation of transactions for the writeable

--- a/include/cgimap/data_selection.hpp
+++ b/include/cgimap/data_selection.hpp
@@ -122,6 +122,12 @@ public:
   /// false.
   virtual void set_redactions_visible(bool visible);
 
+  /// select all versions of nodes, ways and relations which were added as part
+  /// of any of the changesets with the given IDs. returns the number of
+  /// distinct (element_type, id, version) tuples selected.
+  virtual int select_historical_by_changesets(
+    const std::vector<osm_changeset_id_t> &);
+
   /****************** changeset functions **********************/
 
   /// does this data selection support changesets?

--- a/include/cgimap/json_formatter.hpp
+++ b/include/cgimap/json_formatter.hpp
@@ -23,11 +23,13 @@ public:
 
   mime::type mime_type() const;
 
-  void start_document(const std::string &generator);
+  void start_document(const std::string &generator, const std::string &root_name);
   void end_document();
   void write_bounds(const bbox &bounds);
   void start_element_type(element_type type);
   void end_element_type(element_type type);
+  void start_action(action_type type);
+  void end_action(action_type type);
   void error(const std::exception &e);
 
   void write_node(const element_info &elem, double lon, double lat,

--- a/include/cgimap/osmchange_responder.hpp
+++ b/include/cgimap/osmchange_responder.hpp
@@ -1,0 +1,31 @@
+#ifndef OSMCHANGE_RESPONDER_HPP
+#define OSMCHANGE_RESPONDER_HPP
+
+#include "cgimap/osm_responder.hpp"
+
+/**
+ * utility class - inherit from this when implementing something that responds
+ * with an osmChange (a.k.a "diff") document.
+ */
+class osmchange_responder : public osm_responder {
+public:
+  // construct, passing the mime type down to the responder.
+  // optional bounds are stored at this level, but available to derived classes.
+  osmchange_responder(mime::type, data_selection_ptr &s);
+
+  virtual ~osmchange_responder();
+
+  // takes the stuff in the tmp_nodes/ways/relations tables and sorts them by
+  // timestamp, then wraps them in <create>/<modify>/<delete> to create an
+  // approximation of a diff. the reliance on timestamp means it's entirely
+  // likely that some documents may be poorly formed.
+  void write(boost::shared_ptr<output_formatter> f,
+             const std::string &generator,
+             const boost::posix_time::ptime &now);
+
+protected:
+  // selection of elements to be written out
+  data_selection_ptr sel;
+};
+
+#endif /* OSMCHANGE_RESPONDER_HPP */

--- a/include/cgimap/output_formatter.hpp
+++ b/include/cgimap/output_formatter.hpp
@@ -20,6 +20,13 @@ enum element_type {
   element_type_relation
 };
 
+// TODO: document me.
+enum action_type {
+  action_type_create,
+  action_type_modify,
+  action_type_delete
+};
+
 struct element_info {
   element_info();
   element_info(const element_info &);
@@ -127,10 +134,12 @@ struct output_formatter {
   // produce.
   virtual mime::type mime_type() const = 0;
 
-  // called once to start the document - this will be the first call
-  // to this object after construction. the string passed will be
-  // used as the "generator" header attribute.
-  virtual void start_document(const std::string &generator) = 0;
+  // called once to start the document - this will be the first call to this
+  // object after construction. the first argument will be used as the
+  // "generator" header attribute, and the second will name the root element
+  // (if there is one - JSON doesn't have one), e.g: "osm" or "osmChange".
+  virtual void start_document(
+    const std::string &generator, const std::string &root_name) = 0;
 
   // called once to end the document - there will be no calls after this
   // one. this will be called, even if an error has occurred.
@@ -151,6 +160,10 @@ struct output_formatter {
 
   // end a type of element. this is called once for nodes, ways or relations
   virtual void end_element_type(element_type type) = 0;
+
+  // TODO: document me.
+  virtual void start_action(action_type type) = 0;
+  virtual void end_action(action_type type) = 0;
 
   // output a single node given that node's row and an iterator over its tags
   virtual void write_node(const element_info &elem, double lon, double lat,

--- a/include/cgimap/xml_formatter.hpp
+++ b/include/cgimap/xml_formatter.hpp
@@ -23,11 +23,13 @@ public:
 
   mime::type mime_type() const;
 
-  void start_document(const std::string &generator);
+  void start_document(const std::string &generator, const std::string &root_name);
   void end_document();
   void write_bounds(const bbox &bounds);
   void start_element_type(element_type type);
   void end_element_type(element_type type);
+  void start_action(action_type type);
+  void end_action(action_type type);
   void error(const std::exception &e);
 
   void write_node(const element_info &elem, double lon, double lat,

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,13 +16,15 @@ check_PROGRAMS+=\
 	../test/test_apidb_backend_nodes \
 	../test/test_apidb_backend_oauth \
 	../test/test_apidb_backend_historic \
-	../test/test_apidb_backend_changesets
+	../test/test_apidb_backend_changesets \
+	../test/test_apidb_backend_changeset_downloads
 ___openstreetmap_cgimap_LDADD+=libcgimap_apidb.la
 ___test_test_core_LDADD+=libcgimap_apidb.la
 ___test_test_apidb_backend_nodes_LDADD=libcgimap_core.la libcgimap_apidb.la
 ___test_test_apidb_backend_oauth_LDADD=libcgimap_core.la libcgimap_apidb.la
 ___test_test_apidb_backend_historic_LDADD=libcgimap_core.la libcgimap_apidb.la
 ___test_test_apidb_backend_changesets_LDADD=libcgimap_core.la libcgimap_apidb.la
+___test_test_apidb_backend_changeset_downloads_LDADD=libcgimap_core.la libcgimap_apidb.la
 endif
 
 if ENABLE_PGSNAPSHOT
@@ -34,6 +36,7 @@ ___test_test_apidb_backend_nodes_LDADD+=libcgimap_pgsnapshot.la
 ___test_test_apidb_backend_oauth_LDADD+=libcgimap_pgsnapshot.la
 ___test_test_apidb_backend_historic_LDADD+=libcgimap_pgsnapshot.la
 ___test_test_apidb_backend_changesets_LDADD+=libcgimap_pgsnapshot.la
+___test_test_apidb_backend_changeset_downloads_LDADD+=libcgimap_pgsnapshot.la
 endif
 endif
 
@@ -45,6 +48,7 @@ ___test_test_apidb_backend_nodes_LDADD+=libcgimap_staticxml.la
 ___test_test_apidb_backend_oauth_LDADD+=libcgimap_staticxml.la
 ___test_test_apidb_backend_historic_LDADD+=libcgimap_staticxml.la
 ___test_test_apidb_backend_changesets_LDADD+=libcgimap_staticxml.la
+___test_test_apidb_backend_changeset_downloads_LDADD+=libcgimap_staticxml.la
 endif
 
 ___openstreetmap_cgimap_LDADD+=libcgimap_core.la @BOOST_PROGRAM_OPTIONS_LIB@ @BOOST_FILESYSTEM_LIB@ @BOOST_SYSTEM_LIB@ @LIBPQXX_LIBS@ @CRYPTOPP_LIBS@
@@ -60,6 +64,7 @@ ___test_test_apidb_backend_nodes_LDADD+=libcgimap_core.la @BOOST_PROGRAM_OPTIONS
 ___test_test_apidb_backend_oauth_LDADD+=libcgimap_core.la @BOOST_PROGRAM_OPTIONS_LIB@ @BOOST_FILESYSTEM_LIB@ @BOOST_SYSTEM_LIB@ @BOOST_LOCALE_LIB@ @LIBPQXX_LIBS@ @CRYPTOPP_LIBS@
 ___test_test_apidb_backend_historic_LDADD+=libcgimap_core.la @BOOST_PROGRAM_OPTIONS_LIB@ @BOOST_FILESYSTEM_LIB@ @BOOST_SYSTEM_LIB@ @BOOST_LOCALE_LIB@ @LIBPQXX_LIBS@ @CRYPTOPP_LIBS@
 ___test_test_apidb_backend_changesets_LDADD+=libcgimap_core.la @BOOST_PROGRAM_OPTIONS_LIB@ @BOOST_FILESYSTEM_LIB@ @BOOST_SYSTEM_LIB@ @BOOST_LOCALE_LIB@ @LIBPQXX_LIBS@ @CRYPTOPP_LIBS@
+___test_test_apidb_backend_changeset_downloads_LDADD+=libcgimap_core.la @BOOST_PROGRAM_OPTIONS_LIB@ @BOOST_FILESYSTEM_LIB@ @BOOST_SYSTEM_LIB@ @BOOST_LOCALE_LIB@ @LIBPQXX_LIBS@ @CRYPTOPP_LIBS@
 endif
 
 ################################################################################
@@ -100,6 +105,11 @@ ___test_test_apidb_backend_historic_SOURCES=\
 	../test/test_request.cpp
 ___test_test_apidb_backend_changesets_SOURCES=\
 	../test/test_apidb_backend_changesets.cpp \
+	../test/test_formatter.cpp \
+	../test/test_database.cpp \
+	../test/test_request.cpp
+___test_test_apidb_backend_changeset_downloads_SOURCES=\
+	../test/test_apidb_backend_changeset_downloads.cpp \
 	../test/test_formatter.cpp \
 	../test/test_database.cpp \
 	../test/test_request.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -121,6 +121,7 @@ libcgimap_core_la_SOURCES=\
 	oauth.cpp \
 	osm_responder.cpp \
 	osm_current_responder.cpp \
+	osmchange_responder.cpp \
 	output_formatter.cpp \
 	output_writer.cpp \
 	process_request.cpp \
@@ -153,7 +154,8 @@ libcgimap_core_la_SOURCES+=\
 	api06/relation_full_handler.cpp \
 	api06/way_full_handler.cpp \
 	api06/id_version_io.cpp \
-	api06/changeset_handler.cpp
+	api06/changeset_handler.cpp \
+	api06/changeset_download_handler.cpp
 
 if ENABLE_EXPERIMENTAL
 libcgimap_core_la_SOURCES+=\

--- a/src/api06/changeset_download_handler.cpp
+++ b/src/api06/changeset_download_handler.cpp
@@ -24,6 +24,13 @@ changeset_download_responder::changeset_download_responder(
 
   vector<osm_changeset_id_t> ids;
   ids.push_back(id);
+
+  if (sel->select_changesets(ids) == 0) {
+    std::ostringstream error;
+    error << "Changeset " << id << " was not found.";
+    throw http::not_found(error.str());
+  }
+
   sel->select_historical_by_changesets(ids);
 }
 

--- a/src/api06/changeset_download_handler.cpp
+++ b/src/api06/changeset_download_handler.cpp
@@ -1,0 +1,47 @@
+#include "cgimap/api06/changeset_download_handler.hpp"
+#include "cgimap/request_helpers.hpp"
+#include "cgimap/http.hpp"
+#include "cgimap/config.hpp"
+
+#include <sstream>
+
+using std::stringstream;
+using std::vector;
+
+namespace api06 {
+
+changeset_download_responder::changeset_download_responder(
+  mime::type mt, osm_changeset_id_t id_, data_selection_ptr &w_)
+  : osmchange_responder(mt, w_), id(id_) {
+
+  if (!sel->supports_changesets()) {
+    throw http::server_error("Data source does not support changesets.");
+  }
+
+  if (!sel->supports_historical_versions()) {
+    throw http::server_error("Data source does not support historical versions.");
+  }
+
+  //vector<osm_changeset_id_t> ids;
+  //ids.push_back(id);
+
+  vector<osm_edition_t> nodes;
+  nodes.emplace_back(1, 1);
+  sel->select_historical_nodes(nodes);
+}
+
+changeset_download_responder::~changeset_download_responder() {}
+
+changeset_download_handler::changeset_download_handler(request &req, osm_changeset_id_t id_)
+  : id(id_) {
+}
+
+changeset_download_handler::~changeset_download_handler() {}
+
+std::string changeset_download_handler::log_name() const { return "changeset/download"; }
+
+responder_ptr_t changeset_download_handler::responder(data_selection_ptr &w) const {
+  return responder_ptr_t(new changeset_download_responder(mime_type, id, w));
+}
+
+} // namespace api06

--- a/src/api06/changeset_download_handler.cpp
+++ b/src/api06/changeset_download_handler.cpp
@@ -22,12 +22,9 @@ changeset_download_responder::changeset_download_responder(
     throw http::server_error("Data source does not support historical versions.");
   }
 
-  //vector<osm_changeset_id_t> ids;
-  //ids.push_back(id);
-
-  vector<osm_edition_t> nodes;
-  nodes.emplace_back(1, 1);
-  sel->select_historical_nodes(nodes);
+  vector<osm_changeset_id_t> ids;
+  ids.push_back(id);
+  sel->select_historical_by_changesets(ids);
 }
 
 changeset_download_responder::~changeset_download_responder() {}

--- a/src/backend/apidb/readonly_pgsql_selection.cpp
+++ b/src/backend/apidb/readonly_pgsql_selection.cpp
@@ -130,8 +130,9 @@ struct erase_formatter
 
   mime::type mime_type() const { return m_fmt.mime_type(); }
 
-  void start_document(const std::string &generator) {
-    m_fmt.start_document(generator);
+  void start_document(
+    const std::string &generator, const std::string &root_name) {
+    m_fmt.start_document(generator, root_name);
   }
 
   void end_document() { m_fmt.end_document(); }
@@ -139,6 +140,8 @@ struct erase_formatter
   void write_bounds(const bbox &bounds) { m_fmt.write_bounds(bounds); }
   void start_element_type(element_type type) { m_fmt.start_element_type(type); }
   void end_element_type(element_type type) { m_fmt.end_element_type(type); }
+  void start_action(action_type type) { m_fmt.start_action(type); }
+  void end_action(action_type type) { m_fmt.end_action(type); }
   void flush() { m_fmt.flush(); }
   void error(const std::string &str) { m_fmt.error(str); }
 

--- a/src/backend/apidb/readonly_pgsql_selection.cpp
+++ b/src/backend/apidb/readonly_pgsql_selection.cpp
@@ -484,10 +484,10 @@ int readonly_pgsql_selection::select_historical_by_changesets(
       sel_historic_nodes);
     selected += insert_results(w.prepared("select_ways_by_changesets")
       (ids)(m_redactions_visible).exec(),
-      sel_historic_nodes);
+      sel_historic_ways);
     selected += insert_results(w.prepared("select_relations_by_changesets")
       (ids)(m_redactions_visible).exec(),
-      sel_historic_nodes);
+      sel_historic_relations);
   }
 
   return selected;

--- a/src/backend/staticxml/staticxml.cpp
+++ b/src/backend/staticxml/staticxml.cpp
@@ -11,6 +11,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/foreach.hpp>
 #include <sstream>
+#include <unordered_set>
 
 namespace po = boost::program_options;
 namespace pt = boost::posix_time;
@@ -559,6 +560,19 @@ struct static_data_selection : public data_selection {
     m_redactions_visible = visible;
   }
 
+  virtual int select_historical_by_changesets(
+    const std::vector<osm_changeset_id_t> &ids) {
+
+    std::unordered_set<osm_changeset_id_t> changesets(ids.begin(), ids.end());
+
+    int selected = 0;
+    selected += select_by_changesets<node>(m_historic_nodes, changesets);
+    selected += select_by_changesets<way>(m_historic_ways, changesets);
+    selected += select_by_changesets<relation>(m_historic_relations, changesets);
+
+    return selected;
+  }
+
   virtual bool supports_changesets() { return true; }
 
   virtual int select_changesets(const std::vector<osm_changeset_id_t> &ids) {
@@ -702,6 +716,24 @@ private:
         }
       }
     }
+    return selected;
+  }
+
+  template <typename T>
+  int select_by_changesets(
+    std::set<osm_edition_t> &found_eds,
+    const std::unordered_set<osm_changeset_id_t> &changesets) const {
+
+    int selected = 0;
+
+    for (const auto &row : map_of<T>()) {
+      const T &t = row.second;
+      if (changesets.count(t.m_info.changeset) > 0) {
+        found_eds.emplace(t.m_info.id, t.m_info.version);
+        selected += 1;
+      }
+    }
+
     return selected;
   }
 

--- a/src/backend/staticxml/staticxml.cpp
+++ b/src/backend/staticxml/staticxml.cpp
@@ -729,8 +729,11 @@ private:
     for (const auto &row : map_of<T>()) {
       const T &t = row.second;
       if (changesets.count(t.m_info.changeset) > 0) {
-        found_eds.emplace(t.m_info.id, t.m_info.version);
-        selected += 1;
+        bool is_redacted = bool(t.m_info.redaction);
+        if (!is_redacted || m_redactions_visible) {
+          found_eds.emplace(t.m_info.id, t.m_info.version);
+          selected += 1;
+        }
       }
     }
 

--- a/src/data_selection.cpp
+++ b/src/data_selection.cpp
@@ -34,6 +34,12 @@ void data_selection::set_redactions_visible(bool) {
   throw std::runtime_error("data_selection does not support redactions");
 }
 
+int data_selection::select_historical_by_changesets(
+  const std::vector<osm_changeset_id_t> &) {
+  throw std::runtime_error("data_selection does not support historical "
+    "versions or changesets");
+}
+
 void data_selection::write_changesets(output_formatter &, const boost::posix_time::ptime &) {
 }
 

--- a/src/json_formatter.cpp
+++ b/src/json_formatter.cpp
@@ -48,18 +48,15 @@ void json_formatter::write_tags(const tags_t &tags) {
   writer->object_key(k); \
   writer->entry_##vt(v);
 
-void json_formatter::start_document(const std::string &generator) {
+void json_formatter::start_document(
+  const std::string &generator, const std::string &root_name) {
   writer->start_object();
 
   WRITE_KV("version", string, "0.6");
-  writer->object_key("generator");
-  writer->entry_string(generator);
-  writer->object_key("copyright");
-  writer->entry_string("OpenStreetMap and contributors");
-  writer->object_key("attribution");
-  writer->entry_string("http://www.openstreetmap.org/copyright");
-  writer->object_key("license");
-  writer->entry_string("http://opendatacommons.org/licenses/odbl/1-0/");
+  WRITE_KV("generator", string, generator);
+  WRITE_KV("copyright", string, "OpenStreetMap and contributors");
+  WRITE_KV("attribution", string, "http://www.openstreetmap.org/copyright");
+  WRITE_KV("license", string, "http://opendatacommons.org/licenses/odbl/1-0/");
 }
 
 void json_formatter::write_bounds(const bbox &bounds) {
@@ -92,6 +89,12 @@ void json_formatter::start_element_type(element_type type) {
 }
 
 void json_formatter::end_element_type(element_type) { writer->end_array(); }
+
+void json_formatter::start_action(action_type type) {
+}
+
+void json_formatter::end_action(action_type type) {
+}
 
 void json_formatter::error(const std::exception &e) {
   writer->start_object();

--- a/src/osm_current_responder.cpp
+++ b/src/osm_current_responder.cpp
@@ -18,7 +18,7 @@ void osm_current_responder::write(shared_ptr<output_formatter> formatter,
   output_formatter &fmt = *formatter;
 
   try {
-    fmt.start_document(generator);
+    fmt.start_document(generator, "osm");
     if (bounds) {
       fmt.write_bounds(bounds.get());
     }

--- a/src/osmchange_responder.cpp
+++ b/src/osmchange_responder.cpp
@@ -1,0 +1,199 @@
+#include "cgimap/config.hpp"
+#include "cgimap/osmchange_responder.hpp"
+
+using std::list;
+using boost::shared_ptr;
+namespace pt = boost::posix_time;
+
+namespace {
+
+struct element {
+  struct lonlat { double m_lon, m_lat; };
+
+  element_type m_type;
+  element_info m_info;
+  tags_t m_tags;
+
+  // only one of these will be non-empty depending on m_type
+  lonlat m_lonlat;
+  nodes_t m_nds;
+  members_t m_members;
+};
+
+bool operator<(const element &a, const element &b) {
+  // length of YYYY-MM-DDTHH:MM:SSZ is 20, and strings should always be that
+  // long.
+  assert(a.m_info.timestamp.size() == 20);
+  assert(b.m_info.timestamp.size() == 20);
+
+  auto cmp = strncmp(
+    a.m_info.timestamp.c_str(), b.m_info.timestamp.c_str(), 20);
+
+  if (cmp < 0) {
+    return true;
+
+  } else if (cmp > 0) {
+    return false;
+
+  } else if (a.m_type < b.m_type) {
+    return true;
+
+  } else if (a.m_type > b.m_type) {
+    return false;
+
+  } else {
+    return a.m_info.id < b.m_info.id;
+  }
+}
+
+struct sorting_formatter
+  : public output_formatter {
+
+  virtual ~sorting_formatter() {}
+
+  mime::type mime_type() const {
+    throw std::runtime_error("unimplemented");
+  }
+
+  void start_document(
+    const std::string &generator,
+    const std::string &root_name) {
+
+    throw std::runtime_error("unimplemented");
+  }
+
+  void end_document() {
+    throw std::runtime_error("unimplemented");
+  }
+
+  void error(const std::exception &e) {
+    throw std::runtime_error("unimplemented");
+  }
+
+  void write_bounds(const bbox &bounds) {
+    throw std::runtime_error("unimplemented");
+  }
+
+  void start_element_type(element_type type) {
+    throw std::runtime_error("unimplemented");
+  }
+
+  void end_element_type(element_type type) {
+    throw std::runtime_error("unimplemented");
+  }
+
+  void write_node(
+    const element_info &elem,
+    double lon, double lat,
+    const tags_t &tags) {
+
+    element node{
+      element_type_node, elem, tags, element::lonlat{lon, lat},
+        nodes_t(), members_t()};
+
+    m_elements.emplace_back(std::move(node));
+  }
+
+  void write_way(
+    const element_info &elem,
+    const nodes_t &nodes,
+    const tags_t &tags) {
+
+    throw std::runtime_error("unimplemented");
+  }
+
+  void write_relation(
+    const element_info &elem,
+    const members_t &members,
+    const tags_t &tags) {
+
+    throw std::runtime_error("unimplemented");
+  }
+
+  void write_changeset(
+    const changeset_info &elem,
+    const tags_t &tags,
+    bool include_comments,
+    const comments_t &comments,
+    const boost::posix_time::ptime &now) {
+
+    throw std::runtime_error("unimplemented");
+  }
+
+  void flush() {
+    throw std::runtime_error("unimplemented");
+  }
+
+  // write an error to the output stream
+  void error(const std::string &) {
+    throw std::runtime_error("unimplemented");
+  }
+
+  void start_action(action_type type) {
+    // this shouldn't be called here, as the things which call this don't have
+    // actions - they're added by this code.
+    throw std::runtime_error("Unexpected call to start_action.");
+  }
+
+  void end_action(action_type type) {
+    // this shouldn't be called here, as the things which call this don't have
+    // actions - they're added by this code.
+    throw std::runtime_error("Unexpected call to end_action.");
+  }
+
+  void write(output_formatter &fmt) {
+    std::sort(m_elements.begin(), m_elements.end());
+    for (const auto &e : m_elements) {
+      if (e.m_info.version == 1) {
+        fmt.start_action(action_type_create);
+        write_element(e, fmt);
+        fmt.end_action(action_type_create);
+      }
+    }
+  }
+
+private:
+  std::vector<element> m_elements;
+
+  void write_element(const element &e, output_formatter &fmt) {
+    switch (e.m_type) {
+    case element_type_node:
+      fmt.write_node(e.m_info, e.m_lonlat.m_lon, e.m_lonlat.m_lat, e.m_tags);
+      break;
+    }
+  }
+};
+
+} // anonymous namespace
+
+osmchange_responder::osmchange_responder(
+  mime::type mt, data_selection_ptr &s)
+  : osm_responder(mt, boost::none), sel(s) {
+}
+
+osmchange_responder::~osmchange_responder() {
+}
+
+void osmchange_responder::write(
+  shared_ptr<output_formatter> formatter,
+  const std::string &generator, const pt::ptime &now) {
+
+  // TODO: is it possible that formatter can be null?
+  output_formatter &fmt = *formatter;
+
+  fmt.start_document(generator, "osmChange");
+  try {
+    sorting_formatter sorter;
+
+    sel->write_nodes(sorter);
+    sel->write_ways(sorter);
+    sel->write_relations(sorter);
+
+    sorter.write(fmt);
+
+  } catch (const std::exception &e) {
+    fmt.error(e);
+  }
+
+  fmt.end_document();
+}

--- a/src/osmchange_responder.cpp
+++ b/src/osmchange_responder.cpp
@@ -52,34 +52,34 @@ struct sorting_formatter
   virtual ~sorting_formatter() {}
 
   mime::type mime_type() const {
-    throw std::runtime_error("unimplemented");
+    throw std::runtime_error("sorting_formatter::mime_type unimplemented");
   }
 
   void start_document(
     const std::string &generator,
     const std::string &root_name) {
 
-    throw std::runtime_error("unimplemented");
+    throw std::runtime_error("sorting_formatter::start_document unimplemented");
   }
 
   void end_document() {
-    throw std::runtime_error("unimplemented");
+    throw std::runtime_error("sorting_formatter::end_document unimplemented");
   }
 
   void error(const std::exception &e) {
-    throw std::runtime_error("unimplemented");
+    throw std::runtime_error("sorting_formatter::error unimplemented");
   }
 
   void write_bounds(const bbox &bounds) {
-    throw std::runtime_error("unimplemented");
+    throw std::runtime_error("sorting_formatter::write_bounds unimplemented");
   }
 
   void start_element_type(element_type type) {
-    throw std::runtime_error("unimplemented");
+    throw std::runtime_error("sorting_formatter::start_element_type unimplemented");
   }
 
   void end_element_type(element_type type) {
-    throw std::runtime_error("unimplemented");
+    throw std::runtime_error("sorting_formatter::end_element_type unimplemented");
   }
 
   void write_node(
@@ -99,7 +99,11 @@ struct sorting_formatter
     const nodes_t &nodes,
     const tags_t &tags) {
 
-    throw std::runtime_error("unimplemented");
+    element way{
+      element_type_way, elem, tags, element::lonlat{},
+        nodes, members_t()};
+
+    m_elements.emplace_back(std::move(way));
   }
 
   void write_relation(
@@ -107,7 +111,7 @@ struct sorting_formatter
     const members_t &members,
     const tags_t &tags) {
 
-    throw std::runtime_error("unimplemented");
+    throw std::runtime_error("sorting_formatter::write_relation unimplemented");
   }
 
   void write_changeset(
@@ -117,16 +121,16 @@ struct sorting_formatter
     const comments_t &comments,
     const boost::posix_time::ptime &now) {
 
-    throw std::runtime_error("unimplemented");
+    throw std::runtime_error("sorting_formatter::write_changeset unimplemented");
   }
 
   void flush() {
-    throw std::runtime_error("unimplemented");
+    throw std::runtime_error("sorting_formatter::flush unimplemented");
   }
 
   // write an error to the output stream
   void error(const std::string &) {
-    throw std::runtime_error("unimplemented");
+    throw std::runtime_error("sorting_formatter::error unimplemented");
   }
 
   void start_action(action_type type) {
@@ -148,6 +152,16 @@ struct sorting_formatter
         fmt.start_action(action_type_create);
         write_element(e, fmt);
         fmt.end_action(action_type_create);
+
+      } else if (e.m_info.visible) {
+        fmt.start_action(action_type_modify);
+        write_element(e, fmt);
+        fmt.end_action(action_type_modify);
+
+      } else {
+        fmt.start_action(action_type_delete);
+        write_element(e, fmt);
+        fmt.end_action(action_type_delete);
       }
     }
   }
@@ -159,6 +173,12 @@ private:
     switch (e.m_type) {
     case element_type_node:
       fmt.write_node(e.m_info, e.m_lonlat.m_lon, e.m_lonlat.m_lat, e.m_tags);
+      break;
+    case element_type_way:
+      fmt.write_way(e.m_info, e.m_nds, e.m_tags);
+      break;
+    case element_type_relation:
+      fmt.write_relation(e.m_info, e.m_members, e.m_tags);
       break;
     }
   }

--- a/src/osmchange_responder.cpp
+++ b/src/osmchange_responder.cpp
@@ -111,7 +111,11 @@ struct sorting_formatter
     const members_t &members,
     const tags_t &tags) {
 
-    throw std::runtime_error("sorting_formatter::write_relation unimplemented");
+    element rel{
+      element_type_relation, elem, tags, element::lonlat{},
+        nodes_t(), members};
+
+    m_elements.emplace_back(std::move(rel));
   }
 
   void write_changeset(

--- a/src/osmchange_responder.cpp
+++ b/src/osmchange_responder.cpp
@@ -35,6 +35,12 @@ bool operator<(const element &a, const element &b) {
   } else if (cmp > 0) {
     return false;
 
+  } else if (a.m_info.version < b.m_info.version) {
+    return true;
+
+  } else if (a.m_info.version > b.m_info.version) {
+    return false;
+
   } else if (a.m_type < b.m_type) {
     return true;
 

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -23,6 +23,7 @@
 #include "cgimap/api06/relation_history_handler.hpp"
 
 #include "cgimap/api06/changeset_handler.hpp"
+#include "cgimap/api06/changeset_download_handler.hpp"
 
 #ifdef ENABLE_EXPERIMENTAL
 #include "cgimap/api06/node_ways_handler.hpp"
@@ -171,6 +172,7 @@ routes::routes()
     r->add<relation_handler>(root_ / "relation" / osm_id_);
     r->add<relations_handler>(root_ / "relations");
 
+    r->add<changeset_download_handler>(root_ / "changeset" / osm_id_ / "download");
     r->add<changeset_handler>(root_ / "changeset" / osm_id_);
   }
 

--- a/src/xml_formatter.cpp
+++ b/src/xml_formatter.cpp
@@ -76,6 +76,12 @@ void xml_formatter::start_action(action_type type) {
   case action_type_create:
     writer->start("create");
     break;
+  case action_type_modify:
+    writer->start("modify");
+    break;
+  case action_type_delete:
+    writer->start("delete");
+    break;
   }
 }
 

--- a/src/xml_formatter.cpp
+++ b/src/xml_formatter.cpp
@@ -36,8 +36,9 @@ xml_formatter::~xml_formatter() {}
 
 mime::type xml_formatter::mime_type() const { return mime::text_xml; }
 
-void xml_formatter::start_document(const std::string &generator) {
-  writer->start("osm");
+void xml_formatter::start_document(
+  const std::string &generator, const std::string &root_name) {
+  writer->start(root_name);
   writer->attribute("version", string("0.6"));
   writer->attribute("generator", generator);
 
@@ -68,6 +69,22 @@ void xml_formatter::start_element_type(element_type) {
 
 void xml_formatter::end_element_type(element_type) {
   // ditto - nothing needed here for XML.
+}
+
+void xml_formatter::start_action(action_type type) {
+  switch (type) {
+  case action_type_create:
+    writer->start("create");
+    break;
+  }
+}
+
+void xml_formatter::end_action(action_type type) {
+  switch (type) {
+  case action_type_create:
+    writer->end();
+    break;
+  }
 }
 
 void xml_formatter::error(const std::exception &e) {

--- a/src/xml_formatter.cpp
+++ b/src/xml_formatter.cpp
@@ -88,6 +88,8 @@ void xml_formatter::start_action(action_type type) {
 void xml_formatter::end_action(action_type type) {
   switch (type) {
   case action_type_create:
+  case action_type_modify:
+  case action_type_delete:
     writer->end();
     break;
   }

--- a/test/changesets.testcore/data.osm
+++ b/test/changesets.testcore/data.osm
@@ -15,6 +15,7 @@
   <changeset id="7" user="FakeUser2" uid="2" created_at="2017-03-13T15:44:00Z" closed_at="2017-03-13T15:44:00Z" comments_count="0" num_changes="0"/>
   <changeset id="8" user="FakeUser2" uid="2" created_at="2017-03-13T15:45:00Z" closed_at="2017-03-13T15:45:00Z" comments_count="0" num_changes="0"/>
   <changeset id="9" user="FakeUser2" uid="2" created_at="2017-03-13T16:12:00Z" closed_at="2017-03-13T16:12:00Z" comments_count="0" num_changes="0"/>
+  <changeset id="10" user="FakeUser2" uid="2" created_at="2017-03-13T16:27:00Z" closed_at="2017-03-13T16:27:00Z" comments_count="0" num_changes="0"/>
   <node id="1" version="1" changeset="1" lat="0.0" lon="0.0" user="FakeUser1" uid="1" visible="true" timestamp="2015-08-09T10:33:13Z"/>
   <node id="2" version="1" changeset="3" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T09:52:00Z"/>
   <node id="3" version="1" changeset="4" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:34:00Z"/>
@@ -35,4 +36,7 @@
     <nd ref="3"/>
   </way>
   <way id="1" version="4" changeset="9" user="FakeUser2" uid="2" visible="false" timestamp="2017-03-13T16:12:00Z"/>
+  <relation id="1" version="1" changeset="10" user="FakeUser2" uid="2" visible="false" timestamp="2017-03-13T16:27:00Z">
+    <member type="node" role="" ref="1"/>
+  </relation>
 </osm>

--- a/test/changesets.testcore/data.osm
+++ b/test/changesets.testcore/data.osm
@@ -9,6 +9,10 @@
   </changeset>
   <changeset id="2" created_at="2015-09-05T20:16:06Z" closed_at="2015-09-05T20:16:06Z" comments_count="0" num_changes="0"/>
   <changeset id="3" user="FakeUser2" uid="2" created_at="2017-03-13T09:52:00Z" closed_at="2017-03-13T09:52:00Z" comments_count="0" num_changes="0"/>
+  <changeset id="4" user="FakeUser2" uid="2" created_at="2017-03-13T15:34:00Z" closed_at="2017-03-13T15:34:00Z" comments_count="0" num_changes="0"/>
+  <changeset id="5" user="FakeUser2" uid="2" created_at="2017-03-13T15:35:00Z" closed_at="2017-03-13T15:35:00Z" comments_count="0" num_changes="0"/>
   <node id="1" version="1" changeset="1" lat="0.0" lon="0.0" user="FakeUser1" uid="1" visible="true" timestamp="2015-08-09T10:33:13Z"/>
-  <node id="2" version="1" changeset="2" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T09:52:00Z"/>
+  <node id="2" version="1" changeset="3" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T09:52:00Z"/>
+  <node id="3" version="1" changeset="4" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:34:00Z"/>
+  <node id="3" version="2" changeset="5" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:35:00Z"/>
 </osm>

--- a/test/changesets.testcore/data.osm
+++ b/test/changesets.testcore/data.osm
@@ -16,10 +16,15 @@
   <changeset id="8" user="FakeUser2" uid="2" created_at="2017-03-13T15:45:00Z" closed_at="2017-03-13T15:45:00Z" comments_count="0" num_changes="0"/>
   <changeset id="9" user="FakeUser2" uid="2" created_at="2017-03-13T16:12:00Z" closed_at="2017-03-13T16:12:00Z" comments_count="0" num_changes="0"/>
   <changeset id="10" user="FakeUser2" uid="2" created_at="2017-03-13T16:27:00Z" closed_at="2017-03-13T16:27:00Z" comments_count="0" num_changes="0"/>
+  <changeset id="11" user="FakeUser2" uid="2" created_at="2017-03-13T16:32:00Z" closed_at="2017-03-13T16:32:02Z" comments_count="0" num_changes="0"/>
+
   <node id="1" version="1" changeset="1" lat="0.0" lon="0.0" user="FakeUser1" uid="1" visible="true" timestamp="2015-08-09T10:33:13Z"/>
   <node id="2" version="1" changeset="3" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T09:52:00Z"/>
   <node id="3" version="1" changeset="4" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:34:00Z"/>
   <node id="3" version="2" changeset="5" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:35:00Z"/>
+  <node id="3" version="3" changeset="11" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T16:32:01Z"/>
+  <node id="4" version="1" changeset="11" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T16:32:00Z"/>
+
   <way id="1" version="1" changeset="6" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:43:00Z">
     <nd ref="1"/>
     <nd ref="2"/>
@@ -36,7 +41,14 @@
     <nd ref="3"/>
   </way>
   <way id="1" version="4" changeset="9" user="FakeUser2" uid="2" visible="false" timestamp="2017-03-13T16:12:00Z"/>
-  <relation id="1" version="1" changeset="10" user="FakeUser2" uid="2" visible="false" timestamp="2017-03-13T16:27:00Z">
+  <way id="1" version="5" changeset="11" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T16:32:01Z">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+  </way>
+
+  <relation id="1" version="1" changeset="10" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T16:27:00Z">
     <member type="node" role="" ref="1"/>
   </relation>
+  <relation id="1" version="2" changeset="11" user="FakeUser2" uid="2" visible="false" timestamp="2017-03-13T16:32:01Z"/>
 </osm>

--- a/test/changesets.testcore/data.osm
+++ b/test/changesets.testcore/data.osm
@@ -11,8 +11,26 @@
   <changeset id="3" user="FakeUser2" uid="2" created_at="2017-03-13T09:52:00Z" closed_at="2017-03-13T09:52:00Z" comments_count="0" num_changes="0"/>
   <changeset id="4" user="FakeUser2" uid="2" created_at="2017-03-13T15:34:00Z" closed_at="2017-03-13T15:34:00Z" comments_count="0" num_changes="0"/>
   <changeset id="5" user="FakeUser2" uid="2" created_at="2017-03-13T15:35:00Z" closed_at="2017-03-13T15:35:00Z" comments_count="0" num_changes="0"/>
+  <changeset id="6" user="FakeUser2" uid="2" created_at="2017-03-13T15:43:00Z" closed_at="2017-03-13T15:43:00Z" comments_count="0" num_changes="0"/>
+  <changeset id="7" user="FakeUser2" uid="2" created_at="2017-03-13T15:44:00Z" closed_at="2017-03-13T15:44:00Z" comments_count="0" num_changes="0"/>
+  <changeset id="8" user="FakeUser2" uid="2" created_at="2017-03-13T15:45:00Z" closed_at="2017-03-13T15:45:00Z" comments_count="0" num_changes="0"/>
   <node id="1" version="1" changeset="1" lat="0.0" lon="0.0" user="FakeUser1" uid="1" visible="true" timestamp="2015-08-09T10:33:13Z"/>
   <node id="2" version="1" changeset="3" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T09:52:00Z"/>
   <node id="3" version="1" changeset="4" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:34:00Z"/>
   <node id="3" version="2" changeset="5" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:35:00Z"/>
+  <way id="1" version="1" changeset="6" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:43:00Z">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+  </way>
+  <way id="1" version="2" changeset="7" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:44:00Z">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+  </way>
+  <way id="1" version="3" changeset="8" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:45:00Z">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+  </way>
 </osm>

--- a/test/changesets.testcore/data.osm
+++ b/test/changesets.testcore/data.osm
@@ -1,12 +1,14 @@
 <osm version="0.6" generator="by hand">
   <changeset id="1" user="FakeUser1" uid="1" created_at="2015-08-09T10:33:13Z" closed_at="2015-08-09T11:33:13Z" min_lat="51.5288506" min_lon="-0.1465242" max_lat="51.528862" max_lon="-0.1464925" comments_count="1" num_changes="1">
-	 <tag k="created_by" v="manually"/>
-	 <discussion>
-		<comment date="2015-08-09T10:33:13Z" uid="1" user="FakeUser1">
-		  <text>First post!!!!</text>
-		</comment>
-	 </discussion>
+    <tag k="created_by" v="manually"/>
+    <discussion>
+      <comment date="2015-08-09T10:33:13Z" uid="1" user="FakeUser1">
+        <text>First post!!!!</text>
+      </comment>
+    </discussion>
   </changeset>
   <changeset id="2" created_at="2015-09-05T20:16:06Z" closed_at="2015-09-05T20:16:06Z" comments_count="0" num_changes="0"/>
+  <changeset id="3" user="FakeUser2" uid="2" created_at="2017-03-13T09:52:00Z" closed_at="2017-03-13T09:52:00Z" comments_count="0" num_changes="0"/>
   <node id="1" version="1" changeset="1" lat="0.0" lon="0.0" user="FakeUser1" uid="1" visible="true" timestamp="2015-08-09T10:33:13Z"/>
+  <node id="2" version="1" changeset="2" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T09:52:00Z"/>
 </osm>

--- a/test/changesets.testcore/data.osm
+++ b/test/changesets.testcore/data.osm
@@ -14,6 +14,7 @@
   <changeset id="6" user="FakeUser2" uid="2" created_at="2017-03-13T15:43:00Z" closed_at="2017-03-13T15:43:00Z" comments_count="0" num_changes="0"/>
   <changeset id="7" user="FakeUser2" uid="2" created_at="2017-03-13T15:44:00Z" closed_at="2017-03-13T15:44:00Z" comments_count="0" num_changes="0"/>
   <changeset id="8" user="FakeUser2" uid="2" created_at="2017-03-13T15:45:00Z" closed_at="2017-03-13T15:45:00Z" comments_count="0" num_changes="0"/>
+  <changeset id="9" user="FakeUser2" uid="2" created_at="2017-03-13T16:12:00Z" closed_at="2017-03-13T16:12:00Z" comments_count="0" num_changes="0"/>
   <node id="1" version="1" changeset="1" lat="0.0" lon="0.0" user="FakeUser1" uid="1" visible="true" timestamp="2015-08-09T10:33:13Z"/>
   <node id="2" version="1" changeset="3" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T09:52:00Z"/>
   <node id="3" version="1" changeset="4" lat="0.0" lon="0.0" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:34:00Z"/>
@@ -33,4 +34,5 @@
     <nd ref="2"/>
     <nd ref="3"/>
   </way>
+  <way id="1" version="4" changeset="9" user="FakeUser2" uid="2" visible="false" timestamp="2017-03-13T16:12:00Z"/>
 </osm>

--- a/test/changesets.testcore/download.case
+++ b/test/changesets.testcore/download.case
@@ -1,0 +1,13 @@
+Request-Method: GET
+Request-URI: /api/0.6/changeset/1/download
+Date: 2017-02-20T15:22:00Z
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition: 
+---
+<osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <create>
+    <node id="1" version="1" changeset="1" lat="0.0000000" lon="0.0000000" user="FakeUser1" uid="1" visible="true" timestamp="2015-08-09T10:33:13Z"/>
+  </create>
+</osmChange>

--- a/test/changesets.testcore/download_changeset_2.case
+++ b/test/changesets.testcore/download_changeset_2.case
@@ -1,0 +1,13 @@
+Request-Method: GET
+Request-URI: /api/0.6/changeset/2/download
+Date: 2017-03-13T09:54:00Z
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition: 
+---
+<osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <create>
+    <node id="2" version="1" changeset="2" lat="0.0000000" lon="0.0000000" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T09:52:00Z"/>
+  </create>
+</osmChange>

--- a/test/changesets.testcore/download_changeset_2.case
+++ b/test/changesets.testcore/download_changeset_2.case
@@ -1,5 +1,5 @@
 Request-Method: GET
-Request-URI: /api/0.6/changeset/2/download
+Request-URI: /api/0.6/changeset/3/download
 Date: 2017-03-13T09:54:00Z
 ---
 Status: 200 OK
@@ -8,6 +8,6 @@ Content-Type: text/xml; charset=utf-8
 ---
 <osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">
   <create>
-    <node id="2" version="1" changeset="2" lat="0.0000000" lon="0.0000000" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T09:52:00Z"/>
+    <node id="2" version="1" changeset="3" lat="0.0000000" lon="0.0000000" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T09:52:00Z"/>
   </create>
 </osmChange>

--- a/test/changesets.testcore/download_changeset_4.case
+++ b/test/changesets.testcore/download_changeset_4.case
@@ -1,0 +1,15 @@
+# changeset 4 refers to an old version of a node. check that this comes out
+# okay.
+Request-Method: GET
+Request-URI: /api/0.6/changeset/4/download
+Date: 2017-03-13T09:54:00Z
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition: 
+---
+<osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <create>
+    <node id="3" version="1" changeset="4" lat="0.0000000" lon="0.0000000" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:34:00Z"/>
+  </create>
+</osmChange>

--- a/test/changesets.testcore/download_changeset_rel10.case
+++ b/test/changesets.testcore/download_changeset_rel10.case
@@ -8,7 +8,7 @@ Content-Type: text/xml; charset=utf-8
 ---
 <osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">
   <create>
-    <relation id="1" version="1" changeset="10" user="FakeUser2" uid="2" visible="false" timestamp="2017-03-13T16:27:00Z">
+    <relation id="1" version="1" changeset="10" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T16:27:00Z">
       <member type="node" role="" ref="1"/>
     </relation>
   </create>

--- a/test/changesets.testcore/download_changeset_rel10.case
+++ b/test/changesets.testcore/download_changeset_rel10.case
@@ -1,0 +1,15 @@
+Request-Method: GET
+Request-URI: /api/0.6/changeset/10/download
+Date: 2017-03-13T16:27:00Z
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition: 
+---
+<osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <create>
+    <relation id="1" version="1" changeset="10" user="FakeUser2" uid="2" visible="false" timestamp="2017-03-13T16:27:00Z">
+      <member type="node" role="" ref="1"/>
+    </relation>
+  </create>
+</osmChange>

--- a/test/changesets.testcore/download_changeset_sort11.case
+++ b/test/changesets.testcore/download_changeset_sort11.case
@@ -1,0 +1,28 @@
+# this is to check that the elements are sorted by timestamp first, then
+# version.
+Request-Method: GET
+Request-URI: /api/0.6/changeset/11/download
+Date: 2017-03-13T16:32:00Z
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition: 
+---
+<osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <create>
+    <node id="4" version="1" changeset="11" lat="0.0000000" lon="0.0000000" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T16:32:00Z"/>
+  </create>
+  <delete>
+    <relation id="1" version="2" changeset="11" user="FakeUser2" uid="2" visible="false" timestamp="2017-03-13T16:32:01Z"/>
+  </delete>
+  <modify>
+    <node id="3" version="3" changeset="11" lat="0.0000000" lon="0.0000000" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T16:32:01Z"/>
+  </modify>
+  <modify>
+    <way id="1" version="5" changeset="11" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T16:32:01Z">
+      <nd ref="1"/>
+      <nd ref="2"/>
+      <nd ref="3"/>
+    </way>
+  </modify>
+</osmChange>

--- a/test/changesets.testcore/download_changeset_way6.case
+++ b/test/changesets.testcore/download_changeset_way6.case
@@ -1,0 +1,17 @@
+Request-Method: GET
+Request-URI: /api/0.6/changeset/6/download
+Date: 2017-03-13T15:43:00Z
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition: 
+---
+<osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <create>
+    <way id="1" version="1" changeset="6" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:43:00Z">
+      <nd ref="1"/>
+      <nd ref="2"/>
+      <nd ref="3"/>
+    </way>
+  </create>
+</osmChange>

--- a/test/changesets.testcore/download_changeset_way7.case
+++ b/test/changesets.testcore/download_changeset_way7.case
@@ -1,0 +1,17 @@
+Request-Method: GET
+Request-URI: /api/0.6/changeset/7/download
+Date: 2017-03-13T15:44:00Z
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition: 
+---
+<osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <modify>
+    <way id="1" version="2" changeset="7" user="FakeUser2" uid="2" visible="true" timestamp="2017-03-13T15:44:00Z">
+      <nd ref="1"/>
+      <nd ref="2"/>
+      <nd ref="3"/>
+    </way>
+  </modify>
+</osmChange>

--- a/test/changesets.testcore/download_changeset_way9.case
+++ b/test/changesets.testcore/download_changeset_way9.case
@@ -1,0 +1,13 @@
+Request-Method: GET
+Request-URI: /api/0.6/changeset/9/download
+Date: 2017-03-13T16:12:00Z
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition: 
+---
+<osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <delete>
+    <way id="1" version="4" changeset="9" user="FakeUser2" uid="2" visible="false" timestamp="2017-03-13T16:12:00Z"/>
+  </delete>
+</osmChange>

--- a/test/changesets.testcore/empty.case
+++ b/test/changesets.testcore/empty.case
@@ -1,0 +1,10 @@
+# empty changeset - the changeset exists, so returns an empty response.
+Request-Method: GET
+Request-URI: /api/0.6/changeset/2/download
+Date: 2017-03-13T16:58:00Z
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition: 
+---
+<osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***"/>

--- a/test/changesets.testcore/not_found.case
+++ b/test/changesets.testcore/not_found.case
@@ -1,0 +1,7 @@
+# empty changeset - the changeset does not exist, so returns a 404.
+Request-Method: GET
+Request-URI: /api/0.6/changeset/12/download
+Date: 2017-03-13T16:58:00Z
+---
+Status: 404 Not Found
+---

--- a/test/redactions.testcore/changeset_download.case
+++ b/test/redactions.testcore/changeset_download.case
@@ -1,0 +1,11 @@
+# all the elements in this changeset are redacted, so the regular user should
+# not be able to see them.
+Request-Method: GET
+Request-URI: /api/0.6/changeset/2/download
+Date: 2017-03-13T16:47:00Z
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition: 
+---
+<osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***"/>

--- a/test/redactions.testcore/changeset_download_moderator.case
+++ b/test/redactions.testcore/changeset_download_moderator.case
@@ -1,0 +1,30 @@
+# all the elements in this changeset are redacted, but a moderator should be
+# able to see them if they ask nicely.
+Request-Method: GET
+Request-URI: /api/0.6/changeset/2/download?show_redactions=true
+Http-Host: cgimap.example.com
+Date: 2017-03-13T16:47:00Z
+Http-Authorization: OAuth realm="http://cgimap.example.com/api/0.6/changeset/2/download", oauth_consumer_key="heqfjrcolc", oauth_token="scgncknxqr", oauth_nonce="dqndteqmzduesxyjetrd", oauth_timestamp="1489423620", oauth_signature_method="HMAC-SHA1", oauth_version="1.0", oauth_signature="2KQpmh%2FAJi9xTpZvCIo82inmdho%3D"
+---
+Status: 200 OK
+Content-Type: text/xml; charset=utf-8
+!Content-Disposition: 
+---
+<osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">
+  <modify>
+    <node id="1" version="2" changeset="2" lat="0.0000000" lon="0.0000000"
+          user="foo" uid="1" visible="true" timestamp="2017-01-15T16:53:00Z"/>
+  </modify>
+  <modify>
+    <way id="1" version="2" changeset="2" user="foo" uid="1" visible="true"
+         timestamp="2017-01-21T18:03:00Z">
+      <nd ref="1"/>
+    </way>
+  </modify>
+  <modify>
+    <relation id="1" version="2" changeset="2" user="foo" uid="1" visible="true"
+              timestamp="2017-01-21T18:07:00Z">
+      <member type="node" ref="1" role=""/>
+    </relation>
+  </modify>
+</osmChange>

--- a/test/redactions.testcore/data.osm
+++ b/test/redactions.testcore/data.osm
@@ -7,7 +7,7 @@
 
   <!-- second version is redacted, so should only appear in output for
        moderators where they've asked for it. -->
-  <node id="1" version="2" changeset="1" lat="0.0" lon="0.0" user="foo"
+  <node id="1" version="2" changeset="2" lat="0.0" lon="0.0" user="foo"
         uid="1" visible="true" timestamp="2017-01-15T16:53:00Z"
         redaction="1"/>
 
@@ -21,7 +21,7 @@
        timestamp="2017-01-21T18:02:00Z">
     <nd ref="1"/>
   </way>
-  <way id="1" version="2" changeset="1" user="foo" uid="1" visible="true"
+  <way id="1" version="2" changeset="2" user="foo" uid="1" visible="true"
        timestamp="2017-01-21T18:03:00Z" redaction="1">
     <nd ref="1"/>
   </way>
@@ -36,7 +36,7 @@
        timestamp="2017-01-21T18:06:00Z">
     <member type="node" ref="1" role=""/>
   </relation>
-  <relation id="1" version="2" changeset="1" user="foo" uid="1" visible="true"
+  <relation id="1" version="2" changeset="2" user="foo" uid="1" visible="true"
        timestamp="2017-01-21T18:07:00Z" redaction="1">
     <member type="node" ref="1" role=""/>
   </relation>

--- a/test/redactions.testcore/data.osm
+++ b/test/redactions.testcore/data.osm
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <osm version="0.6" generator="by hand">
+  <changeset id="1" user="foo" uid="1" created_at="2017-01-15T16:52:00Z" closed_at="2017-01-21T18:08:00Z" comments_count="0" num_changes="0"/>
+  <changeset id="2" user="foo" uid="1" created_at="2017-01-15T16:52:00Z" closed_at="2017-01-21T18:08:00Z" comments_count="0" num_changes="0"/>
+
   <!-- first version is deleted, but not redacted, therefore should still
        appear in output -->
   <node id="1" version="1" changeset="1" lat="0.0" lon="0.0" user="foo"

--- a/test/redactions.testcore/node_history_moderator.case
+++ b/test/redactions.testcore/node_history_moderator.case
@@ -11,6 +11,6 @@ Content-Type: text/xml; charset=utf-8
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
   <node id="1" version="1" changeset="1" user="foo" uid="1" visible="false" timestamp="2017-01-15T16:52:00Z"/>
-  <node id="1" version="2" changeset="1" lat="0.0000000" lon="0.0000000" user="foo" uid="1" visible="true" timestamp="2017-01-15T16:53:00Z"/>
+  <node id="1" version="2" changeset="2" lat="0.0000000" lon="0.0000000" user="foo" uid="1" visible="true" timestamp="2017-01-15T16:53:00Z"/>
   <node id="1" version="3" changeset="1" lat="0.0000000" lon="0.0000000" user="foo" uid="1" visible="true" timestamp="2017-01-15T16:54:00Z"/>
 </osm>

--- a/test/redactions.testcore/node_version_moderator.case
+++ b/test/redactions.testcore/node_version_moderator.case
@@ -11,6 +11,6 @@ Content-Type: text/xml; charset=utf-8
 ---
 <?xml version="1.0"?>
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
-  <node id="1" version="2" changeset="1" lat="0.0000000" lon="0.0000000" user="foo"
+  <node id="1" version="2" changeset="2" lat="0.0000000" lon="0.0000000" user="foo"
         uid="1" visible="true" timestamp="2017-01-15T16:53:00Z"/>
 </osm>

--- a/test/redactions.testcore/nodes_moderator.case
+++ b/test/redactions.testcore/nodes_moderator.case
@@ -11,5 +11,5 @@ Content-Type: text/xml; charset=utf-8
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
   <node id="1" version="1" changeset="1" user="foo" uid="1" visible="false" timestamp="2017-01-15T16:52:00Z"/>
-  <node id="1" version="2" changeset="1" lat="0.0000000" lon="0.0000000" user="foo" uid="1" visible="true" timestamp="2017-01-15T16:53:00Z"/>
+  <node id="1" version="2" changeset="2" lat="0.0000000" lon="0.0000000" user="foo" uid="1" visible="true" timestamp="2017-01-15T16:53:00Z"/>
 </osm>

--- a/test/redactions.testcore/relation_history_moderator.case
+++ b/test/redactions.testcore/relation_history_moderator.case
@@ -14,7 +14,7 @@ Content-Type: text/xml; charset=utf-8
        timestamp="2017-01-21T18:06:00Z">
     <member type="node" ref="1" role=""/>
   </relation>
-  <relation id="1" version="2" changeset="1" user="foo" uid="1" visible="true"
+  <relation id="1" version="2" changeset="2" user="foo" uid="1" visible="true"
        timestamp="2017-01-21T18:07:00Z">
     <member type="node" ref="1" role=""/>
   </relation>

--- a/test/redactions.testcore/relation_version_moderator.case
+++ b/test/redactions.testcore/relation_version_moderator.case
@@ -12,7 +12,7 @@ Content-Type: text/xml; charset=utf-8
 ---
 <?xml version="1.0"?>
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
-  <relation id="1" version="2" changeset="1" user="foo" uid="1" visible="true"
+  <relation id="1" version="2" changeset="2" user="foo" uid="1" visible="true"
        timestamp="2017-01-21T18:07:00Z">
     <member type="node" ref="1" role=""/>
   </relation>

--- a/test/redactions.testcore/relations_moderator.case
+++ b/test/redactions.testcore/relations_moderator.case
@@ -14,7 +14,7 @@ Content-Type: text/xml; charset=utf-8
        timestamp="2017-01-21T18:06:00Z">
     <member type="node" ref="1" role=""/>
   </relation>
-  <relation id="1" version="2" changeset="1" user="foo" uid="1" visible="true"
+  <relation id="1" version="2" changeset="2" user="foo" uid="1" visible="true"
        timestamp="2017-01-21T18:07:00Z">
     <member type="node" ref="1" role=""/>
   </relation>

--- a/test/redactions.testcore/way_history_moderator.case
+++ b/test/redactions.testcore/way_history_moderator.case
@@ -14,7 +14,7 @@ Content-Type: text/xml; charset=utf-8
        timestamp="2017-01-21T18:02:00Z">
     <nd ref="1"/>
   </way>
-  <way id="1" version="2" changeset="1" user="foo" uid="1" visible="true"
+  <way id="1" version="2" changeset="2" user="foo" uid="1" visible="true"
        timestamp="2017-01-21T18:03:00Z">
     <nd ref="1"/>
   </way>

--- a/test/redactions.testcore/way_version_moderator.case
+++ b/test/redactions.testcore/way_version_moderator.case
@@ -12,7 +12,7 @@ Content-Type: text/xml; charset=utf-8
 ---
 <?xml version="1.0"?>
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
-  <way id="1" version="2" changeset="1" user="foo" uid="1" visible="true"
+  <way id="1" version="2" changeset="2" user="foo" uid="1" visible="true"
        timestamp="2017-01-21T18:03:00Z">
     <nd ref="1"/>
   </way>

--- a/test/redactions.testcore/ways_moderator.case
+++ b/test/redactions.testcore/ways_moderator.case
@@ -14,7 +14,7 @@ Content-Type: text/xml; charset=utf-8
        timestamp="2017-01-21T18:02:00Z">
     <nd ref="1"/>
   </way>
-  <way id="1" version="2" changeset="1" user="foo" uid="1" visible="true"
+  <way id="1" version="2" changeset="2" user="foo" uid="1" visible="true"
        timestamp="2017-01-21T18:03:00Z">
     <nd ref="1"/>
   </way>

--- a/test/test_apidb_backend_changeset_downloads.cpp
+++ b/test/test_apidb_backend_changeset_downloads.cpp
@@ -1,0 +1,105 @@
+#include <iostream>
+#include <stdexcept>
+#include <boost/noncopyable.hpp>
+#include <boost/format.hpp>
+#include <boost/foreach.hpp>
+#include <boost/optional/optional_io.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/program_options.hpp>
+
+#include <sys/time.h>
+#include <stdio.h>
+
+#include "cgimap/config.hpp"
+#include "cgimap/time.hpp"
+#include "cgimap/oauth.hpp"
+#include "cgimap/rate_limiter.hpp"
+#include "cgimap/routes.hpp"
+#include "cgimap/process_request.hpp"
+
+#include "test_formatter.hpp"
+#include "test_database.hpp"
+#include "test_request.hpp"
+
+namespace {
+
+template <typename T>
+void assert_equal(const T& a, const T&b, const std::string &message) {
+  if (a != b) {
+    throw std::runtime_error(
+      (boost::format(
+        "Expecting %1% to be equal, but %2% != %3%")
+       % message % a % b).str());
+  }
+}
+
+void test_changeset_select_node(test_database &tdb) {
+  tdb.run_sql(
+    "INSERT INTO users (id, email, pass_crypt, creation_time, display_name, data_public) "
+    "VALUES "
+    "  (1, 'user_1@example.com', '', '2017-03-19T19:13:00Z', 'user_1', true); "
+
+    "INSERT INTO changesets (id, user_id, created_at, closed_at, num_changes) "
+    "VALUES "
+    "  (1, 1, '2017-03-19T19:13:00Z', '2017-03-19T19:13:00Z', 1);"
+
+    "INSERT INTO current_nodes (id, latitude, longitude, changeset_id, visible, \"timestamp\", tile, version) "
+    " VALUES "
+    "  (1, 90000000, 90000000, 1, true,  '2017-03-19T19:13:00Z', 3229120632, 1); "
+
+    "INSERT INTO nodes (node_id, latitude, longitude, changeset_id, visible, "
+    "                   \"timestamp\", tile, version, redaction_id) "
+    "VALUES "
+    "  (1, 90000000, 90000000, 1, true,  '2017-03-19T19:13:00Z', 3229120632, 1, NULL);"
+    );
+  boost::shared_ptr<data_selection> sel = tdb.get_data_selection();
+
+  assert_equal<bool>(sel->supports_changesets(), true,
+    "apidb should support changesets.");
+  assert_equal<bool>(sel->supports_historical_versions(), true,
+    "apidb should support historical versions.");
+
+  std::vector<osm_changeset_id_t> ids;
+  ids.push_back(1);
+  int num = sel->select_historical_by_changesets(ids);
+  assert_equal<int>(num, 1, "should have selected one element from changeset 1");
+
+  test_formatter f;
+  sel->write_nodes(f);
+  assert_equal<size_t>(f.m_nodes.size(), 1,
+    "should have written one node from changeset 1");
+
+  assert_equal<test_formatter::node_t>(
+    f.m_nodes.front(),
+    test_formatter::node_t(
+      element_info(1, 1, 1, "2017-03-19T19:13:00Z", 1, std::string("user_1"), true),
+      9.0, 9.0,
+      tags_t()),
+    "node 1 in changeset 1");
+}
+
+} // anonymous namespace
+
+int main(int, char **) {
+  try {
+    test_database tdb;
+    tdb.setup();
+
+    tdb.run(boost::function<void(test_database&)>(
+        &test_changeset_select_node));
+
+  } catch (const test_database::setup_error &e) {
+    std::cout << "Unable to set up test database: " << e.what() << std::endl;
+    return 77;
+
+  } catch (const std::exception &e) {
+    std::cout << "Error: " << e.what() << std::endl;
+    return 1;
+
+  } catch (...) {
+    std::cout << "Unknown exception type." << std::endl;
+    return 99;
+  }
+
+  return 0;
+}

--- a/test/test_apidb_backend_changeset_downloads.cpp
+++ b/test/test_apidb_backend_changeset_downloads.cpp
@@ -78,6 +78,70 @@ void test_changeset_select_node(test_database &tdb) {
     "node 1 in changeset 1");
 }
 
+void test_changeset_select_way(test_database &tdb) {
+  tdb.run_sql(
+    "INSERT INTO users (id, email, pass_crypt, creation_time, display_name, data_public) "
+    "VALUES "
+    "  (1, 'user_1@example.com', '', '2017-03-19T19:57:00Z', 'user_1', true); "
+
+    "INSERT INTO changesets (id, user_id, created_at, closed_at, num_changes) "
+    "VALUES "
+    "  (1, 1, '2017-03-19T19:13:00Z', '2017-03-19T19:57:00Z', 1),"
+    "  (2, 1, '2017-03-19T19:13:00Z', '2017-03-19T19:57:00Z', 2);"
+
+    "INSERT INTO current_nodes (id, latitude, longitude, changeset_id, visible, \"timestamp\", tile, version) "
+    " VALUES "
+    "  (1, 90000000, 90000000, 1, true,  '2017-03-19T19:57:00Z', 3229120632, 1); "
+
+    "INSERT INTO nodes (node_id, latitude, longitude, changeset_id, visible, "
+    "                   \"timestamp\", tile, version, redaction_id) "
+    "VALUES "
+    "  (1, 90000000, 90000000, 1, true,  '2017-03-19T19:57:00Z', 3229120632, 1, NULL);"
+
+    "INSERT INTO ways (way_id, changeset_id, \"timestamp\", visible, "
+    "                  version, redaction_id) "
+    "VALUES "
+    "  (1, 2, '2017-03-19T19:57:00Z', true, 2, NULL), "
+    "  (1, 2, '2017-03-19T19:57:00Z', true, 1, NULL); "
+
+    "INSERT INTO way_nodes (way_id, version, node_id, sequence_id) "
+    "VALUES "
+    "  (1, 2, 1, 1), "
+    "  (1, 1, 1, 1); "
+    );
+  boost::shared_ptr<data_selection> sel = tdb.get_data_selection();
+
+  assert_equal<bool>(sel->supports_changesets(), true,
+    "apidb should support changesets.");
+  assert_equal<bool>(sel->supports_historical_versions(), true,
+    "apidb should support historical versions.");
+
+  std::vector<osm_changeset_id_t> ids;
+  ids.push_back(2);
+  int num = sel->select_historical_by_changesets(ids);
+  assert_equal<int>(num, 2, "number of ways (2) selected from changeset 1");
+
+  test_formatter f;
+  sel->write_ways(f);
+  assert_equal<size_t>(f.m_ways.size(), 2,
+    "number of ways (2) written from changeset 1");
+
+  assert_equal<test_formatter::way_t>(
+    f.m_ways[0],
+    test_formatter::way_t(
+      element_info(1, 1, 2, "2017-03-19T19:57:00Z", 1, std::string("user_1"), true),
+      nodes_t{1},
+      tags_t()),
+    "way 1, version 1 in changeset 1");
+  assert_equal<test_formatter::way_t>(
+    f.m_ways[1],
+    test_formatter::way_t(
+      element_info(1, 2, 2, "2017-03-19T19:57:00Z", 1, std::string("user_1"), true),
+      nodes_t{1},
+      tags_t()),
+    "way 1, version 2 in changeset 1");
+}
+
 } // anonymous namespace
 
 int main(int, char **) {
@@ -87,6 +151,9 @@ int main(int, char **) {
 
     tdb.run(boost::function<void(test_database&)>(
         &test_changeset_select_node));
+
+    tdb.run(boost::function<void(test_database&)>(
+        &test_changeset_select_way));
 
   } catch (const test_database::setup_error &e) {
     std::cout << "Unable to set up test database: " << e.what() << std::endl;

--- a/test/test_formatter.cpp
+++ b/test/test_formatter.cpp
@@ -136,7 +136,8 @@ mime::type test_formatter::mime_type() const {
   throw std::runtime_error("Unimplemented");
 }
 
-void test_formatter::start_document(const std::string &generator) {
+void test_formatter::start_document(
+  const std::string &generator, const std::string &root_name) {
 }
 
 void test_formatter::end_document() {
@@ -149,6 +150,12 @@ void test_formatter::start_element_type(element_type type) {
 }
 
 void test_formatter::end_element_type(element_type type) {
+}
+
+void test_formatter::start_action(action_type type) {
+}
+
+void test_formatter::end_action(action_type type) {
 }
 
 void test_formatter::write_node(const element_info &elem, double lon, double lat,

--- a/test/test_formatter.hpp
+++ b/test/test_formatter.hpp
@@ -76,11 +76,13 @@ struct test_formatter : public output_formatter {
 
   virtual ~test_formatter();
   mime::type mime_type() const;
-  void start_document(const std::string &generator);
+  void start_document(const std::string &generator, const std::string &root_name);
   void end_document();
   void write_bounds(const bbox &bounds);
   void start_element_type(element_type type);
   void end_element_type(element_type type);
+  void start_action(action_type type);
+  void end_action(action_type type);
   void write_node(const element_info &elem, double lon, double lat,
                   const tags_t &tags);
   void write_way(const element_info &elem, const nodes_t &nodes,


### PR DESCRIPTION
Adds support for the `changeset/#{id}/download` API call.

The element sorting is implemented in the same way as [openstreetmap-website](https://github.com/openstreetmap/openstreetmap-website/blob/834a821d3cc6cbcbc5f267799ede419047740854/app/controllers/changeset_controller.rb#L164-L170), which isn't necessarily exactly the same as the order the elements were committed. But it seems to have sufficed up to this point, so perhaps it's okay :wink:

A small number of tests have been added, and I'd be really interested to know if you think that there are other important areas or corner-cases which should be tested too.

/cc @tomhughes, @jronak & @pnorman - please let me know if you have any advice on how to improve this code, or if you think something's wrong or needs extra testing. Thanks!