### PR TITLE
Fix confusing error message for /map call 

### DIFF
--- a/include/cgimap/request.hpp
+++ b/include/cgimap/request.hpp
@@ -52,6 +52,11 @@ struct request {
   // after a call to any of the output functions.
   void add_header(const std::string &key, const std::string &value);
 
+  // add a key-value header to the response like add_header, provided that
+  // processing didn't trigger any error before calling any of the output
+  // functions
+  void add_success_header(const std::string &key, const std::string &value);
+
   /********************** RESPONSE OUTPUT FUNCTIONS **************************/
 
   // return a handle to the output buffer to write body output. this function
@@ -116,6 +121,9 @@ private:
 
   // the headers to be written in the response
   headers_t m_headers;
+
+  // the headers to be written in the response if process was successful
+  headers_t m_success_headers;
 
   // allowed methods, to be returned to the client in the CORS headers.
   http::method m_methods;

--- a/src/api06/map_handler.cpp
+++ b/src/api06/map_handler.cpp
@@ -45,7 +45,20 @@ map_responder::~map_responder() = default;
 map_handler::map_handler(request &req) : bounds(validate_request(req)) {
   // map calls typically have a Content-Disposition header saying that
   // what's coming back is an attachment.
-  req.add_header("Content-Disposition", "attachment; filename=\"map.osm\"");
+  //
+  // Content-Disposition should be only returned to the browser, in case the
+  // node extraction does not exceed the maximum number of nodes in a bounding box.
+  //
+  // Sending this header even for HTTP 400 Bad request errors is causing lots
+  // of confusion to users, as most browsers will only show the following meaningless
+  // error message:
+  //
+  // The webpage at ... might be temporarily down or it may have
+  // moved permanently to a new web address.
+  //
+  // ERR_INVALID_RESPONSE
+  //
+  req.add_success_header("Content-Disposition", "attachment; filename=\"map.osm\"");
 }
 
 map_handler::~map_handler() = default;

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -19,7 +19,7 @@ void set_default_headers(request &req) {
 } // anonymous namespace
 
 request::request()
-  : m_workflow_status(status_NONE), m_status(500), m_headers()
+  : m_workflow_status(status_NONE), m_status(500), m_headers(), m_success_headers()
   , m_methods(http::method::GET | http::method::HEAD | http::method::OPTIONS) {}
 
 request::~request() = default;
@@ -32,6 +32,11 @@ void request::status(int code) {
 void request::add_header(const std::string &key, const std::string &value) {
   check_workflow(status_HEADERS);
   m_headers.push_back(std::make_pair(key, value));
+}
+
+void request::add_success_header(const std::string &key, const std::string &value) {
+  check_workflow(status_HEADERS);
+  m_success_headers.push_back(std::make_pair(key, value));
 }
 
 std::shared_ptr<output_buffer> request::get_buffer() {
@@ -66,7 +71,13 @@ void request::check_workflow(workflow_status this_stage) {
     if ((status_BODY > m_workflow_status) && (status_BODY <= this_stage)) {
       // must be in BODY workflow stage to write output
       m_workflow_status = status_BODY;
-      write_header_info(m_status, m_headers);
+
+      // some HTTP headers are only returned in case the request was successful
+      auto headers = m_headers;
+      if (m_status == 200)
+	headers.insert(headers.end(), m_success_headers.begin(), m_success_headers.end());
+
+      write_header_info(m_status, headers);
     }
 
     m_workflow_status = this_stage;
@@ -85,6 +96,7 @@ void request::reset() {
   m_workflow_status = status_NONE;
   m_status = 500;
   m_headers.clear();
+  m_success_headers.clear();
 }
 
 void request::set_default_methods(http::method m) {


### PR DESCRIPTION
Fix confusing error message for /map call in case max node limit has been exceeded.

Previous behavior was a constant source of confusion to users, as most browsers would only display a meaningless error message, instead of telling the user that the bbox contains too many nodes.

This pull request introduces a change to only return the Content-Disposition header in case the overall request is successful (HTTP status code 200)

Old behavior:

![map_error_too_many_nodes_current](https://user-images.githubusercontent.com/5842757/52500003-26c93c80-2bdd-11e9-9890-a499a251adce.png)


New behavior:

![map_error_too_many_nodes](https://user-images.githubusercontent.com/5842757/52499915-ee296300-2bdc-11e9-9502-38c010536381.png)


References:
* https://help.openstreetmap.org/questions/45330/error-downloading-a-map-invalid-response
* https://help.openstreetmap.org/questions/67901/cant-export-maps-err_invalid_response
* https://help.openstreetmap.org/questions/50006/this-site-cant-be-reached-error-while-trying-to-export-a-map
* ... and many more ...