### PR TITLE
[perf] relation member changes for bbox calculation

### DIFF
--- a/include/cgimap/backend/apidb/transaction_manager.hpp
+++ b/include/cgimap/backend/apidb/transaction_manager.hpp
@@ -1,6 +1,10 @@
 #ifndef TRANSACTION_MANAGER_HPP
 #define TRANSACTION_MANAGER_HPP
 
+#include "cgimap/logger.hpp"
+
+#include <chrono>
+#include <boost/format.hpp>
 #include <pqxx/pqxx>
 
 class Transaction_Manager {
@@ -15,10 +19,42 @@ public:
 
   pqxx::result exec(const std::string &query,
                     const std::string &description = std::string());
-
   void commit();
 
+  template<typename... Args>
+  pqxx::result exec_prepared(const std::string &statement, Args&&... args) {
+
+    pqxx::prepare::invocation inv = m_txn.prepared(statement);
+    pqxx::prepare::invocation inv_with_params = pass_param<Args...>(inv, std::forward<Args>(args)...);
+
+    auto start = std::chrono::steady_clock::now();
+    pqxx::result res = inv_with_params.exec();
+    auto end = std::chrono::steady_clock::now();
+
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+    logger::message(boost::format("Executed prepared statement %1% in %2% ms, returning %3% rows, %4% affected rows")
+                               % statement
+			       % elapsed.count()
+			       % res.size()
+			       % res.affected_rows());
+    return res;
+  }
+
 private:
+
+  template<typename Arg>
+  pqxx::prepare::invocation pass_param(pqxx::prepare::invocation& in, Arg&& arg)
+  {
+    return(in(std::forward<Arg>(arg)));
+  }
+
+  template<typename Arg, typename... Args>
+  pqxx::prepare::invocation pass_param(pqxx::prepare::invocation& in, Arg&& arg, Args&&... args)
+  {
+    return (pass_param<Args...>(in(std::forward<Arg>(arg)), std::forward<Args>(args)...));
+  }
+
   pqxx::work m_txn;
 };
 

--- a/src/backend/apidb/changeset_upload/relation_updater.cpp
+++ b/src/backend/apidb/changeset_upload/relation_updater.cpp
@@ -482,7 +482,7 @@ void ApiDB_Relation_Updater::insert_new_relations_to_tmp_table(
     oldids.emplace_back(create_relation.old_id);
   }
 
