### PR TITLE
Refactoring: improve OSMChange_Tracking diffresult isolation

### DIFF
--- a/include/cgimap/api06/changeset_upload/osmchange_tracking.hpp
+++ b/include/cgimap/api06/changeset_upload/osmchange_tracking.hpp
@@ -10,13 +10,23 @@
 
 namespace api06 {
 
+
+struct diffresult_t {
+  operation op;
+  object_type obj_type;
+  osm_nwr_signed_id_t old_id;
+  osm_nwr_id_t new_id;
+  osm_version_t new_version;
+  bool deletion_skipped;
+};
+
 class OSMChange_Tracking {
 
 public:
 
   OSMChange_Tracking() = default;
 
-  void populate_orig_sequence_mapping();
+  std::vector<diffresult_t> assemble_diffresult();
 
   struct object_id_mapping_t {
     osm_nwr_signed_id_t old_id;
@@ -30,10 +40,6 @@ public:
     osm_nwr_signed_id_t orig_id;
     osm_version_t orig_version;
     bool if_unused;
-    // the following fields will be populated once the whole message has been processed
-    object_id_mapping_t mapping;
-    bool deletion_skipped;         // if-unused flag was set, and object could not be deleted
-
   };
 
   // created objects are kept separately for id replacement purposes

--- a/include/cgimap/osm_diffresult_responder.hpp
+++ b/include/cgimap/osm_diffresult_responder.hpp
@@ -1,8 +1,11 @@
 #ifndef OSM_DIFFRESULT_RESPONDER_HPP
 #define OSM_DIFFRESULT_RESPONDER_HPP
 
+#include <vector>
+
 #include "cgimap/osm_responder.hpp"
 #include "cgimap/api06/changeset_upload/osmchange_tracking.hpp"
+
 
 /**
  * utility class - inherit from this when implementing something that responds
@@ -21,7 +24,7 @@ public:
              const std::chrono::system_clock::time_point &now);
 
 protected:
-  std::shared_ptr<api06::OSMChange_Tracking> change_tracking;
+  std::vector<api06::diffresult_t> m_diffresult;
 };
 
 #endif /* OSM_DIFFRESULT_RESPONDER_HPP */

--- a/include/cgimap/types.hpp
+++ b/include/cgimap/types.hpp
@@ -33,4 +33,5 @@ enum class object_type {
   node = 1, way = 2, relation = 3
 };
 
+
 #endif /* TYPES_HPP */

--- a/src/api06/changeset_upload/osmchange_tracking.cpp
+++ b/src/api06/changeset_upload/osmchange_tracking.cpp
@@ -5,135 +5,161 @@
 
 namespace api06 {
 
-void OSMChange_Tracking::populate_orig_sequence_mapping() {
+  std::vector<diffresult_t> OSMChange_Tracking::assemble_diffresult() {
 
-  // For compatibility reasons, diffResult output matches the exact object sequence provided in the osmChange message.
-  // OSM API documentation doesn't provide any guarantees wrt the actual sequence. However, some clients might
-  // implicitly rely on osmChange entries to be processed in the sequence given.
+    // For compatibility reasons, diffResult output matches the exact object sequence provided in the osmChange message.
+    // OSM API documentation doesn't provide any guarantees wrt the actual sequence. However, some clients might
+    // implicitly rely on osmChange entries to be processed in the sequence given.
 
-  // Prepare maps for faster lookup
+    // Prepare maps for faster lookup
 
-  // Create
-  std::map< std::pair< object_type, osm_nwr_signed_id_t >, OSMChange_Tracking::object_id_mapping_t > map_create_ids;
-  for (const auto &id : created_node_ids)
-    map_create_ids.insert(std::make_pair(std::make_pair(object_type::node, id.old_id), id));
+    // Create
+    std::map< std::pair< object_type, osm_nwr_signed_id_t >, OSMChange_Tracking::object_id_mapping_t > map_create_ids;
+    for (const auto &id : created_node_ids)
+      map_create_ids.insert(std::make_pair(std::make_pair(object_type::node, id.old_id), id));
 
-  for (const auto &id : created_way_ids)
-    map_create_ids.insert(std::make_pair(std::make_pair(object_type::way, id.old_id), id));
+    for (const auto &id : created_way_ids)
+      map_create_ids.insert(std::make_pair(std::make_pair(object_type::way, id.old_id), id));
 
-  for (const auto &id : created_relation_ids)
-    map_create_ids.insert(std::make_pair(std::make_pair(object_type::relation, id.old_id), id));
-
-
-  // Modify
-  std::map< std::tuple< object_type, osm_nwr_signed_id_t, osm_version_t>, OSMChange_Tracking::object_id_mapping_t > map_modify_ids;
-  for (const auto &id : modified_node_ids)
-    map_modify_ids.insert(std::make_pair(std::make_tuple(object_type::node, id.old_id, id.new_version), id));
-
-  for (const auto &id : modified_way_ids)
-    map_modify_ids.insert(std::make_pair(std::make_tuple(object_type::way, id.old_id, id.new_version), id));
-
-  for (const auto &id : modified_relation_ids)
-    map_modify_ids.insert(std::make_pair(std::make_tuple(object_type::relation, id.old_id, id.new_version), id));
-
-  // Delete (if-unused)
-  std::map< std::pair< object_type, osm_nwr_signed_id_t>, OSMChange_Tracking::object_id_mapping_t > map_skip_delete_ids;
-  for (const auto &id : skip_deleted_node_ids)
-    map_skip_delete_ids.insert(std::make_pair(std::make_pair(object_type::node, id.old_id), id));
-
-  for (const auto &id : skip_deleted_way_ids)
-    map_skip_delete_ids.insert(std::make_pair(std::make_pair(object_type::way, id.old_id), id));
-
-  for (const auto &id : skip_deleted_relation_ids)
-    map_skip_delete_ids.insert(std::make_pair(std::make_pair(object_type::relation, id.old_id), id));
-
-  // Deleted object ids
-  std::set< std::pair< object_type, osm_nwr_signed_id_t> > set_delete_ids;
-  for (const auto &id : deleted_node_ids)
-    set_delete_ids.insert(std::make_pair(object_type::node, id));
-
-  for (const auto &id : deleted_way_ids)
-    set_delete_ids.insert(std::make_pair(object_type::way, id));
-
-  for (const auto &id : deleted_relation_ids)
-    set_delete_ids.insert(std::make_pair(object_type::relation, id));
+    for (const auto &id : created_relation_ids)
+      map_create_ids.insert(std::make_pair(std::make_pair(object_type::relation, id.old_id), id));
 
 
-  // Iterate over all elements in the sequence defined in the osmChange message
+    // Modify
+    std::map< std::tuple< object_type, osm_nwr_signed_id_t, osm_version_t>, OSMChange_Tracking::object_id_mapping_t > map_modify_ids;
+    for (const auto &id : modified_node_ids)
+      map_modify_ids.insert(std::make_pair(std::make_tuple(object_type::node, id.old_id, id.new_version), id));
 
-  for (auto &item : osmchange_orig_sequence) {
+    for (const auto &id : modified_way_ids)
+      map_modify_ids.insert(std::make_pair(std::make_tuple(object_type::way, id.old_id, id.new_version), id));
 
-      switch (item.op) {
+    for (const auto &id : modified_relation_ids)
+      map_modify_ids.insert(std::make_pair(std::make_tuple(object_type::relation, id.old_id, id.new_version), id));
 
-	case operation::op_create:
-	  {
-	    auto it = map_create_ids.find(std::make_pair(item.obj_type, item.orig_id));
-	    if (it != map_create_ids.end()) {
-		const auto id = it->second;
-		item.mapping.old_id = id.old_id;
-		item.mapping.new_id = id.new_id;
-		item.mapping.new_version = id.new_version;
-	    }
-	    else
-	      throw std::runtime_error ("Element in osmChange message was not processed");
-	  }
-	  break;
+    // Delete (if-unused)
+    std::map< std::pair< object_type, osm_nwr_signed_id_t>, OSMChange_Tracking::object_id_mapping_t > map_skip_delete_ids;
+    for (const auto &id : skip_deleted_node_ids)
+      map_skip_delete_ids.insert(std::make_pair(std::make_pair(object_type::node, id.old_id), id));
 
-	case operation::op_modify:
-	  {
-	    auto it = map_modify_ids.find(std::make_tuple(item.obj_type, item.orig_id, item.orig_version + 1));
-	    if (it != map_modify_ids.end()) {
-		const auto id = it->second;
-		item.mapping.old_id = id.old_id;
-		item.mapping.new_id = id.new_id;
-		item.mapping.new_version = id.new_version;
-	    }
-	    else
-	      throw std::runtime_error ("Element in osmChange message was not processed");
-	  }
-	  break;
+    for (const auto &id : skip_deleted_way_ids)
+      map_skip_delete_ids.insert(std::make_pair(std::make_pair(object_type::way, id.old_id), id));
 
-	case operation::op_delete:
+    for (const auto &id : skip_deleted_relation_ids)
+      map_skip_delete_ids.insert(std::make_pair(std::make_pair(object_type::relation, id.old_id), id));
 
-	  if (item.if_unused) {
-	      auto it = map_skip_delete_ids.find(std::make_pair(item.obj_type, item.orig_id));
-	      if (it != map_skip_delete_ids.end()) {
+    // Deleted object ids
+    std::set< std::pair< object_type, osm_nwr_signed_id_t> > set_delete_ids;
+    for (const auto &id : deleted_node_ids)
+      set_delete_ids.insert(std::make_pair(object_type::node, id));
 
+    for (const auto &id : deleted_way_ids)
+      set_delete_ids.insert(std::make_pair(object_type::way, id));
+
+    for (const auto &id : deleted_relation_ids)
+      set_delete_ids.insert(std::make_pair(object_type::relation, id));
+
+
+    std::vector<diffresult_t> result;
+
+    // Iterate over all elements in the sequence defined in the osmChange message
+
+    for (auto &item : osmchange_orig_sequence) {
+
+	switch (item.op) {
+
+	  case operation::op_create:
+	    {
+	      auto it = map_create_ids.find(std::make_pair(item.obj_type, item.orig_id));
+	      if (it != map_create_ids.end()) {
+		  diffresult_t row{};
 		  const auto id = it->second;
-		  item.mapping.old_id = id.old_id;
-		  item.mapping.new_id = id.new_id;
-		  item.mapping.new_version = id.new_version;
-		  item.deletion_skipped = true;
+		  row.op = item.op;
+		  row.obj_type = item.obj_type;
+		  row.old_id = id.old_id;
+		  row.new_id = id.new_id;
+		  row.new_version = id.new_version;
+		  row.deletion_skipped = false;
+		  result.push_back(row);
 	      }
-	      else {
-		  auto it = set_delete_ids.find(std::make_pair(item.obj_type, item.orig_id));
-		  if (it != set_delete_ids.end()) {
-		      item.deletion_skipped = false;
-		  }
-		  else {
-		      throw std::runtime_error ("Element in osmChange message was not processed");
-		  }
+	      else
+		throw std::runtime_error ("Element in osmChange message was not processed");
+	    }
+	    break;
+
+	  case operation::op_modify:
+	    {
+	      auto it = map_modify_ids.find(std::make_tuple(item.obj_type, item.orig_id, item.orig_version + 1));
+	      if (it != map_modify_ids.end()) {
+		  diffresult_t row{};
+		  const auto id = it->second;
+		  row.op = item.op;
+		  row.obj_type = item.obj_type;
+		  row.old_id = id.old_id;
+		  row.new_id = id.new_id;
+		  row.new_version = id.new_version;
+		  row.deletion_skipped = false;
+		  result.push_back(row);
 	      }
-	  }
+	      else
+		throw std::runtime_error ("Element in osmChange message was not processed");
+	    }
+	    break;
 
-	  if (!item.if_unused) {
-	      auto it = set_delete_ids.find(std::make_pair(item.obj_type, item.orig_id));
-	      if (it != set_delete_ids.end()) {
+	  case operation::op_delete:
 
-		  item.deletion_skipped = false;
-	      }
-	      else {
-		  throw std::runtime_error ("Element in osmChange message was not processed");
-	      }
-	  }
-	  break;
+	    if (item.if_unused) {
+		auto it = map_skip_delete_ids.find(std::make_pair(item.obj_type, item.orig_id));
+		if (it != map_skip_delete_ids.end()) {
+		    diffresult_t row{};
+		    const auto id = it->second;
+		    row.op  = item.op;
+		    row.obj_type = item.obj_type;
+		    row.old_id = id.old_id;
+		    row.new_id = id.new_id;
+		    row.new_version = id.new_version;
+		    row.deletion_skipped = true;
+		    result.push_back(row);
+		}
+		else {
+		    auto it = set_delete_ids.find(std::make_pair(item.obj_type, item.orig_id));
+		    if (it != set_delete_ids.end()) {
+			diffresult_t row{};
+			row.op = item.op;
+			row.obj_type = item.obj_type;
+			row.old_id = it->second;
+			row.deletion_skipped = false;
+			result.push_back(row);
+		    }
+		    else {
+			throw std::runtime_error ("Element in osmChange message was not processed");
+		    }
+		}
+	    }
 
-	case operation::op_undefined:
+	    if (!item.if_unused) {
+		auto it = set_delete_ids.find(std::make_pair(item.obj_type, item.orig_id));
+		if (it != set_delete_ids.end()) {
+		    diffresult_t row{};
+		    row.op = item.op;
+		    row.obj_type = item.obj_type;
+		    row.old_id = it->second;
+		    row.deletion_skipped = false;
+		    result.push_back(row);
+		}
+		else {
+		    throw std::runtime_error ("Element in osmChange message was not processed");
+		}
+	    }
+	    break;
 
-	  throw std::runtime_error ("Unexpected operation in original sequence mapping. This should not happen!");
+	  case operation::op_undefined:
 
-      }
+	    throw std::runtime_error ("Unexpected operation in original sequence mapping. This should not happen!");
+
+	}
+    }
+
+    return result;
   }
-}
 
 } // namespace api06

--- a/src/api06/changeset_upload_handler.cpp
+++ b/src/api06/changeset_upload_handler.cpp
@@ -30,7 +30,7 @@ changeset_upload_responder::changeset_upload_responder(
   osm_changeset_id_t changeset = id_;
   osm_user_id_t uid = *user_id;
 
-  change_tracking = std::make_shared<OSMChange_Tracking>();
+  auto change_tracking = std::make_shared<OSMChange_Tracking>();
 
   auto changeset_updater = upd->get_changeset_updater(changeset, uid);
   auto node_updater = upd->get_node_updater(change_tracking);
@@ -46,7 +46,8 @@ changeset_upload_responder::changeset_upload_responder(
 
   parser.process_message(payload);
 
-  change_tracking->populate_orig_sequence_mapping();
+  // store diffresult for output handling in class osm_diffresult_responder
+  m_diffresult = change_tracking->assemble_diffresult();
 
   changeset_updater->update_changeset(handler.get_num_changes(),
                                       handler.get_bbox());

--- a/src/osm_diffresult_responder.cpp
+++ b/src/osm_diffresult_responder.cpp
@@ -37,31 +37,31 @@ void osm_diffresult_responder::write(shared_ptr<output_formatter> formatter,
 
     // Iterate over all elements in the sequence defined in the osmChange
     // message
-    for (const auto &item : change_tracking->osmchange_orig_sequence) {
+    for (const auto &item : m_diffresult) {
 
       switch (item.op) {
       case operation::op_create:
         fmt.write_diffresult_create_modify(
-            as_elem_type(item.obj_type), item.mapping.old_id,
-            item.mapping.new_id, item.mapping.new_version);
+            as_elem_type(item.obj_type), item.old_id,
+            item.new_id, item.new_version);
 
         break;
 
       case operation::op_modify:
         fmt.write_diffresult_create_modify(
-            as_elem_type(item.obj_type), item.mapping.old_id,
-            item.mapping.new_id, item.mapping.new_version);
+            as_elem_type(item.obj_type), item.old_id,
+            item.new_id, item.new_version);
 
         break;
 
       case operation::op_delete:
         if (item.deletion_skipped)
           fmt.write_diffresult_create_modify(
-              as_elem_type(item.obj_type), item.mapping.old_id,
-              item.mapping.new_id, item.mapping.new_version);
+              as_elem_type(item.obj_type), item.old_id,
+              item.new_id, item.new_version);
         else
           fmt.write_diffresult_delete(as_elem_type(item.obj_type),
-                                      item.orig_id);
+                                      item.old_id);
         break;
 
       case operation::op_undefined:


### PR DESCRIPTION
Improves code readability in osm_diffresult_responder.cpp by omitting irrelevant details from OSMChange_Tracking class.