### PR TITLE
Fix: XML parser handling for invalid data

### DIFF
--- a/include/cgimap/api06/changeset_upload/osmchange_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/osmchange_input_format.hpp
@@ -160,7 +160,11 @@ class OSMChangeXMLParser {
       if (ctxt == NULL)
         throw std::runtime_error("Could not create parser context!");
 
-      xmlCtxtUseOptions(ctxt, XML_PARSE_RECOVER | XML_PARSE_NONET | XML_PARSE_NOENT);
+      // removed XML_PARSE_RECOVER : the use of XML_PARSE_RECOVER in libxml2
+      // is discouraged in production  code as it hides errors in invalid XML
+      // and exercises some less-tested code paths in libxml2.
+      // Source: https://mail.gnome.org/archives/xml/2018-January/msg00016.html
+      xmlCtxtUseOptions(ctxt, XML_PARSE_NONET | XML_PARSE_NOENT);
 
       unsigned int offset = 4;
 
@@ -171,7 +175,7 @@ class OSMChangeXMLParser {
 
         if (xmlParseChunk(ctxt, data.c_str() + offset, current_chunksize, 0)) {
           xmlErrorPtr err = xmlGetLastError();
-          throw std::runtime_error(
+          throw http::bad_request(
               (boost::format("XML ERROR: %1%.") % err->message).str());
         }
 

--- a/test/test_parse_osmchange_input.cpp
+++ b/test/test_parse_osmchange_input.cpp
@@ -844,6 +844,18 @@ void test_relation() {
   }
 }
 
+void test_invalid_data() {
+
+  std::string s = "\x3C\x00\x00\x00\x00\x0A\x01\x00";
+  try {
+    process_testmsg(s);
+    throw std::runtime_error("test_invalid_data::001: Expected exception");
+  } catch (http::exception &e) {
+    if (e.code() != 400)
+      throw std::runtime_error("test_invalid_data::001: Expected HTTP 400");
+  }
+}
+
 void test_large_message() {
 
   // Test XML chunking with a very large message
@@ -889,6 +901,7 @@ int main(int argc, char *argv[]) {
     test_node();
     test_way();
     test_relation();
+    test_invalid_data();
     test_large_message();
 
   } catch (const std::exception &ex) {


### PR DESCRIPTION
XML parser fixes after a round of fuzzing:

* Return HTTP 400 instead of 500 for invalid XML
* Removed XML_PARSE_RECOVER : the use of XML_PARSE_RECOVER in libxml2 is discouraged in production  code as it hides errors in invalid XML and exercises some less-tested code paths in libxml2.
Source: https://mail.gnome.org/archives/xml/2018-January/msg00016.html