### PR TITLE
OAuth parsing failures should be failures, not crashes.

### DIFF
--- a/src/oauth.cpp
+++ b/src/oauth.cpp
@@ -460,8 +460,6 @@ boost::optional<std::string> hashed_signature(request &req, secret_store &store)
   return hash;
 }
 
-} // namespace detail
-
 validity::validity is_valid_signature(
   request &req, secret_store &store,
   nonce_store &nonces, token_store &tokens) {
@@ -546,6 +544,21 @@ validity::validity is_valid_signature(
   }
 
   return validity::copacetic(*token);
+}
+
+} // namespace detail
+
+validity::validity is_valid_signature(
+  request &req, secret_store &store,
+  nonce_store &nonces, token_store &tokens) {
+
+  try {
+    return detail::is_valid_signature(req, store, nonces, tokens);
+
+  } catch (const std::exception &) {
+    // can't parse the signature - must be bad?
+    return validity::bad_request();
+  }
 }
 
 store::~store() {

--- a/test/test_oauth.cpp
+++ b/test/test_oauth.cpp
@@ -459,8 +459,9 @@ void oauth_check_almost_expired_signature() {
                           "nnch734d00sl2jdk", "pfkkdhi9sl3r4s00");
   oauth::validity::validity expected(
     oauth::validity::copacetic("nnch734d00sl2jdk"));
-  assert_equal(expected,
-               oauth::is_valid_signature(req, store, store, store));
+  assert_equal(
+    oauth::is_valid_signature(req, store, store, store),
+    expected);
 }
 
 void oauth_check_expired_signature() {
@@ -475,8 +476,25 @@ void oauth_check_expired_signature() {
                           "nnch734d00sl2jdk", "pfkkdhi9sl3r4s00");
   oauth::validity::validity expected(
     oauth::validity::unauthorized("Timestamp is too far in the past."));
-  assert_equal(expected,
-               oauth::is_valid_signature(req, store, store, store));
+  assert_equal(
+    oauth::is_valid_signature(req, store, store, store),
+    expected);
+}
+
+void oauth_check_bad_quoting() {
+  boost::optional<std::string> auth_header = std::string("OAuth %3Cdummy%20id=\"'-1'%2F%3E\", oauth_consumer_key=\"U84xxVrHBewaYHehTpaV0Rk3nGhahzRj0zntCe1N\", oauth_nonce=\"Xw1WlI\", oauth_signature=\"32gRmihzmdV47jW2juAL7mIpXkA%3D\", oauth_signature_method=\"HMAC-SHA1\", oauth_timestamp=\"1526814151\", oauth_token=\"FLfg7mbQlV6TAcBSY58YgQz39mpcWgj47J3PZPEx\"");
+  test_request req(
+    "GET",
+    "http", "localhost", "31337", "api/0.6/changeset/876/download", "",
+    1191242096,
+    auth_header);
+
+  test_secret_store store("", "", "", "");
+
+  oauth::validity::bad_request bad_request;
+  assert_equal(
+    oauth::is_valid_signature(req, store, store, store),
+    oauth::validity::validity(bad_request));
 }
 
 int main() {
@@ -496,6 +514,7 @@ int main() {
     ANNOTATE_EXCEPTION(oauth_check_valid_signature_header_2());
     ANNOTATE_EXCEPTION(oauth_check_almost_expired_signature());
     ANNOTATE_EXCEPTION(oauth_check_expired_signature());
+    ANNOTATE_EXCEPTION(oauth_check_bad_quoting());
 
   } catch (const std::exception &e) {
     std::cerr << "EXCEPTION: " << e.what() << std::endl;


### PR DESCRIPTION
Don't propagate exceptions during OAuth header parsing and validation. Instead, treat it as a validation failure.

Fixes #146.

@mmd-osm, could you try out this branch and let me know if it no longer crashes, please?