### PR TITLE
Added exception logging in osm_responder subclasses

### DIFF
--- a/src/osm_current_responder.cpp
+++ b/src/osm_current_responder.cpp
@@ -1,5 +1,8 @@
 #include "cgimap/config.hpp"
+#include "cgimap/logger.hpp"
 #include "cgimap/osm_current_responder.hpp"
+
+#include <boost/format.hpp>
 
 using std::list;
 using std::shared_ptr;
@@ -43,6 +46,8 @@ void osm_current_responder::write(shared_ptr<output_formatter> formatter,
     fmt.end_element_type(element_type_relation);
 
   } catch (const std::exception &e) {
+    logger::message(boost::format("Caught error in osm_current_responder: %1%") %
+                      e.what());
     fmt.error(e);
   }
 

--- a/src/osm_diffresult_responder.cpp
+++ b/src/osm_diffresult_responder.cpp
@@ -1,7 +1,9 @@
 #include "cgimap/osm_diffresult_responder.hpp"
 #include "cgimap/config.hpp"
+#include "cgimap/logger.hpp"
 
 #include <chrono>
+#include <boost/format.hpp>
 
 using std::list;
 using std::shared_ptr;
@@ -71,6 +73,8 @@ void osm_diffresult_responder::write(shared_ptr<output_formatter> formatter,
     }
 
   } catch (const std::exception &e) {
+    logger::message(boost::format("Caught error in osm_diffresult_responder: %1%") %
+                        e.what());
     fmt.error(e);
   }
 

--- a/src/osmchange_responder.cpp
+++ b/src/osmchange_responder.cpp
@@ -1,7 +1,9 @@
 #include "cgimap/config.hpp"
+#include "cgimap/logger.hpp"
 #include "cgimap/osmchange_responder.hpp"
 
 #include <chrono>
+#include <boost/format.hpp>
 
 using std::list;
 using std::shared_ptr;
@@ -242,6 +244,8 @@ void osmchange_responder::write(
     sorter.write(fmt);
 
   } catch (const std::exception &e) {
+    logger::message(boost::format("Caught error in osmchange_responder: %1%") %
+                          e.what());
     fmt.error(e);
   }
 


### PR DESCRIPTION
Missing database user permissions were only sent to the client as `<error>` tag, leaving no information about such issue in the local log file. From an operations pov, this makes it next to impossible to detect and analyze such issues.

This pull request logs all exceptions during output, which catches database exceptions, but might also log issues about broken client connections. If this too noisy, a more fine granular logging based on exception type can be added in a subsequent PR. 

Fixes #180