-  pqxx::result r = m.prepared("insert_tmp_create_relations")(cs)(oldids).exec();
+  pqxx::result r = m.exec_prepared("insert_tmp_create_relations", cs, oldids);
 
   if (r.affected_rows() != create_relations.size())
     throw http::server_error(
@@ -517,7 +517,7 @@ void ApiDB_Relation_Updater::lock_current_relations(
   m.prepare("lock_current_relations",
             "SELECT id FROM current_relations WHERE id = ANY($1) FOR UPDATE");
 
-  pqxx::result r = m.prepared("lock_current_relations")(ids).exec();
+  pqxx::result r = m.exec_prepared("lock_current_relations", ids);
 
   std::set<osm_nwr_id_t> locked_ids;
 
@@ -604,7 +604,7 @@ void ApiDB_Relation_Updater::check_current_relation_versions(
        )");
 
   pqxx::result r =
-      m.prepared("check_current_relation_versions")(ids)(versions).exec();
+      m.exec_prepared("check_current_relation_versions", ids, versions);
 
   if (!r.empty()) {
     throw http::conflict((boost::format("Version mismatch: Provided %1%, "
@@ -650,7 +650,7 @@ ApiDB_Relation_Updater::determine_already_deleted_relations(
                                          "AND visible = false");
 
   pqxx::result r =
-      m.prepared("already_deleted_relations")(ids_to_be_deleted).exec();
+      m.exec_prepared("already_deleted_relations", ids_to_be_deleted);
 
   for (const auto &row : r) {
     osm_nwr_id_t id = row["id"].as<osm_nwr_id_t>();
@@ -731,7 +731,7 @@ void ApiDB_Relation_Updater::lock_future_members(
               )");
 
     pqxx::result r =
-        m.prepared("lock_future_nodes_in_relations")(node_ids).exec();
+        m.exec_prepared("lock_future_nodes_in_relations", node_ids);
 
     if (r.size() != node_ids.size()) {
       std::set<osm_nwr_id_t> locked_nodes;
@@ -768,7 +768,7 @@ void ApiDB_Relation_Updater::lock_future_members(
              )");
 
     pqxx::result r =
-        m.prepared("lock_future_ways_in_relations")(way_ids).exec();
+        m.exec_prepared("lock_future_ways_in_relations", way_ids);
 
     if (r.size() != way_ids.size()) {
       std::set<osm_nwr_id_t> locked_ways;
@@ -804,7 +804,7 @@ void ApiDB_Relation_Updater::lock_future_members(
                 AND id = ANY($1) FOR SHARE )");
 
     pqxx::result r =
-        m.prepared("lock_future_relations_in_relations")(relation_ids).exec();
+        m.exec_prepared("lock_future_relations_in_relations", relation_ids);
 
     if (r.size() != relation_ids.size()) {
       std::set<osm_nwr_id_t> locked_relations;
@@ -876,9 +876,7 @@ ApiDB_Relation_Updater::relations_with_new_relation_members(
           GROUP BY t.relation_id
      )");
 
-  pqxx::result r = m.prepared("relations_with_new_relation_members")(
-                        relation_ids)(member_ids)
-                       .exec();
+  pqxx::result r = m.exec_prepared("relations_with_new_relation_members", relation_ids, member_ids);
 
   for (const auto &row : r) {
     result.insert(row["relation_id"].as<osm_nwr_id_t>());
@@ -949,7 +947,7 @@ ApiDB_Relation_Updater::relations_with_changed_relation_tags(
          )");
 
   pqxx::result r =
-      m.prepared("relations_with_changed_relation_tags")(ids)(ks)(vs).exec();
+      m.exec_prepared("relations_with_changed_relation_tags", ids, ks, vs);
 
   for (const auto &row : r) {
     result.insert(row["relation_id"].as<osm_nwr_id_t>());
@@ -1018,9 +1016,7 @@ ApiDB_Relation_Updater::relations_with_changed_way_node_members(
 
          )");
 
-  pqxx::result r = m.prepared("relations_with_changed_way_node_members")(ids)(
-                        membertypes)(memberids)
-                       .exec();
+  pqxx::result r = m.exec_prepared("relations_with_changed_way_node_members", ids, membertypes, memberids);
 
   for (const auto &row : r) {
     rel_member_difference_t diff;
@@ -1067,7 +1063,7 @@ bbox_t ApiDB_Relation_Updater::calc_rel_member_difference_bbox(
       FROM current_nodes WHERE id = ANY($1)
        )");
 
-    pqxx::result r = m.prepared("calc_node_bbox_rel_member")(node_ids).exec();
+    pqxx::result r = m.exec_prepared("calc_node_bbox_rel_member", node_ids);
 
     if (!(r.empty() || r[0]["minlat"].is_null())) {
       bbox_nodes.minlat = r[0]["minlat"].as<int64_t>();
@@ -1097,7 +1093,7 @@ bbox_t ApiDB_Relation_Updater::calc_rel_member_difference_bbox(
       WHERE w.id = ANY($1)
        )");
 
-    pqxx::result r = m.prepared("calc_way_bbox_rel_member")(way_ids).exec();
+    pqxx::result r = m.exec_prepared("calc_way_bbox_rel_member", way_ids);
 
     if (!(r.empty() || r[0]["minlat"].is_null())) {
       bbox_ways.minlat = r[0]["minlat"].as<int64_t>();
@@ -1150,7 +1146,7 @@ bbox_t ApiDB_Relation_Updater::calc_relation_bbox(
                    AND current_relation_members.relation_id = ANY($1)
             )");
 
-  pqxx::result rn = m.prepared("calc_relation_bbox_nodes")(ids).exec();
+  pqxx::result rn = m.exec_prepared("calc_relation_bbox_nodes", ids);
 
   if (!(rn.empty() || rn[0]["minlat"].is_null())) {
     bbox.minlat = rn[0]["minlat"].as<int64_t>();
@@ -1176,7 +1172,7 @@ bbox_t ApiDB_Relation_Updater::calc_relation_bbox(
                    AND current_relation_members.relation_id = ANY($1)
               )");
 
-  pqxx::result rw = m.prepared("calc_relation_bbox_ways")(ids).exec();
+  pqxx::result rw = m.exec_prepared("calc_relation_bbox_ways", ids);
 
   if (!(rw.empty() || rw[0]["minlat"].is_null())) {
     bbox_t bbox_way;
@@ -1232,8 +1228,7 @@ void ApiDB_Relation_Updater::update_current_relations(
   }
 
   pqxx::result r =
-      m.prepared("update_current_relations")(ids)(cs)(visibles)(versions)
-          .exec();
+      m.exec_prepared("update_current_relations", ids, cs, visibles, versions);
 
   if (r.affected_rows() != relations.size())
     throw http::server_error("Could not update all current relations");
@@ -1283,7 +1278,7 @@ void ApiDB_Relation_Updater::insert_new_current_relation_tags(
     }
 
   pqxx::result r =
-      m.prepared("insert_new_current_relation_tags")(ids)(ks)(vs).exec();
+      m.exec_prepared("insert_new_current_relation_tags", ids, ks, vs);
 }
 
 void ApiDB_Relation_Updater::insert_new_current_relation_members(
@@ -1323,9 +1318,8 @@ void ApiDB_Relation_Updater::insert_new_current_relation_members(
       sequenceids.emplace_back(member.sequence_id);
     }
 
-  pqxx::result r = m.prepared("insert_new_current_relation_members")(ids)(
-                        membertypes)(memberids)(memberroles)(sequenceids)
-                       .exec();
+  pqxx::result r = m.exec_prepared("insert_new_current_relation_members",
+				   ids, membertypes, memberids, memberroles, sequenceids);
 }
 
 void ApiDB_Relation_Updater::save_current_relations_to_history(
@@ -1342,7 +1336,7 @@ void ApiDB_Relation_Updater::save_current_relations_to_history(
                  WHERE id = ANY($1)) 
             )");
 
-  pqxx::result r = m.prepared("current_relations_to_history")(ids).exec();
+  pqxx::result r = m.exec_prepared("current_relations_to_history", ids);
 
   if (r.affected_rows() != ids.size())
     throw http::server_error("Could not save current relations to history");
@@ -1362,7 +1356,7 @@ void ApiDB_Relation_Updater::save_current_relation_tags_to_history(
                  WHERE id = ANY($1)) 
              )");
 
-  pqxx::result r = m.prepared("current_relation_tags_to_history")(ids).exec();
+  pqxx::result r = m.exec_prepared("current_relation_tags_to_history", ids);
 }
 
 void ApiDB_Relation_Updater::save_current_relation_members_to_history(
@@ -1383,7 +1377,7 @@ void ApiDB_Relation_Updater::save_current_relation_members_to_history(
                           )");
 
   pqxx::result r =
-      m.prepared("current_relation_members_to_history")(ids).exec();
+      m.exec_prepared("current_relation_members_to_history", ids);
 }
 
 std::vector<ApiDB_Relation_Updater::relation_t>
@@ -1458,7 +1452,7 @@ ApiDB_Relation_Updater::is_relation_still_referenced(
        )");
 
   pqxx::result r =
-      m.prepared("relation_still_referenced_by_relation")(ids).exec();
+      m.exec_prepared("relation_still_referenced_by_relation", ids);
 
   for (const auto &row : r) {
     auto rel_id = row["member_id"].as<osm_nwr_id_t>();
@@ -1508,9 +1502,7 @@ ApiDB_Relation_Updater::is_relation_still_referenced(
     m.prepare("still_referenced_relations",
               "SELECT id, version FROM current_relations WHERE id = ANY($1)");
 
-    pqxx::result r = m.prepared("still_referenced_relations")(
-                          relations_to_exclude_from_deletion)
-                         .exec();
+    pqxx::result r = m.exec_prepared("still_referenced_relations", relations_to_exclude_from_deletion);
 
     if (r.affected_rows() != relations_to_exclude_from_deletion.size())
       throw http::server_error(
@@ -1545,7 +1537,7 @@ void ApiDB_Relation_Updater::delete_current_relation_members(
   m.prepare("delete_current_relation_members",
             "DELETE FROM current_relation_members WHERE relation_id = ANY($1)");
 
-  pqxx::result r = m.prepared("delete_current_relation_members")(ids).exec();
+  pqxx::result r = m.exec_prepared("delete_current_relation_members", ids);
 }
 
 void ApiDB_Relation_Updater::delete_current_relation_tags(
@@ -1556,7 +1548,7 @@ void ApiDB_Relation_Updater::delete_current_relation_tags(
   m.prepare("delete_current_relation_tags",
             "DELETE FROM current_relation_tags WHERE relation_id = ANY($1)");
 
-  pqxx::result r = m.prepared("delete_current_relation_tags")(ids).exec();
+  pqxx::result r = m.exec_prepared("delete_current_relation_tags", ids);
 }
 
 uint32_t ApiDB_Relation_Updater::get_num_changes() {

--- a/src/backend/apidb/transaction_manager.cpp
+++ b/src/backend/apidb/transaction_manager.cpp
@@ -22,3 +22,4 @@ pqxx::result Transaction_Manager::exec(const std::string &query,
 }
 
 void Transaction_Manager::commit() { m_txn.commit(); }
+


### PR DESCRIPTION
+ Fixes major performance issue with very large relations when determining added/removed relation members for bbox calculation
+ Added instrumentation code to log prepared statements execution times

See https://github.com/openstreetmap/operations/issues/236#issuecomment-467541630 for discussion