### PR TITLE
Provide option to enforce limits for tags and relation members

### DIFF
--- a/include/cgimap/api06/changeset_upload/osmchange_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/osmchange_input_format.hpp
@@ -239,7 +239,7 @@ protected:
       break;
     case context::relation:
       assert(!std::strcmp(element, "relation"));
-      if (!m_relation->is_valid()) {
+      if (!m_relation->is_valid(m_operation)) {
         throw xml_error{
           (boost::format("%1% does not include all mandatory fields") %
            m_relation->to_string())

--- a/include/cgimap/api06/changeset_upload/osmobject.hpp
+++ b/include/cgimap/api06/changeset_upload/osmobject.hpp
@@ -143,6 +143,12 @@ namespace api06 {
 	throw xml_error(
 	    "You need to supply a changeset to be able to make a change");
 
+      if (m_tags.size() > OSM_ELEMENT_MAX_TAGS)
+	  throw xml_error(
+	      (boost::format("OSM element exceeds limit of %1% tags")
+                 % OSM_ELEMENT_MAX_TAGS)
+		  .str());
+
       return (m_changeset && m_id && m_version);
     }
 

--- a/include/cgimap/api06/changeset_upload/osmobject.hpp
+++ b/include/cgimap/api06/changeset_upload/osmobject.hpp
@@ -143,11 +143,13 @@ namespace api06 {
 	throw xml_error(
 	    "You need to supply a changeset to be able to make a change");
 
-      if (m_tags.size() > OSM_ELEMENT_MAX_TAGS)
+      if ((global_settings::get_element_max_tags()) &&
+	  m_tags.size() > *global_settings::get_element_max_tags()) {
 	  throw xml_error(
 	      (boost::format("OSM element exceeds limit of %1% tags")
-                 % OSM_ELEMENT_MAX_TAGS)
+                 % *global_settings::get_element_max_tags())
 		  .str());
+      }
 
       return (m_changeset && m_id && m_version);
     }

--- a/include/cgimap/api06/changeset_upload/relation.hpp
+++ b/include/cgimap/api06/changeset_upload/relation.hpp
@@ -105,8 +105,30 @@ public:
 
   std::string get_type_name() { return "Relation"; }
 
+  bool is_valid(operation op) const {
+
+    switch (op) {
+
+    case operation::op_delete:
+      return (is_valid());
+
+    default:
+      if (m_relation_member.size() > RELATION_MAX_MEMBERS) {
+        throw http::bad_request(
+            (boost::format(
+                 "You tried to add %1% members to relation %2%, however only "
+                 "%3% are allowed") %
+        	m_relation_member.size() % (has_id() ? id() : 0) % RELATION_MAX_MEMBERS)
+                .str());
+      }
+
+      return (is_valid());
+    }
+  }
+
 private:
   std::vector<RelationMember> m_relation_member;
+  using OSMObject::is_valid;
 };
 
 } // namespace api06

--- a/include/cgimap/api06/changeset_upload/relation.hpp
+++ b/include/cgimap/api06/changeset_upload/relation.hpp
@@ -113,12 +113,13 @@ public:
       return (is_valid());
 
     default:
-      if (m_relation_member.size() > RELATION_MAX_MEMBERS) {
+      if ((global_settings::get_relation_max_members()) &&
+	  m_relation_member.size() > *global_settings::get_relation_max_members()) {
         throw http::bad_request(
             (boost::format(
                  "You tried to add %1% members to relation %2%, however only "
                  "%3% are allowed") %
-        	m_relation_member.size() % (has_id() ? id() : 0) % RELATION_MAX_MEMBERS)
+        	m_relation_member.size() % (has_id() ? id() : 0) % *global_settings::get_relation_max_members())
                 .str());
       }
 

--- a/include/cgimap/options.hpp
+++ b/include/cgimap/options.hpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <regex>
+#include <boost/optional.hpp>
 #include <boost/program_options.hpp>
 
 namespace po = boost::program_options;
@@ -20,6 +21,8 @@ public:
   virtual int get_changeset_max_elements() const = 0;
   virtual int get_way_max_nodes() const = 0;
   virtual long get_scale() const = 0;
