### PR TITLE
[Perf] Avoid unnecessary changeset comment extraction, if not requested

### DIFF
--- a/src/backend/apidb/readonly_pgsql_selection.cpp
+++ b/src/backend/apidb/readonly_pgsql_selection.cpp
@@ -247,7 +247,7 @@ void readonly_pgsql_selection::write_relations(output_formatter &formatter) {
 
 void readonly_pgsql_selection::write_changesets(output_formatter &formatter,
                                                 const std::chrono::system_clock::time_point &now) {
-  pqxx::result changesets = w.prepared("extract_changesets")(sel_changesets).exec();
+  pqxx::result changesets = w.prepared("extract_changesets")(sel_changesets)(include_changeset_discussions).exec();
   extract_changesets(changesets, formatter, cc, now, include_changeset_discussions);
 }
 
@@ -805,7 +805,7 @@ readonly_pgsql_selection::factory::factory(const po::variables_map &opts)
           "to_char(cc.created_at,'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS created_at "
           "FROM changeset_comments cc JOIN users u ON cc.author_id = u.id "
           "where cc.changeset_id=c.id AND cc.visible ORDER BY cc.created_at) x "
-        ")cc ON true "
+        ")cc ON ($2) "
      "WHERE c.id = ANY($1)");
 
   // ------------------- CHANGESET DOWNLOAD QUERIES -----------------------

--- a/src/backend/apidb/writeable_pgsql_selection.cpp
+++ b/src/backend/apidb/writeable_pgsql_selection.cpp
@@ -138,7 +138,7 @@ void writeable_pgsql_selection::write_relations(output_formatter &formatter) {
 
 void writeable_pgsql_selection::write_changesets(output_formatter &formatter,
                                                  const std::chrono::system_clock::time_point &now) {
-  pqxx::result changesets = w.prepared("extract_changesets").exec();
+  pqxx::result changesets = w.prepared("extract_changesets")(include_changeset_discussions).exec();
   extract_changesets(changesets, formatter, cc, now, include_changeset_discussions);
 }
 
@@ -539,7 +539,7 @@ writeable_pgsql_selection::factory::factory(const po::variables_map &opts)
           "to_char(cc.created_at,'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS created_at "
           "FROM changeset_comments cc JOIN users u ON cc.author_id = u.id "
           "where cc.changeset_id=c.id AND cc.visible ORDER BY cc.created_at) x "
-        ")cc ON true");
+        ")cc ON ($1)");
 
   // selecting a set of nodes as a list
   m_connection.prepare("add_nodes_list",

--- a/test/test_apidb_backend_changesets.cpp
+++ b/test/test_apidb_backend_changesets.cpp
@@ -254,6 +254,7 @@ void check_changeset_with_comments_impl(
                        "should have written one changeset.");
 
   comments_t comments;
+  if (include_discussion)
   {
     changeset_comment_info comment;
     comment.author_id = 3;
@@ -274,7 +275,7 @@ void check_changeset_with_comments_impl(
         std::string("user_1"), // display_name
         boost::none, // bounding box
         0, // num_changes
-        1 // comments_count
+        comments.size() // comments_count
         ),
       tags_t(),
       include_discussion,


### PR DESCRIPTION
Prepared statement `extract_changesets` always fetches all related changeset comments from the _changeset_comments_ table, even though it hasn't been requested by the caller. Today, it's cgimap's job to discard that information in case it isn't needed.


