### PR TITLE
Introduce --disable-api-write command line param to disable API writes

### DIFF
--- a/include/cgimap/backend/apidb/pgsql_update.hpp
+++ b/include/cgimap/backend/apidb/pgsql_update.hpp
@@ -31,7 +31,7 @@ public:
 
   void commit();
 
-  bool is_readonly();
+  bool is_api_write_disabled();
 
   /**
    * abstracts the creation of transactions for the
@@ -45,7 +45,7 @@ public:
 
   private:
     pqxx::connection m_connection;
-    bool m_readonly;
+    bool m_api_write_disabled;
     pqxx::quiet_errorhandler m_errorhandler;
   };
 

--- a/include/cgimap/data_update.hpp
+++ b/include/cgimap/data_update.hpp
@@ -34,7 +34,7 @@ public:
   virtual void
   commit() = 0;
 
-  virtual bool is_readonly() = 0;
+  virtual bool is_api_write_disabled() = 0;
 
   /**
    * factory for the creation of data updates. this abstracts away

--- a/src/backend/apidb/apidb.cpp
+++ b/src/backend/apidb/apidb.cpp
@@ -25,7 +25,8 @@ struct apidb_backend : public backend {
       ("password", po::value<string>(), "database password")
       ("charset", po::value<string>()->default_value("utf8"),
        "database character set")
-      ("readonly", "use the database in read-only mode")
+      ("readonly", "use the read-only backend (default: write backend)")
+      ("disable-api-write", "disable API write operations")
       ("cachesize", po::value<size_t>()->default_value(CACHE_SIZE),
        "maximum size of changeset cache")
       ("dbport", po::value<string>(),

--- a/src/process_request.cpp
+++ b/src/process_request.cpp
@@ -535,7 +535,7 @@ void process_request(request &req, rate_limiter &limiter,
 
       auto data_update = update_factory->make_data_update();
 
-      if (data_update->is_readonly())
+      if (data_update->is_api_write_disabled())
         throw http::bad_request("Server is currently in read only mode, no database changes allowed at this time");
 
       std::string payload = req.get_payload();


### PR DESCRIPTION
See https://github.com/zerebubuth/openstreetmap-cgimap/issues/181#issuecomment-495989666:

A new command line parameter `--disable-write-api` allows disabling API write operations irrespective of the read only/write backend settings. 

Also, the description of the `--readonly` command line parameter has been rephrased to `use the read-only backend (default: write backend)`