+  virtual boost::optional<int> get_relation_max_members() const = 0;
+  virtual boost::optional<int> get_element_max_tags() const = 0;
 };
 
 class global_settings_default : public global_settings_base {
@@ -55,6 +58,14 @@ public:
 
   long get_scale() const override {
      return 10000000L;
+  }
+
+  boost::optional<int> get_relation_max_members() const override {
+     return boost::none;  // default: unlimited
+  }
+
+  boost::optional<int> get_element_max_tags() const override {
+     return boost::none;  // default: unlimited
   }
 };
 
@@ -108,6 +119,14 @@ public:
      return m_scale;
   }
 
+  boost::optional<int> get_relation_max_members() const override {
+     return m_relation_max_members;
+  }
+
+  boost::optional<int> get_element_max_tags() const override {
+     return m_element_max_tags;
+  }
+
 private:
   void init_fallback_values(const global_settings_base &def);
   void set_new_options(const po::variables_map &options);
@@ -119,6 +138,8 @@ private:
   void set_changeset_max_elements(const po::variables_map &options);
   void set_way_max_nodes(const po::variables_map &options);
   void set_scale(const po::variables_map &options);
+  void set_relation_max_members(const po::variables_map &options);
+  void set_element_max_tags(const po::variables_map &options);
   bool validate_timeout(const std::string &timeout) const;
 
   long m_payload_max_size;
@@ -129,6 +150,8 @@ private:
   int m_changeset_max_elements;
   int m_way_max_nodes;
   long m_scale;
