### PR TITLE
Fix Basic Auth realm to be in sync with Rails

### DIFF
--- a/src/process_request.cpp
+++ b/src/process_request.cpp
@@ -53,7 +53,7 @@ void respond_401(const http::unauthorized &e, request &r) {
   r.status(e.code());
   r.add_header("Content-Type", "text/plain; charset=utf-8");
   // Header according to RFC 7617, section 2.1
-  r.add_header("WWW-Authenticate", R"(Basic realm="OpenStreetMap login required", charset="UTF-8")");
+  r.add_header("WWW-Authenticate", R"(Basic realm="Web Password", charset="UTF-8")");
   r.add_header("WWW-Authenticate", R"(OAuth realm="OpenStreetMap login required")");
   r.add_header("Content-Length", message_size.str());
   r.add_header("Cache-Control", "no-cache");


### PR DESCRIPTION
We need to use the same Realm as in the Rails API controller (https://github.com/openstreetmap/openstreetmap-website/blob/dbbbd62ef1982e905ceb23f1278e9b4bfdb49d5b/app/controllers/api_controller.rb#L6), because some clients are relying on the correct value.