### PR TITLE
[Perf] Mass prefetch user details for faster /map call

### DIFF
--- a/include/cgimap/backend/apidb/changeset.hpp
+++ b/include/cgimap/backend/apidb/changeset.hpp
@@ -2,6 +2,8 @@
 #define CHANGESET_HPP
 
 #include "cgimap/types.hpp"
+#include <map>
+#include <set>
 #include <string>
 #include <pqxx/pqxx>
 
@@ -18,6 +20,9 @@ struct changeset {
   changeset(bool dp, const std::string &dn, osm_user_id_t id);
 };
 
-changeset *fetch_changeset(pqxx::transaction_base &w, osm_changeset_id_t id);
+changeset *fetch_changeset(pqxx::transaction_base &w,  osm_changeset_id_t id);
+
+std::map<osm_changeset_id_t, changeset *> fetch_changesets(pqxx::transaction_base &w,  std::set<osm_changeset_id_t> id);
+
 
 #endif /* CHANGESET_HPP */

--- a/src/backend/apidb/apidb.cpp
+++ b/src/backend/apidb/apidb.cpp
@@ -11,7 +11,7 @@ namespace po = boost::program_options;
 using boost::shared_ptr;
 using std::string;
 
-#define CACHE_SIZE 1000
+#define CACHE_SIZE 100000
 
 namespace {
 struct apidb_backend : public backend {

--- a/src/backend/apidb/changeset.cpp
+++ b/src/backend/apidb/changeset.cpp
@@ -1,6 +1,9 @@
+
+#include "backend/apidb/pqxx_string_traits.hpp"
 #include "cgimap/backend/apidb/changeset.hpp"
 #include "cgimap/logger.hpp"
 #include "cgimap/http.hpp"
+#include <map>
 #include <boost/format.hpp>
 
 using std::string;
@@ -40,3 +43,60 @@ changeset *fetch_changeset(pqxx::transaction_base &w, osm_changeset_id_t id) {
                          osm_user_id_t(user_id));
   }
 }
+
+std::map<osm_changeset_id_t, changeset *> fetch_changesets(pqxx::transaction_base &w, std::set< osm_changeset_id_t > ids) {
+
+  std::map<osm_changeset_id_t, changeset*> result;
+
+  if (ids.empty())
+    return result;
+
+  pqxx::result res =
+      w.prepared("extract_changeset_userdetails")(ids).exec();
+
+  for (const auto & r : res) {
+
+    osm_changeset_id_t cs = r[0].as<int64_t>();
+
+    // Multiple results for one changeset?
+    if (result.find(cs) != result.end()) {
+      logger::message(
+          format("ERROR: Request for user data associated with changeset "
+                 "%1% failed: returned multiple rows.") %
+          cs);
+      throw http::server_error(
+          (format("Possible database inconsistency with changeset %1%.") % cs)
+              .str());
+    }
+
+    int64_t user_id = r[3].as<int64_t>();
+    // apidb instances external to OSM don't have access to anonymous
+    // user information and so use an ID which isn't in use for any
+    // other user to indicate this - generally 0 or negative.
+    if (user_id <= 0) {
+      result.insert(std::pair<osm_changeset_id_t, changeset*>(cs, new changeset(false, "", 0)));
+    } else {
+      result.insert(std::pair<osm_changeset_id_t, changeset*>(cs,
+                          new changeset(r[1].as<bool>(), r[2].as<string>(), osm_user_id_t(user_id))));
+    }
+  }
+
+  // although the above query should always return one row, it might
+  // happen that we get a weird changeset ID from somewhere, or the
+  // FK constraints might have failed. in this situation all we can
+  // really do is whine loudly and bail.
+
+  // Missing changeset in query result?
+  for (const auto & id : ids) {
+    if (result.find(id) == result.end()) {
+      logger::message(
+          format("ERROR: Request for user data associated with changeset "
+                 "%1% failed: returned 0 rows.") % id);
+      throw http::server_error(
+          (format("Possible database inconsistency with changeset %1%.") % id).str());
+    }
+  }
+
+  return result;
+}
+

--- a/src/backend/apidb/common_pgsql_selection.cpp
+++ b/src/backend/apidb/common_pgsql_selection.cpp
@@ -200,7 +200,15 @@ void extract(
   typename T::extra_info extra;
   tags_t tags;
 
+  std::set<osm_changeset_id_t> changeset_ids;
+
+  for (const auto &row : rows)
+    changeset_ids.insert(row["changeset_id"].as<osm_changeset_id_t>());
+
+  cc.prefetch(changeset_ids);
+
   for (const auto &row : rows) {
+
     extract_elem(row, elem, cc);
     extra.extract(row);
     extract_tags(row, tags);

--- a/src/backend/apidb/readonly_pgsql_selection.cpp
+++ b/src/backend/apidb/readonly_pgsql_selection.cpp
@@ -518,6 +518,7 @@ readonly_pgsql_selection::factory::factory(const po::variables_map &opts)
 #endif
       m_cache_tx(m_cache_connection, "changeset_cache"),
       m_cache(boost::bind(fetch_changeset, boost::ref(m_cache_tx), _1),
+              boost::bind(fetch_changesets, boost::ref(m_cache_tx), _1),
               opts["cachesize"].as<size_t>()) {
 
   if (m_connection.server_version() < 90300) {
@@ -543,6 +544,11 @@ readonly_pgsql_selection::factory::factory(const po::variables_map &opts)
   logger::message("Preparing prepared statements.");
 
   // clang-format off
+
+  m_cache_connection.prepare("extract_changeset_userdetails",
+      "SELECT c.id, u.data_public, u.display_name, u.id from users u "
+                   "join changesets c on u.id=c.user_id where c.id = ANY($1)");
+  PREPARE_ARGS("bigint[]");
 
   // select nodes with bbox
   m_connection.prepare("visible_node_in_bbox",

--- a/src/backend/apidb/writeable_pgsql_selection.cpp
+++ b/src/backend/apidb/writeable_pgsql_selection.cpp
@@ -424,6 +424,7 @@ writeable_pgsql_selection::factory::factory(const po::variables_map &opts)
 #endif
       m_cache_tx(m_cache_connection, "changeset_cache"),
       m_cache(boost::bind(fetch_changeset, boost::ref(m_cache_tx), _1),
+              boost::bind(fetch_changesets, boost::ref(m_cache_tx), _1),
               get_or_convert_cachesize(opts)) {
 
   check_postgres_version(m_connection);
@@ -443,6 +444,10 @@ writeable_pgsql_selection::factory::factory(const po::variables_map &opts)
   logger::message("Preparing prepared statements.");
 
   // clang-format off
+
+  m_cache_connection.prepare("extract_changeset_userdetails",
+      "SELECT c.id, u.data_public, u.display_name, u.id from users u "
+                   "join changesets c on u.id=c.user_id where c.id = ANY($1)");
 
   // select nodes with bbox
   // version which ignores any existing tmp_nodes IDs


### PR DESCRIPTION
Fixes #122, and pretty much any other API call based on the same extraction logic.

I hope the general approach of tackling this issue is ok with only minor code cleanups needed.