+  boost::optional<int> m_relation_max_members;
+  boost::optional<int> m_element_max_tags;
 };
 
 class global_settings final {
@@ -161,6 +184,12 @@ public:
 
   // Conversion factor from double lat/lon format to internal int format used for db persistence
   static long get_scale() { return settings->get_scale(); }
+
+  // Maximum number of relation members for an OSM object (may be unlimited)
+  static boost::optional<int> get_relation_max_members() { return settings->get_relation_max_members(); }
+
+  // Maximum number of tags for an OSM object (may be unlimited)
+  static boost::optional<int> get_element_max_tags() { return settings->get_element_max_tags(); }
 
 private:
   static std::unique_ptr<global_settings_base> settings;  // gets initialized with global_settings_default instance

--- a/include/cgimap/util.hpp
+++ b/include/cgimap/util.hpp
@@ -17,7 +17,6 @@
 #include <string>
 
 
-
 inline size_t unicode_strlen(const std::string & s)
 {
    const char* mbstr = s.c_str();

--- a/include/cgimap/util.hpp
+++ b/include/cgimap/util.hpp
@@ -17,6 +17,7 @@
 #include <string>
 
 
+
 inline size_t unicode_strlen(const std::string & s)
 {
    const char* mbstr = s.c_str();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,8 +126,10 @@ static void get_options(int argc, char **argv, po::variables_map &options) {
     ("changeset-timeout-open", po::value<string>(), "max open time period for a changeset")
     ("changeset-timeout-idle", po::value<string>(), "time period a changeset will remain open after last edit")
     ("max-changeset-elements", po::value<int>(), "max number of elements allowed in one changeset")
-    ("max-way-nodes", po::value<int>(), "max number of nodes allowed in one way (!!)")
-    ("scale", po::value<long>(), "conversion factor from double lat/lon to internal int format (!!)")
+    ("max-way-nodes", po::value<int>(), "max number of nodes allowed in one way")
+    ("scale", po::value<long>(), "conversion factor from double lat/lon to internal int format")
+    ("max-relation-members", po::value<int>(), "max number of relation members per relation")
+    ("max-element-tags", po::value<int>(), "max number of tags per OSM element")
     ;
   // clang-format on
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -17,6 +17,8 @@ void global_settings_via_options::init_fallback_values(const global_settings_bas
   m_changeset_max_elements = def.get_changeset_max_elements();
   m_way_max_nodes = def.get_way_max_nodes();
   m_scale = def.get_scale();
+  m_relation_max_members = def.get_relation_max_members();
+  m_element_max_tags = def.get_element_max_tags();
 }
 
 void global_settings_via_options::set_new_options(const po::variables_map &options) {
@@ -29,6 +31,8 @@ void global_settings_via_options::set_new_options(const po::variables_map &optio
   set_changeset_max_elements(options);
   set_way_max_nodes(options);
   set_scale(options);
+  set_relation_max_members(options);
+  set_element_max_tags(options);
 }
 
 void global_settings_via_options::set_payload_max_size(const po::variables_map &options)  {
@@ -95,6 +99,23 @@ void global_settings_via_options::set_scale(const po::variables_map &options) {
       throw std::invalid_argument("scale must be a positive number");
   }
 }
+
+void global_settings_via_options::set_relation_max_members(const po::variables_map &options) {
+  if (options.count("max-relation-members")) {
+    m_relation_max_members = options["max-relation-members"].as<int>();
+    if (m_relation_max_members <= 0)
+      throw std::invalid_argument("max-relation-members must be a positive number");
+  }
+}
+
+void global_settings_via_options::set_element_max_tags(const po::variables_map &options) {
+  if (options.count("max-element-tags")) {
+    m_element_max_tags = options["max-element-tags"].as<int>();
+    if (m_element_max_tags <= 0)
+      throw std::invalid_argument("max-element-tags must be a positive number");
+  }
+}
+
 
 bool global_settings_via_options::validate_timeout(const std::string &timeout) const {
   std::smatch sm;

--- a/test/test_parse_osmchange_input.cpp
+++ b/test/test_parse_osmchange_input.cpp
@@ -5,6 +5,7 @@
 #include "cgimap/util.hpp"
 
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 
@@ -25,6 +26,23 @@ public:
 
   bool start_executed;
   bool end_executed;
+};
+
+class global_settings_test_class : public global_settings_default {
+
+public:
+
+  boost::optional<int> get_relation_max_members() const override {
+     return m_relation_max_members;
+  }
+
+  boost::optional<int> get_element_max_tags() const override {
+     return m_element_max_tags;
+  }
+
+  boost::optional<int> m_relation_max_members{boost::none};
+  boost::optional<int> m_element_max_tags{boost::none};
+
 };
 
 std::string repeat(const std::string &input, size_t num) {
@@ -593,28 +611,6 @@ void test_node() {
       throw std::runtime_error("test_node::102: Expected HTTP 400");
   }
 
-  // Check maximum number of tags per element
-  for (int i = OSM_ELEMENT_MAX_TAGS; i <= OSM_ELEMENT_MAX_TAGS + 1; i++) {
-     std::ostringstream os;
-
-     for (int x = 0; x < i; x++)
-       os << "<tag k='amenity_" << x << "' v='cafe' />";
-
-    try {
-      process_testmsg(
-          (boost::format(
-               R"(<osmChange><create><node changeset="858" id="-1" lat="-1" lon="2">%1%</node></create></osmChange>)") %
-              os.str()).str());
-      if (i > OSM_ELEMENT_MAX_TAGS)
-        throw std::runtime_error("test_node::120: Expected exception for max number of tags exceeded");
-    } catch (http::exception &e) {
-      if (e.code() != 400)
-        throw std::runtime_error("test_node::120: Expected HTTP 400");
-      if (i <= OSM_ELEMENT_MAX_TAGS)
-        throw std::runtime_error("test_node::120: Unexpected exception max. tags not yet exceeded");
-    }
-  }
-
 }
 
 void test_way() {
@@ -866,27 +862,6 @@ void test_relation() {
                                  "string length <= 255 characters");
     }
   }
-
-  // Check maximum number of members in relation
-  for (int i = RELATION_MAX_MEMBERS; i <= RELATION_MAX_MEMBERS + 1; i++) {
-    auto v = repeat(R"(<member type="node" role="demo" ref="123"/>)", i);
-
-    try {
-      process_testmsg(
-          (boost::format(
-               R"(<osmChange><create><relation changeset="858" id="-1">%1%"</relation></create></osmChange>)") %
-           v).str());
-      if (i > RELATION_MAX_MEMBERS)
-        throw std::runtime_error("test_relation::011: Expected exception for "
-                                 "maximum number of members in relation exceeded");
-    } catch (http::exception &e) {
-      if (e.code() != 400)
-        throw std::runtime_error("test_relation::011: Expected HTTP 400");
-      if (i <= RELATION_MAX_MEMBERS)
-        throw std::runtime_error("test_relation::011: Unexpected exception for "
-                                 "maximum number of members in relation not exceeded");
-    }
-  }
 }
 
 void test_invalid_data() {
@@ -940,6 +915,73 @@ void test_large_message() {
   }
 }
 
+void test_object_limits() {
+
+  auto test_settings = std::unique_ptr<global_settings_test_class>(new global_settings_test_class());
+  test_settings->m_element_max_tags = 5000;
+  test_settings->m_relation_max_members = 32000;
+
+  global_settings::set_configuration(std::move(test_settings));
+
+  if (global_settings::get_element_max_tags()) {
+
+    // Check maximum number of tags per element
+    for (int i = *global_settings::get_element_max_tags(); i <= *global_settings::get_element_max_tags() + 1; i++) {
+       std::ostringstream os;
+
+       for (int x = 0; x < i; x++)
+	 os << "<tag k='amenity_" << x << "' v='cafe' />";
+
+      try {
+	process_testmsg(
+	    (boost::format(
+		 R"(<osmChange><create><node changeset="858" id="-1" lat="-1" lon="2">%1%</node></create></osmChange>)") %
+		os.str()).str());
+	if (i > *global_settings::get_element_max_tags())
+	  throw std::runtime_error("test_node::120: Expected exception for max number of tags exceeded");
+      } catch (http::exception &e) {
+	if (e.code() != 400)
+	  throw std::runtime_error("test_node::120: Expected HTTP 400");
+	if (i <= *global_settings::get_element_max_tags())
+	  throw std::runtime_error("test_node::120: Unexpected exception max. tags not yet exceeded");
+      }
+    }
+  }
+  else {
+      throw std::runtime_error("test_node::120: Unexpected exception max. tags not executed");
+  }
+
+
+  if (global_settings::get_relation_max_members()) {
+
+    // Check maximum number of members in relation
+    for (int i = *global_settings::get_relation_max_members();
+	i <= *global_settings::get_relation_max_members() + 1; i++) {
+      auto v = repeat(R"(<member type="node" role="demo" ref="123"/>)", i);
+
+      try {
+	process_testmsg(
+	    (boost::format(
+		 R"(<osmChange><create><relation changeset="858" id="-1">%1%"</relation></create></osmChange>)") %
+	     v).str());
+	if (i > *global_settings::get_relation_max_members())
+	  throw std::runtime_error("test_relation::011: Expected exception for "
+				   "maximum number of members in relation exceeded");
+      } catch (http::exception &e) {
+	if (e.code() != 400)
+	  throw std::runtime_error("test_relation::011: Expected HTTP 400");
+	if (i <= *global_settings::get_relation_max_members())
+	  throw std::runtime_error("test_relation::011: Unexpected exception for "
+				   "maximum number of members in relation not exceeded");
+      }
+    }
+  }
+  else {
+      throw std::runtime_error("test_relation::011: Unexpected exception max relation members not executed");
+  }
+
+}
+
 int main(int argc, char *argv[]) {
   try {
     test_osmchange_structure();
@@ -948,6 +990,7 @@ int main(int argc, char *argv[]) {
     test_relation();
     test_invalid_data();
     test_large_message();
+    test_object_limits();
 
   } catch (const std::exception &ex) {
     std::cerr << "EXCEPTION: " << ex.what() << std::endl;


### PR DESCRIPTION
Corresponds to https://github.com/openstreetmap/openstreetmap-website/issues/1711

This pull request introduces fairly liberal limits for relation members and tags per object. Without those limits, relations with millions of members could be uploaded, which is clearly something we don't want.

```
const int RELATION_MAX_MEMBERS = 100000;
const int OSM_ELEMENT_MAX_TAGS = 5000;
```