### PR TITLE
Migrate XML parsers to use SaxHandler

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,13 @@ cgimap_include_HEADERS = \
 	include/cgimap/routes.hpp \
 	include/cgimap/types.hpp \
 	include/cgimap/util.hpp \
-	include/cgimap/zlib.hpp
+	include/cgimap/zlib.hpp \
+	include/parsers/exception.h \
+	include/parsers/internal_error.h \
+ 	include/parsers/parse_error.h \
+	include/parsers/parser.h \
+	include/parsers/saxparser.h \
+	include/parsers/wrapped_exception.h
 
 cgimap_api06_includedir=$(includedir)/cgimap/api06
 cgimap_api06_include_HEADERS = \

--- a/include/cgimap/api06/changeset_upload/changeset_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/changeset_input_format.hpp
@@ -23,7 +23,7 @@ namespace api06 {
 
 
 
-  class ChangesetXMLParser : public xmlpp::SaxParser {
+  class ChangesetXMLParser : private xmlpp::SaxParser {
 
   public:
     explicit ChangesetXMLParser() {}

--- a/include/cgimap/api06/changeset_upload/osmchange_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/osmchange_input_format.hpp
@@ -24,7 +24,7 @@
 
 namespace api06 {
 
-class OSMChangeXMLParser : public xmlpp::SaxParser {
+class OSMChangeXMLParser : private xmlpp::SaxParser {
 
 public:
   explicit OSMChangeXMLParser(Parser_Callback *callback)
@@ -274,22 +274,6 @@ private:
     in_object
   };
 
-  context m_context = context::root;
-  context m_operation_context = context::root;
-  context m_last_context = context::root;
-
-  operation m_operation = operation::op_undefined;
-
-  Parser_Callback *m_callback;
-
-  std::unique_ptr<Node> m_node{};
-  std::unique_ptr<Way> m_way{};
-  std::unique_ptr<Relation> m_relation{};
-
-  bool m_if_unused = false;
-
-
-
   template <typename T>
   static void check_attributes(const char **attrs, T check) {
     if (attrs == NULL)
@@ -386,6 +370,21 @@ private:
 
     o.add_tag(*k, *v);
   }
+
+
+  context m_context = context::root;
+  context m_operation_context = context::root;
+  context m_last_context = context::root;
+
+  operation m_operation = operation::op_undefined;
+
+  Parser_Callback *m_callback;
+
+  std::unique_ptr<Node> m_node{};
+  std::unique_ptr<Way> m_way{};
+  std::unique_ptr<Relation> m_relation{};
+
+  bool m_if_unused = false;
 
 };
 

--- a/include/cgimap/api06/changeset_upload/osmchange_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/osmchange_input_format.hpp
@@ -8,6 +8,8 @@
 #include "cgimap/api06/changeset_upload/way.hpp"
 #include "cgimap/types.hpp"
 
+#include "parsers/saxparser.h"
+
 #include <libxml/parser.h>
 #include <boost/format.hpp>
 
@@ -22,277 +24,31 @@
 
 namespace api06 {
 
-class OSMChangeXMLParser {
+class OSMChangeXMLParser : public xmlpp::SaxParser {
 
-  enum class context {
-    root,
-    top,
-    in_create,
-    in_modify,
-    in_delete,
-    node,
-    way,
-    relation,
-    in_object
-  };
+public:
+  explicit OSMChangeXMLParser(Parser_Callback *callback)
+      : m_callback(callback) {}
 
-  context m_context = context::root;
-  context m_operation_context = context::root;
-  context m_last_context = context::root;
+  OSMChangeXMLParser(const OSMChangeXMLParser &) = delete;
+  OSMChangeXMLParser &operator=(const OSMChangeXMLParser &) = delete;
 
-  operation m_operation = operation::op_undefined;
+  OSMChangeXMLParser(OSMChangeXMLParser &&) = delete;
+  OSMChangeXMLParser &operator=(OSMChangeXMLParser &&) = delete;
 
-  Parser_Callback *m_callback;
+  void process_message(const std::string &data) {
 
-  std::unique_ptr<Node> m_node{};
-  std::unique_ptr<Way> m_way{};
-  std::unique_ptr<Relation> m_relation{};
-
-  bool m_if_unused = false;
-
-  template <typename T> class XMLParser {
-
-    xmlSAXHandler handler{};
-    xmlParserCtxtPtr ctxt{};
-    T *m_callback_object;
-
-    struct user_data_t {
-       T *callback;
-       std::function<std::pair<int, int>(void)> current_location;
-    };
-
-    // Include XML message location information where error occurred in exception
-    template <typename TEx>
-    static void throw_with_context(void *data, TEx& e) {
-      auto location = static_cast<user_data_t *>(data)->current_location();
-
-      // Location unknown
-      if (location.first == 0 && location.second == 0)
-	throw e;
-
-      throw TEx{ (boost::format("%1% at line %2%, column %3%") %
-	  e.what() %
-	  location.first %
-	  location.second )
-	.str() };
-    }
-
-    static void start_element_wrapper(void *data, const xmlChar *element,
-				      const xmlChar **attrs) {
-      try {
-	  static_cast<user_data_t *>(data)->callback->
-	                          start_element((const char *)element,
-						(const char **)attrs);
-      } catch (xml_error& e) {
-	 throw_with_context(data, e);
-      }
-    }
-
-    static void end_element_wrapper(void *data, const xmlChar *element) {
-      try {
-	  static_cast<user_data_t *>(data)->callback->
-	                             end_element((const char *)element);
-      } catch (xml_error& e) {
-	 throw_with_context(data, e);
-      }
-    }
-
-    static void warning(void *, const char *, ...) {}
-
-    static void error(void *, const char *fmt, ...) {
-      char buffer[1024];
-      va_list arg_ptr;
-      va_start(arg_ptr, fmt);
-      vsnprintf(buffer, sizeof(buffer) - 1, fmt, arg_ptr);
-      va_end(arg_ptr);
-      throw http::bad_request((boost::format("XML Error: %1%") % buffer).str());
-    }
-
-    // Don't load any external entities provided in the XML document
-    static xmlParserInputPtr xmlCustomExternalEntityLoader(const char *,
-                                                           const char *,
-                                                           xmlParserCtxtPtr) {
-      throw xml_error{ "XML external entities not supported" };
-    }
-
-  public:
-    explicit XMLParser(T *callback_object)
-        : m_callback_object(callback_object) {
-
-      xmlInitParser();
-
-      xmlSetExternalEntityLoader(xmlCustomExternalEntityLoader);
-
-      memset(&handler, 0, sizeof(handler));
-      handler.initialized = XML_SAX2_MAGIC;
-      handler.startElement = &start_element_wrapper;
-      handler.endElement = &end_element_wrapper;
-      handler.warning = &warning;
-      handler.error = &error;
-    }
-
-    XMLParser(const XMLParser &) = delete;
-    XMLParser(XMLParser &&) = delete;
-
-    XMLParser &operator=(const XMLParser &) = delete;
-    XMLParser &operator=(XMLParser &&) = delete;
-
-    ~XMLParser() noexcept {
-      xmlFreeParserCtxt(ctxt);
-      xmlCleanupParser();
-    }
-
-    void operator()(const std::string &data) {
-
-      const size_t MAX_CHUNKSIZE = 131072;
-
-      if (data.size() < 4)
-        throw http::bad_request("Invalid XML input");
-
-      user_data_t user_data;
-      user_data.callback = m_callback_object;
-      user_data.current_location = std::bind(&XMLParser::get_current_location, this);
-
-      // provide first 4 characters of data string, according to
-      // http://xmlsoft.org/library.html
-      ctxt = xmlCreatePushParserCtxt(&handler, &user_data, data.c_str(),
-                                     4, NULL);
-      if (ctxt == NULL)
-        throw std::runtime_error("Could not create parser context!");
-
-      // removed XML_PARSE_RECOVER : the use of XML_PARSE_RECOVER in libxml2
-      // is discouraged in production  code as it hides errors in invalid XML
-      // and exercises some less-tested code paths in libxml2.
-      // Source: https://mail.gnome.org/archives/xml/2018-January/msg00016.html
-      xmlCtxtUseOptions(ctxt, XML_PARSE_NONET | XML_PARSE_NOENT);
-
-      unsigned int offset = 4;
-
-      while (offset < data.size()) {
-
-        unsigned int current_chunksize =
-            std::min(data.size() - offset, MAX_CHUNKSIZE);
-
-        if (xmlParseChunk(ctxt, data.c_str() + offset, current_chunksize, 0)) {
-          xmlErrorPtr err = xmlGetLastError();
-          throw http::bad_request(
-              (boost::format("XML ERROR: %1%.") % err->message).str());
-        }
-
-        offset += current_chunksize;
-      }
-
-      xmlParseChunk(ctxt, 0, 0, 1);
-    }
-
-  private:
-
-    std::pair<int, int> get_current_location() {
-      if (ctxt->input == nullptr)
-	return {};
-      return { ctxt->input->line, ctxt->input->col };
-    }
-
-  }; // class XMLParser
-
-  template <typename T>
-  static void check_attributes(const char **attrs, T check) {
-    if (attrs == NULL)
-      return;
-
-    while (*attrs) {
-      check(attrs[0], attrs[1]);
-      attrs += 2;
+    try {
+      parse_memory(data);
+    } catch (const xmlpp::exception& e) {
+      throw http::bad_request(e.what());    // rethrow XML parser error as HTTP 400 Bad request
     }
   }
 
-  void init_object(OSMObject &object, const char **attrs) {
 
-    check_attributes(attrs, [&object](const char *name, const char *value) {
+protected:
 
-      if (!std::strcmp(name, "id")) {
-        object.set_id(value);
-      } else if (!std::strcmp(name, "changeset")) {
-        object.set_changeset(value);
-      } else if (!std::strcmp(name, "version")) {
-        object.set_version(value);
-      } // don't parse any other attributes here
-    });
-
-    if (!object.has_id()) {
-	throw xml_error{ "Mandatory field id missing in object" };
-    }
-
-    if (!object.has_changeset()) {
-      throw xml_error{ (boost::format("Changeset id is missing for %1%") %
-                        object.to_string())
-                           .str() };
-    }
-
-    if (m_operation == operation::op_create) {
-      // we always override version number for create operations (they are not
-      // mandatory)
-      object.set_version(0u);
-    } else if (m_operation == operation::op_delete ||
-               m_operation == operation::op_modify) {
-      // objects for other operations must have a positive version number
-      if (!object.has_version()) {
-        throw xml_error{ (boost::format(
-                              "Version is required when updating %1%") %
-                          object.to_string())
-                             .str() };
-      }
-      if (object.version() < 1) {
-        throw xml_error{ (boost::format("Invalid version number %1% in %2%") %
-                          object.version() % object.to_string())
-                             .str() };
-      }
-    }
-  }
-
-  void init_node(Node &node, const char **attrs) {
-    check_attributes(attrs, [&node](const char *name, const char *value) {
-
-      if (!std::strcmp(name, "lon")) {
-        node.set_lon(value);
-      } else if (!std::strcmp(name, "lat")) {
-        node.set_lat(value);
-      }
-    });
-  }
-
-  void add_tag(OSMObject &o, const char **attrs) {
-
-    boost::optional<std::string> k;
-    boost::optional<std::string> v;
-
-    check_attributes(attrs, [&k, &v](const char *name, const char *value) {
-
-      if (name[0] == 'k' && name[1] == 0) {
-        k = value;
-      } else if (name[0] == 'v' && name[1] == 0) {
-        v = value;
-      }
-    });
-
-    if (!k)
-      throw xml_error{
-        (boost::format("Mandatory field k missing in tag element for %1%") %
-         o.to_string())
-            .str()
-      };
-
-    if (!v)
-      throw xml_error{
-        (boost::format("Mandatory field v missing in tag element for %1%") %
-         o.to_string())
-            .str()
-      };
-
-    o.add_tag(*k, *v);
-  }
-
-  void start_element(const char *element, const char **attrs) {
+  void on_start_element(const char *element, const char **attrs) override {
 
     switch (m_context) {
     case context::root:
@@ -424,7 +180,7 @@ class OSMChangeXMLParser {
     }
   }
 
-  void end_element(const char *element) {
+  void on_end_element(const char *element) override {
 
     switch (m_context) {
     case context::root:
@@ -501,22 +257,136 @@ class OSMChangeXMLParser {
     }
   }
 
-public:
-  explicit OSMChangeXMLParser(Parser_Callback *callback)
-      : m_callback(callback) {}
 
-  OSMChangeXMLParser(const OSMChangeXMLParser &) = delete;
-  OSMChangeXMLParser &operator=(const OSMChangeXMLParser &) = delete;
 
-  OSMChangeXMLParser(OSMChangeXMLParser &&) = delete;
-  OSMChangeXMLParser &operator=(OSMChangeXMLParser &&) = delete;
+private:
 
-  void process_message(const std::string &data) {
 
-    XMLParser<OSMChangeXMLParser> parser{ this };
+  enum class context {
+    root,
+    top,
+    in_create,
+    in_modify,
+    in_delete,
+    node,
+    way,
+    relation,
+    in_object
+  };
 
-    parser(data);
+  context m_context = context::root;
+  context m_operation_context = context::root;
+  context m_last_context = context::root;
+
+  operation m_operation = operation::op_undefined;
+
+  Parser_Callback *m_callback;
+
+  std::unique_ptr<Node> m_node{};
+  std::unique_ptr<Way> m_way{};
+  std::unique_ptr<Relation> m_relation{};
+
+  bool m_if_unused = false;
+
+
+
+  template <typename T>
+  static void check_attributes(const char **attrs, T check) {
+    if (attrs == NULL)
+      return;
+
+    while (*attrs) {
+      check(attrs[0], attrs[1]);
+      attrs += 2;
+    }
   }
+
+  void init_object(OSMObject &object, const char **attrs) {
+
+    check_attributes(attrs, [&object](const char *name, const char *value) {
+
+      if (!std::strcmp(name, "id")) {
+        object.set_id(value);
+      } else if (!std::strcmp(name, "changeset")) {
+        object.set_changeset(value);
+      } else if (!std::strcmp(name, "version")) {
+        object.set_version(value);
+      } // don't parse any other attributes here
+    });
+
+    if (!object.has_id()) {
+	throw xml_error{ "Mandatory field id missing in object" };
+    }
+
+    if (!object.has_changeset()) {
+      throw xml_error{ (boost::format("Changeset id is missing for %1%") %
+                        object.to_string())
+                           .str() };
+    }
+
+    if (m_operation == operation::op_create) {
+      // we always override version number for create operations (they are not
+      // mandatory)
+      object.set_version(0u);
+    } else if (m_operation == operation::op_delete ||
+               m_operation == operation::op_modify) {
+      // objects for other operations must have a positive version number
+      if (!object.has_version()) {
+        throw xml_error{ (boost::format(
+                              "Version is required when updating %1%") %
+                          object.to_string())
+                             .str() };
+      }
+      if (object.version() < 1) {
+        throw xml_error{ (boost::format("Invalid version number %1% in %2%") %
+                          object.version() % object.to_string())
+                             .str() };
+      }
+    }
+  }
+
+  void init_node(Node &node, const char **attrs) {
+    check_attributes(attrs, [&node](const char *name, const char *value) {
+
+      if (!std::strcmp(name, "lon")) {
+        node.set_lon(value);
+      } else if (!std::strcmp(name, "lat")) {
+        node.set_lat(value);
+      }
+    });
+  }
+
+  void add_tag(OSMObject &o, const char **attrs) {
+
+    boost::optional<std::string> k;
+    boost::optional<std::string> v;
+
+    check_attributes(attrs, [&k, &v](const char *name, const char *value) {
+
+      if (name[0] == 'k' && name[1] == 0) {
+        k = value;
+      } else if (name[0] == 'v' && name[1] == 0) {
+        v = value;
+      }
+    });
+
+    if (!k)
+      throw xml_error{
+        (boost::format("Mandatory field k missing in tag element for %1%") %
+         o.to_string())
+            .str()
+      };
+
+    if (!v)
+      throw xml_error{
+        (boost::format("Mandatory field v missing in tag element for %1%") %
+         o.to_string())
+            .str()
+      };
+
+    o.add_tag(*k, *v);
+  }
+
 };
 
 } // namespace api06

--- a/include/parsers/exception.h
+++ b/include/parsers/exception.h
@@ -1,0 +1,98 @@
+/* exception.h
+ *
+ * Copyright (C) 2002 The libxml++ development team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef __LIBXMLPP_EXCEPTION_H
+#define __LIBXMLPP_EXCEPTION_H
+
+#include <exception>
+#include <cstdarg> // va_list
+#include <string>
+
+
+extern "C" {
+  struct _xmlError;
+  struct _xmlParserCtxt;
+}
+
+namespace xmlpp
+{
+
+/** Base class for all xmlpp exceptions.
+ */
+class exception : public std::exception
+{
+public:
+  explicit exception(const std::string& message);
+  ~exception() noexcept override;
+
+  const char* what() const noexcept override;
+
+  virtual void raise() const;
+  virtual exception* clone() const;
+
+private:
+  std::string message_;
+};
+
+/** Format an _xmlError struct into a text string, suitable for printing.
+ *
+ * @newin{2,36}
+ *
+ * @param error Pointer to an _xmlError struct or <tt>nullptr</tt>.
+ *              If <tt>nullptr</tt>, the error returned by xmlGetLastError() is used.
+ * @returns A formatted text string. If the error struct does not contain an
+ *          error (error->code == XML_ERR_OK), an empty string is returned.
+ */
+std::string format_xml_error(const _xmlError* error = nullptr);
+
+/** Format a parser error into a text string, suitable for printing.
+ *
+ * @newin{2,36}
+ *
+ * @param parser_context Pointer to an _xmlParserCtxt struct.
+ * @returns A formatted text string. If the parser context does not contain an
+ *          error (parser_context->lastError.code == XML_ERR_OK), an empty
+ *          string is returned.
+ */
+std::string format_xml_parser_error(const _xmlParserCtxt* parser_context);
+
+/** Format a message from a function with C-style variadic parameters.
+ *
+ * Helper function that formats a message supplied in the form of a printf-style
+ * format specification and zero or more ... parameters.
+ *
+ * @code
+ * // Typical call:
+ * void f(const char* fmt, ...)
+ * {
+ *   va_list args;
+ *   va_start(args, fmt);
+ *   std::string msg = xmlpp::format_printf_message(fmt, args);
+ *   va_end(args);
+ *   // ...
+ * }
+ * @endcode
+ *
+ * @newin{3,0}
+ */
+std::string format_printf_message(const char* fmt, va_list args);
+
+} // namespace xmlpp
+
+#endif // __LIBXMLPP_EXCEPTION_H

--- a/include/parsers/internal_error.h
+++ b/include/parsers/internal_error.h
@@ -1,0 +1,41 @@
+/* internal_error.h
+ *
+ * Copyright (C) 2002 The libxml++ development team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef __LIBXMLPP_INTERNAL_ERROR_H
+#define __LIBXMLPP_INTERNAL_ERROR_H
+
+#include <string>
+
+#include "exception.h"
+
+namespace xmlpp {
+
+class internal_error : public exception
+{
+public:
+  explicit internal_error(const std::string& message);
+  ~internal_error() noexcept override;
+
+  void raise() const override;
+  exception* clone() const override;
+};
+
+} // namespace xmlpp
+
+#endif // __LIBXMLPP_INTERNAL_ERROR_H

--- a/include/parsers/parse_error.h
+++ b/include/parsers/parse_error.h
@@ -1,0 +1,42 @@
+/* parse_error.h
+ *
+ * Copyright (C) 2002 The libxml++ development team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef __LIBXMLPP_PARSE_ERROR_H
+#define __LIBXMLPP_PARSE_ERROR_H
+
+#include "exception.h"
+
+namespace xmlpp
+{
+
+/** This exception will be thrown when the parser encounters an error in the XML document.
+ */
+class parse_error : public exception
+{
+public:
+  explicit parse_error(const std::string& message);
+  ~parse_error() noexcept override;
+
+  void raise() const override;
+  exception* clone() const override;
+};
+
+} // namespace xmlpp
+
+#endif // __LIBXMLPP_PARSE_ERROR_H

--- a/include/parsers/parser.h
+++ b/include/parsers/parser.h
@@ -30,7 +30,7 @@ class Parser
 {
 public:
   Parser();
-  ~Parser();
+  virtual ~Parser();
 
   Parser( const Parser& ) = delete;
   Parser& operator=( const Parser& ) = delete;
@@ -112,8 +112,6 @@ public:
    * @param in The stream.
    */
   virtual void parse_stream(std::istream& in) = 0;
-
-  //TODO: Add stop_parser()/stop_parsing(), wrapping xmlStopParser()?
 
 protected:
   virtual void initialize_context();

--- a/include/parsers/parser.h
+++ b/include/parsers/parser.h
@@ -1,0 +1,164 @@
+/* parser.h
+ * libxml++ and this file are copyright (C) 2000 by Ari Johnson, and
+ * are covered by the GNU Lesser General Public License, which should be
+ * included with libxml++ as the file COPYING.
+ */
+
+#ifndef __LIBXMLPP_PARSER_H
+#define __LIBXMLPP_PARSER_H
+
+#include "exception.h"
+#include "internal_error.h"
+
+#include <string>
+#include <istream>
+#include <cstdarg> // va_list
+#include <memory> // std::unique_ptr
+
+
+extern "C" {
+  struct _xmlParserCtxt;
+}
+
+namespace xmlpp {
+
+/** XML parser.
+ *
+ * Abstract base class for DOM parser and SAX parser.
+ */
+class Parser
+{
+public:
+  Parser();
+  ~Parser();
+
+  Parser( const Parser& ) = delete;
+  Parser& operator=( const Parser& ) = delete;
+
+  using size_type = unsigned int;
+
+
+  /** Set whether the parser will collect and throw error and warning messages.
+   *
+   * If messages are collected, they are included in an exception thrown at the
+   * end of parsing.
+   *
+   * - SAX parser
+   *
+   *   If the messages are not collected, the error handling on_*() methods in
+   *   the user's SAX parser subclass are called. This is the default, if
+   *   set_throw_messages() is not called.
+   *
+   * @newin{2,36}
+   *
+   * @param val Whether messages will be collected and thrown in an exception.
+   */
+  void set_throw_messages(bool val = true) noexcept;
+
+  /** See set_throw_messages().
+   *
+   * @newin{2,36}
+   *
+   * @returns Whether messages will be collected and thrown in an exception.
+   */
+  bool get_throw_messages() const noexcept;
+
+
+  /** Set and/or clear parser option flags.
+   * See the libxml2 documentation, enum xmlParserOption, for a list of parser options.
+   * This method overrides other methods that set parser options, such as set_validate(),
+   * set_substitute_entities() and set_include_default_attributes(). Use set_parser_options()
+   * only if no other method can set the parser options you want.
+   *
+   * @newin{2,38}
+   *
+   * @param set_options Set bits correspond to flags that shall be set during parsing.
+   * @param clear_options Set bits correspond to flags that shall be cleared during parsing.
+   *        Bits that are set in neither @a set_options nor @a clear_options are not affected.
+   */
+  void set_parser_options(int set_options = 0, int clear_options = 0) noexcept;
+
+  /** See set_parser_options().
+   *
+   * @newin{2,38}
+   *
+   * @param[out] set_options Set bits correspond to flags that shall be set during parsing.
+   * @param[out] clear_options Set bits correspond to flags that shall be cleared during parsing.
+   *        Bits that are set in neither @a set_options nor @a clear_options are not affected.
+   */
+  void get_parser_options(int& set_options, int& clear_options) const noexcept;
+
+  /** Parse an XML document from a file.
+   * @throw exception
+   * @param filename The path to the file.
+   */
+  virtual void parse_file(const std::string& filename) = 0;
+
+  /** Parse an XML document from raw memory.
+   * @throw exception
+   * @param contents The XML document as an array of bytes.
+   * @param bytes_count The number of bytes in the @a contents array.
+   */
+  virtual void parse_memory_raw(const unsigned char* contents, size_type bytes_count) = 0;
+
+  /** Parse an XML document from a string.
+   * @throw exception
+   * @param contents The XML document as a string.
+   */
+  virtual void parse_memory(const std::string& contents) = 0;
+
+  /** Parse an XML document from a stream.
+   * @throw exception
+   * @param in The stream.
+   */
+  virtual void parse_stream(std::istream& in) = 0;
+
+  //TODO: Add stop_parser()/stop_parsing(), wrapping xmlStopParser()?
+
+protected:
+  virtual void initialize_context();
+  virtual void release_underlying();
+
+  virtual void on_parser_error(const std::string& message);
+  virtual void on_parser_warning(const std::string& message);
+
+  /// To be called in an exception handler.
+  virtual void handle_exception();
+  virtual void check_for_exception();
+
+  virtual void check_for_error_and_warning_messages();
+
+  static void callback_parser_error(void* ctx, const char* msg, ...);
+  static void callback_parser_warning(void* ctx, const char* msg, ...);
+
+  enum class MsgType
+  {
+    ParserError,
+    ParserWarning
+  };
+
+  static void callback_error_or_warning(MsgType msg_type, void* ctx,
+                                        const char* msg, va_list var_args);
+
+  _xmlParserCtxt* context_;
+  std::unique_ptr<exception> exception_;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> pimpl_;
+};
+
+/** Equivalent to Parser::parse_stream().
+ *
+ * @newin{2,38}
+ */
+inline std::istream& operator>>(std::istream& in, Parser& parser)
+{
+  parser.parse_stream(in);
+  return in;
+}
+
+} // namespace xmlpp
+
+#endif //__LIBXMLPP_PARSER_H
+

--- a/include/parsers/saxparser.h
+++ b/include/parsers/saxparser.h
@@ -26,18 +26,13 @@ namespace xmlpp {
 /** SAX XML parser.
  * Derive your own class and override the on_*() methods.
  * SAX = Simple API for XML
- *
- * In a system that does not support std::exception_ptr: If an overridden on_*()
- * method throws an exception which is not derived from xmlpp::exception,
- * that exception is replaced by a xmlpp::exception before it is propagated
- * out of the parse method, such as parse_file().
  */
 class SaxParser : public Parser
 {
 public:
 
   SaxParser();
-  ~SaxParser();
+  virtual ~SaxParser();
 
   /** Parse an XML document from a file.
    * @param filename The path to the file.
@@ -120,8 +115,8 @@ public:
 protected:
   virtual void on_start_document();
   virtual void on_end_document();
-  virtual void on_start_element(const xmlChar* name, const xmlChar** p);
-  virtual void on_end_element(const xmlChar* name);
+  virtual void on_start_element(const char* name, const char** p);
+  virtual void on_end_element(const char* name);
   virtual void on_warning(const std::string& text);
   virtual void on_error(const std::string& text);
 

--- a/include/parsers/saxparser.h
+++ b/include/parsers/saxparser.h
@@ -1,0 +1,145 @@
+/* saxparser.h
+ * libxml++ and this file are copyright (C) 2000 by Ari Johnson, and
+ * are covered by the GNU Lesser General Public License, which should be
+ * included with libxml++ as the file COPYING.
+ */
+
+#ifndef __LIBXMLPP_PARSERS_SAXPARSER_H
+#define __LIBXMLPP_PARSERS_SAXPARSER_H
+
+#include "parsers/parser.h"
+#include "parsers/wrapped_exception.h"
+#include "parsers/parse_error.h"
+
+#include <memory>
+
+#include <libxml/parser.h>
+
+extern "C" {
+  struct _xmlSAXHandler;
+  struct _xmlEntity;
+}
+
+
+namespace xmlpp {
+
+/** SAX XML parser.
+ * Derive your own class and override the on_*() methods.
+ * SAX = Simple API for XML
+ *
+ * In a system that does not support std::exception_ptr: If an overridden on_*()
+ * method throws an exception which is not derived from xmlpp::exception,
+ * that exception is replaced by a xmlpp::exception before it is propagated
+ * out of the parse method, such as parse_file().
+ */
+class SaxParser : public Parser
+{
+public:
+
+  SaxParser();
+  ~SaxParser();
+
+  /** Parse an XML document from a file.
+   * @param filename The path to the file.
+   * @throws xmlpp::internal_error
+   * @throws xmlpp::parse_error
+   * @throws xmlpp::validity_error
+   */
+  void parse_file(const std::string& filename) override;
+
+  /** Parse an XML document from a string.
+   * @param contents The XML document as a string.
+   * @throws xmlpp::internal_error
+   * @throws xmlpp::parse_error
+   * @throws xmlpp::validity_error
+   */
+  void parse_memory(const std::string& contents) override;
+
+  /** Parse an XML document from raw memory.
+   * @param contents The XML document as an array of bytes.
+   * @param bytes_count The number of bytes in the @a contents array.
+   * @throws xmlpp::internal_error
+   * @throws xmlpp::parse_error
+   * @throws xmlpp::validity_error
+   */
+  void parse_memory_raw(const unsigned char* contents, size_type bytes_count) override;
+
+  /** Parse an XML document from a stream.
+   * @param in The stream.
+   * @throws xmlpp::internal_error
+   * @throws xmlpp::parse_error
+   * @throws xmlpp::validity_error
+   */
+  void parse_stream(std::istream& in) override;
+
+  /** Parse a chunk of data.
+   *
+   * This lets you pass a document in small chunks, e.g. from a network
+   * connection. The on_* virtual functions are called each time the chunks
+   * provide enough information to advance the parser.
+   *
+   * The first call to parse_chunk() will setup the parser. When the last chunk
+   * has been parsed, call finish_chunk_parsing() to finish the parse.
+   *
+   * @param chunk The next piece of the XML document.
+   * @throws xmlpp::internal_error
+   * @throws xmlpp::parse_error
+   * @throws xmlpp::validity_error
+   */
+  void parse_chunk(const std::string& chunk);
+
+  /** Parse a chunk of data.
+   *
+   * @newin{2,24}
+   *
+   * This lets you pass a document in small chunks, e.g. from a network
+   * connection. The on_* virtual functions are called each time the chunks
+   * provide enough information to advance the parser.
+   *
+   * The first call to parse_chunk_raw() will setup the parser. When the last chunk
+   * has been parsed, call finish_chunk_parsing() to finish the parse.
+   *
+   * @param contents The next piece of the XML document as an array of bytes.
+   * @param bytes_count The number of bytes in the @a contents array.
+   * @throws xmlpp::internal_error
+   * @throws xmlpp::parse_error
+   * @throws xmlpp::validity_error
+   */
+  void parse_chunk_raw(const unsigned char* contents, size_type bytes_count);
+
+  /** Finish a chunk-wise parse.
+   *
+   * Call this after the last call to parse_chunk() or parse_chunk_raw().
+   * Don't use this function with the other parsing methods.
+   * @throws xmlpp::internal_error
+   * @throws xmlpp::parse_error
+   * @throws xmlpp::validity_error
+   */
+  void finish_chunk_parsing();
+
+protected:
+  virtual void on_start_document();
+  virtual void on_end_document();
+  virtual void on_start_element(const xmlChar* name, const xmlChar** p);
+  virtual void on_end_element(const xmlChar* name);
+  virtual void on_warning(const std::string& text);
+  virtual void on_error(const std::string& text);
+
+  /** @throws xmlpp::parse_error
+   */
+  virtual void on_fatal_error(const std::string& text);
+
+  void release_underlying() override;
+  void initialize_context() override;
+
+private:
+  void parse();
+
+  std::unique_ptr<_xmlSAXHandler> sax_handler_;
+
+  friend struct SaxParserCallback;
+};
+
+} // namespace xmlpp
+
+#endif //__LIBXMLPP_PARSERS_SAXPARSER_H

--- a/include/parsers/wrapped_exception.h
+++ b/include/parsers/wrapped_exception.h
@@ -1,0 +1,50 @@
+/* Copyright (C) 2015  The libxml++ development team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef __LIBXMLPP_WRAPPED_EXCEPTION_H
+#define __LIBXMLPP_WRAPPED_EXCEPTION_H
+
+#include <exception>
+
+#include "exception.h"
+
+
+namespace xmlpp
+{
+
+/** Helper class for propagating an exception through C code.
+ * Should not be used by applications.
+ * Does not exist in systems that don't support std::exception_ptr.
+ *
+ * @newin{2,40}
+ */
+class wrapped_exception : public exception
+{
+public:
+  explicit wrapped_exception(std::exception_ptr exception_ptr);
+  ~wrapped_exception() noexcept override;
+
+  void raise() const override;
+  exception* clone() const override;
+
+private:
+  std::exception_ptr exception_ptr_;
+};
+
+} // namespace xmlpp
+
+#endif // __LIBXMLPP_WRAPPED_EXCEPTION_H

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -160,6 +160,14 @@ libcgimap_core_la_SOURCES=\
 libcgimap_core_la_LIBADD=@LIBXML_LIBS@ @YAJL_LIBS@ @LIBMEMCACHED_LIBS@ @BOOST_PROGRAM_OPTIONS_LIB@ @BOOST_FILESYSTEM_LIB@ @BOOST_SYSTEM_LIB@ @BOOST_LOCALE_LIB@  @CRYPTOPP_LIBS@
 
 libcgimap_core_la_SOURCES+=\
+	parsers/exception.cc \
+	parsers/internal_error.cc \
+	parsers/parse_error.cc \
+	parsers/parser.cc \
+	parsers/saxparser.cc \
+	parsers/wrapped_exception.cc
+
+libcgimap_core_la_SOURCES+=\
 	api06/changeset_close_handler.cpp \
 	api06/changeset_create_handler.cpp \
 	api06/changeset_download_handler.cpp \

--- a/src/parsers/exception.cc
+++ b/src/parsers/exception.cc
@@ -1,0 +1,125 @@
+#include "parsers/exception.h"
+#include <libxml/xmlerror.h>
+#include <libxml/parser.h>
+#include <cstdio>
+#include <vector>
+
+namespace xmlpp {
+
+exception::exception(const std::string& message)
+: message_(message)
+{
+}
+
+exception::~exception() noexcept
+{}
+
+const char* exception::what() const noexcept
+{
+  return message_.c_str();
+}
+
+void exception::raise() const
+{
+  throw *this;
+}
+
+exception* exception::clone() const
+{
+  return new exception(*this);
+}
+
+std::string format_xml_error(const _xmlError* error)
+{
+  if (!error)
+    error = xmlGetLastError();
+
+  if (!error || error->code == XML_ERR_OK)
+    return ""; // No error
+
+  std::string str;
+
+  if (error->file && *error->file != '\0')
+  {
+    str += "File ";
+    str += error->file;
+  }
+
+  if (error->line > 0)
+  {
+    str += (str.empty() ? "Line " : ", line ") + std::to_string(error->line);
+    if (error->int2 > 0)
+      str += ", column " + std::to_string(error->int2);
+  }
+
+  const bool two_lines = !str.empty();
+  if (two_lines)
+    str += ' ';
+
+  switch (error->level)
+  {
+    case XML_ERR_WARNING:
+      str += "(warning):";
+      break;
+    case XML_ERR_ERROR:
+      str += "(error):";
+      break;
+    case XML_ERR_FATAL:
+      str += "(fatal):";
+      break;
+    default:
+      str += "():";
+      break;
+  }
+
+  str += two_lines ? '\n' : ' ';
+
+  if (error->message && *error->message != '\0')
+    str += error->message;
+  else
+    str += "Error code " + std::to_string(error->code);
+
+  // If the string does not end with end-of-line, append an end-of-line.
+  if (*str.rbegin() != '\n')
+    str += '\n';
+
+  return str;
+}
+
+std::string format_xml_parser_error(const _xmlParserCtxt* parser_context)
+{
+  if (!parser_context)
+    return "Error. xmlpp::format_xml_parser_error() called with parser_context == nullptr\n";
+
+  const auto error = xmlCtxtGetLastError(const_cast<_xmlParserCtxt*>(parser_context));
+
+  if (!error)
+    return ""; // No error
+
+  std::string str;
+
+  if (!parser_context->wellFormed)
+    str += "Document not well-formed.\n";
+
+  return str + format_xml_error(error);
+}
+
+std::string format_printf_message(const char* fmt, va_list args)
+{
+  // This code was inspired by the example at
+  // http://en.cppreference.com/w/cpp/io/c/vfprintf
+  va_list args2;
+  va_copy(args2, args);
+  // Number of characters (bytes) in the resulting string;
+  // error, if < 0.
+  const int nchar = std::vsnprintf(nullptr, 0, fmt, args2);
+  va_end(args2);
+  if (nchar < 0)
+   return std::string("Error code from std::vsnprintf = " + std::to_string(nchar));
+
+  std::vector<char> buf(nchar+1);
+  std::vsnprintf(buf.data(), buf.size(), fmt, args);
+  return std::string(buf.data());
+}
+
+} //namespace xmlpp

--- a/src/parsers/internal_error.cc
+++ b/src/parsers/internal_error.cc
@@ -1,0 +1,23 @@
+#include "parsers/internal_error.h"
+
+namespace xmlpp {
+
+internal_error::internal_error(const std::string& message)
+: exception(message)
+{
+}
+
+internal_error::~internal_error() noexcept
+{}
+
+void internal_error::raise() const
+{
+  throw *this;
+}
+
+exception* internal_error::clone() const
+{
+  return new internal_error(*this);
+}
+
+} //namespace xmlpp

--- a/src/parsers/parse_error.cc
+++ b/src/parsers/parse_error.cc
@@ -1,0 +1,23 @@
+#include "parsers/parse_error.h"
+
+namespace xmlpp {
+
+parse_error::parse_error(const std::string& message)
+: exception(message)
+{
+}
+
+parse_error::~parse_error() noexcept
+{}
+
+void parse_error::raise() const
+{
+  throw *this;
+}
+
+exception* parse_error::clone() const
+{
+  return new parse_error(*this);
+}
+
+} //namespace xmlpp

--- a/src/parsers/parser.cc
+++ b/src/parsers/parser.cc
@@ -1,0 +1,253 @@
+/* parser.cc
+ * libxml++ and this file are copyright (C) 2000 by Ari Johnson, and
+ * are covered by the GNU Lesser General Public License, which should be
+ * included with libxml++ as the file COPYING.
+ */
+
+#include "parsers/wrapped_exception.h"
+#include "parsers/parse_error.h"
+#include "parsers/parser.h"
+
+#include <libxml/parser.h>
+
+namespace xmlpp
+{
+
+struct Parser::Impl
+{
+  Impl()
+  :
+  throw_messages_(true), set_options_(0), clear_options_(0)
+  {}
+
+  // Built gradually - used in an exception at the end of parsing.
+  std::string parser_error_;
+  std::string parser_warning_;
+
+
+  bool throw_messages_;
+  int set_options_;
+  int clear_options_;
+};
+
+Parser::Parser()
+: context_(nullptr), exception_(nullptr), pimpl_(new Impl)
+{
+}
+
+Parser::~Parser()
+{
+  release_underlying();
+}
+
+
+
+void Parser::set_throw_messages(bool val) noexcept
+{
+  pimpl_->throw_messages_ = val;
+}
+
+bool Parser::get_throw_messages() const noexcept
+{
+  return pimpl_->throw_messages_;
+}
+
+void Parser::set_parser_options(int set_options, int clear_options) noexcept
+{
+  pimpl_->set_options_ = set_options;
+  pimpl_->clear_options_ = clear_options;
+}
+
+void Parser::get_parser_options(int& set_options, int& clear_options) const noexcept
+{
+  set_options = pimpl_->set_options_;
+  clear_options = pimpl_->clear_options_;
+}
+
+void Parser::initialize_context()
+{
+  //Clear these temporary buffers:
+  pimpl_->parser_error_.erase();
+  pimpl_->parser_warning_.erase();
+
+
+  //Disactivate any non-standards-compliant libxml1 features.
+  //These are disactivated by default, but if we don't deactivate them for each context
+  //then some other code which uses a global function, such as xmlKeepBlanksDefault(),
+  // could cause this to use the wrong settings:
+  context_->linenumbers = 1; // TRUE - This is the default anyway.
+
+  //Turn on/off validation, entity substitution and default attribute inclusion.
+  int options = context_->options;
+
+  options &= ~XML_PARSE_DTDVALID;
+  options &= ~XML_PARSE_NOENT;
+
+  options &= ~XML_PARSE_DTDATTR;
+
+  //Turn on/off any parser options.
+  options |= pimpl_->set_options_;
+  options &= ~pimpl_->clear_options_;
+
+  xmlCtxtUseOptions(context_, options);
+
+  if (context_->sax && pimpl_->throw_messages_)
+  {
+    //Tell the parser context about the callbacks.
+    context_->sax->fatalError = &callback_parser_error;
+    context_->sax->error = &callback_parser_error;
+    context_->sax->warning = &callback_parser_warning;
+  }
+
+  //Allow callback_error_or_warning() to retrieve the C++ instance:
+  context_->_private = this;
+}
+
+void Parser::release_underlying()
+{
+  if(context_)
+  {
+    context_->_private = nullptr; //Not really necessary.
+
+    if( context_->myDoc != nullptr )
+    {
+      xmlFreeDoc(context_->myDoc);
+    }
+
+    xmlFreeParserCtxt(context_);
+    context_ = nullptr;
+  }
+}
+
+void Parser::on_parser_error(const std::string& message)
+{
+  //Throw an exception later when the whole message has been received:
+  pimpl_->parser_error_ += message;
+}
+
+void Parser::on_parser_warning(const std::string& message)
+{
+  //Throw an exception later when the whole message has been received:
+  pimpl_->parser_warning_ += message;
+}
+
+void Parser::check_for_error_and_warning_messages()
+{
+  std::string msg(exception_ ? exception_->what() : "");
+  bool parser_msg = false;
+  bool validity_msg = false;
+
+  if (!pimpl_->parser_error_.empty())
+  {
+    parser_msg = true;
+    msg += "\nParser error:\n" + pimpl_->parser_error_;
+    pimpl_->parser_error_.erase();
+  }
+
+  if (!pimpl_->parser_warning_.empty())
+  {
+    parser_msg = true;
+    msg += "\nParser warning:\n" + pimpl_->parser_warning_;
+    pimpl_->parser_warning_.erase();
+  }
+
+  if (parser_msg)
+    exception_.reset(new parse_error(msg));
+}
+
+//static
+void Parser::callback_parser_error(void* ctx, const char* msg, ...)
+{
+  va_list var_args;
+  va_start(var_args, msg);
+  callback_error_or_warning(MsgType::ParserError, ctx, msg, var_args);
+  va_end(var_args);
+}
+
+//static
+void Parser::callback_parser_warning(void* ctx, const char* msg, ...)
+{
+  va_list var_args;
+  va_start(var_args, msg);
+  callback_error_or_warning(MsgType::ParserWarning, ctx, msg, var_args);
+  va_end(var_args);
+}
+
+
+//static
+void Parser::callback_error_or_warning(MsgType msg_type, void* ctx,
+                                       const char* msg, va_list var_args)
+{
+  //See xmlHTMLValidityError() in xmllint.c in libxml for more about this:
+
+  auto context = (xmlParserCtxtPtr)ctx;
+  if(context)
+  {
+    auto parser = static_cast<Parser*>(context->_private);
+    if(parser)
+    {
+      auto ubuff = format_xml_error(&context->lastError);
+      if (ubuff.empty())
+      {
+        // Usually the result of formatting var_args with the format string msg
+        // is the same string as is stored in context->lastError.message.
+        // It's unnecessary to use msg and var_args, if format_xml_error()
+        // returns an error message (as it usually does).
+
+        //Convert the ... to a string:
+        ubuff = format_printf_message(msg, var_args);
+      }
+
+      try
+      {
+        switch (msg_type)
+        {
+          case MsgType::ParserError:
+            parser->on_parser_error(ubuff);
+            break;
+          case MsgType::ParserWarning:
+            parser->on_parser_warning(ubuff);
+            break;
+        }
+      }
+      catch (...)
+      {
+        parser->handle_exception();
+      }
+    }
+  }
+}
+
+void Parser::handle_exception()
+{
+  try
+  {
+    throw; // Re-throw current exception
+  }
+  catch (const exception& e)
+  {
+    exception_.reset(e.clone());
+  }
+  catch (...)
+  {
+    exception_.reset(new wrapped_exception(std::current_exception()));
+  }
+
+  if (context_)
+    xmlStopParser(context_);
+
+  //release_underlying();
+}
+
+void Parser::check_for_exception()
+{
+  check_for_error_and_warning_messages();
+
+  if (exception_)
+  {
+    std::unique_ptr<exception> tmp(std::move(exception_));
+    tmp->raise();
+  }
+}
+
+} // namespace xmlpp

--- a/src/parsers/parser.cc
+++ b/src/parsers/parser.cc
@@ -70,9 +70,8 @@ void Parser::initialize_context()
   pimpl_->parser_error_.erase();
   pimpl_->parser_warning_.erase();
 
-
   //Disactivate any non-standards-compliant libxml1 features.
-  //These are disactivated by default, but if we don't deactivate them for each context
+  //These are deactivated by default, but if we don't deactivate them for each context
   //then some other code which uses a global function, such as xmlKeepBlanksDefault(),
   // could cause this to use the wrong settings:
   context_->linenumbers = 1; // TRUE - This is the default anyway.
@@ -81,9 +80,9 @@ void Parser::initialize_context()
   int options = context_->options;
 
   options &= ~XML_PARSE_DTDVALID;
-  options &= ~XML_PARSE_NOENT;
-
   options &= ~XML_PARSE_DTDATTR;
+
+  options |= XML_PARSE_NONET | XML_PARSE_NOENT;
 
   //Turn on/off any parser options.
   options |= pimpl_->set_options_;
@@ -108,11 +107,6 @@ void Parser::release_underlying()
   if(context_)
   {
     context_->_private = nullptr; //Not really necessary.
-
-    if( context_->myDoc != nullptr )
-    {
-      xmlFreeDoc(context_->myDoc);
-    }
 
     xmlFreeParserCtxt(context_);
     context_ = nullptr;

--- a/src/parsers/saxparser.cc
+++ b/src/parsers/saxparser.cc
@@ -196,7 +196,6 @@ void SaxParser::parse_stream(std::istream& in)
 
   initialize_context();
 
-  // std::string or Glib::ustring?
   // Output from the XML parser is UTF-8 encoded.
   // But the istream "in" is input, i.e. an XML file. It can use any encoding.
   // If it's not UTF-8, the file itself must contain information about which

--- a/src/parsers/saxparser.cc
+++ b/src/parsers/saxparser.cc
@@ -1,0 +1,465 @@
+/* saxparser.cc
+ * libxml++ and this file are copyright (C) 2000 by Ari Johnson, and
+ * are covered by the GNU Lesser General Public License, which should be
+ * included with libxml++ as the file COPYING.
+ *
+ * 2002/01/05 Valentin Rusu - fixed some potential buffer overruns
+ * 2002/01/21 Valentin Rusu - added CDATA handlers
+ */
+
+
+#include "parsers/saxparser.h"
+
+#include <libxml/parser.h>
+#include <libxml/parserInternals.h> // for xmlCreateFileParserCtxt
+
+#include <cstdarg> //For va_list.
+#include <iostream>
+
+namespace xmlpp {
+
+struct SaxParserCallback
+{
+  static void start_document(void* context);
+  static void end_document(void* context);
+  static void start_element(void* context, const xmlChar* name, const xmlChar** p);
+  static void end_element(void* context, const xmlChar* name);
+  static void warning(void* context, const char* fmt, ...);
+  static void error(void* context, const char* fmt, ...);
+  static void fatal_error(void* context, const char* fmt, ...);
+};
+
+
+
+SaxParser::SaxParser()
+  : sax_handler_(new _xmlSAXHandler)
+{
+  xmlSAXHandler temp = {
+    nullptr, // internal_subset,
+    nullptr, // isStandalone
+    nullptr, // hasInternalSubset
+    nullptr, // hasExternalSubset
+    nullptr, // resolveEntity
+    nullptr, // getEntity
+    nullptr, // entityDecl
+    nullptr, // notationDecl
+    nullptr, // attributeDecl
+    nullptr, // elementDecl
+    nullptr, // unparsedEntityDecl
+    nullptr, // setDocumentLocator
+    SaxParserCallback::start_document, // startDocument
+    SaxParserCallback::end_document, // endDocument
+    SaxParserCallback::start_element, // startElement
+    SaxParserCallback::end_element, // endElement
+    nullptr, // reference
+    nullptr, // characters
+    nullptr, // ignorableWhitespace
+    nullptr, // processingInstruction
+    nullptr, // comment
+    SaxParserCallback::warning,  // warning
+    SaxParserCallback::error,  // error
+    SaxParserCallback::fatal_error, // fatalError
+    nullptr, // getParameterEntity
+    nullptr, // cdataBlock
+    nullptr, // externalSubset
+    0,       // initialized
+    nullptr, // private
+    nullptr, // startElementNs
+    nullptr, // endElementNs
+    nullptr, // serror
+  };
+  *sax_handler_ = temp;
+
+  // The default action is to call on_warning(), on_error(), on_fatal_error().
+  set_throw_messages(false);
+}
+
+SaxParser::~SaxParser()
+{
+  release_underlying();
+}
+
+
+void SaxParser::on_start_document()
+{
+}
+
+void SaxParser::on_end_document()
+{
+}
+
+
+void SaxParser::on_start_element(const xmlChar* name,
+                                 const xmlChar** p)
+{
+}
+
+void SaxParser::on_end_element(const xmlChar* name)
+{
+}
+
+
+void SaxParser::on_warning(const std::string& /* text */)
+{
+}
+
+void SaxParser::on_error(const std::string& /* text */)
+{
+}
+
+
+void SaxParser::on_fatal_error(const std::string& text)
+{
+  throw parse_error("Fatal error: " + text);
+}
+
+// implementation of this function is inspired by the SAX documentation by James Henstridge.
+// (http://www.daa.com.au/~james/gnome/xml-sax/implementing.html)
+void SaxParser::parse()
+{
+  if(!context_)
+  {
+    throw internal_error("Parser context not created.");
+  }
+
+  auto old_sax = context_->sax;
+  context_->sax = sax_handler_.get();
+
+  xmlResetLastError();
+  initialize_context();
+
+  const int parseError = xmlParseDocument(context_);
+
+  context_->sax = old_sax;
+
+  auto error_str = format_xml_parser_error(context_);
+  if (error_str.empty() && parseError == -1)
+    error_str = "xmlParseDocument() failed.";
+
+  release_underlying(); // Free context_
+
+  check_for_exception();
+
+  if(!error_str.empty())
+  {
+    throw parse_error(error_str);
+  }
+}
+
+void SaxParser::parse_file(const std::string& filename)
+{
+  if(context_)
+  {
+    throw parse_error("Attempt to start a second parse while a parse is in progress.");
+  }
+
+  context_ = xmlCreateFileParserCtxt(filename.c_str());
+  parse();
+}
+
+void SaxParser::parse_memory_raw(const unsigned char* contents, size_type bytes_count)
+{
+  if(context_)
+  {
+    throw parse_error("Attempt to start a second parse while a parse is in progress.");
+  }
+
+  context_ = xmlCreateMemoryParserCtxt((const char*)contents, bytes_count);
+  parse();
+}
+
+void SaxParser::parse_memory(const std::string& contents)
+{
+  parse_memory_raw((const unsigned char*)contents.c_str(), contents.size());
+}
+
+void SaxParser::parse_stream(std::istream& in)
+{
+  if(context_)
+  {
+    throw parse_error("Attempt to start a second parse while a parse is in progress.");
+  }
+
+  xmlResetLastError();
+
+  context_ = xmlCreatePushParserCtxt(
+      sax_handler_.get(),
+      nullptr,  // user_data
+      nullptr,  // chunk
+      0,        // size
+      nullptr); // no filename for fetching external entities
+
+  if(!context_)
+  {
+    throw internal_error("Could not create parser context\n" + format_xml_error());
+  }
+
+  initialize_context();
+
+  // std::string or Glib::ustring?
+  // Output from the XML parser is UTF-8 encoded.
+  // But the istream "in" is input, i.e. an XML file. It can use any encoding.
+  // If it's not UTF-8, the file itself must contain information about which
+  // encoding it uses. See the XML specification. Thus use std::string.
+  int firstParseError = XML_ERR_OK;
+  std::string line;
+  while (!exception_ && std::getline(in, line))
+  {
+    // since getline does not get the line separator, we have to add it since the parser care
+    // about layout in certain cases.
+    line += '\n';
+
+    const int parseError = xmlParseChunk(context_, line.c_str(),
+      line.size() /* This is a std::string, not a ustring, so this is the number of bytes. */,
+      0 /* don't terminate */);
+
+    // Save the first error code if any, but read on.
+    // More errors might be reported and then thrown by check_for_exception().
+    if (parseError != XML_ERR_OK && firstParseError == XML_ERR_OK)
+      firstParseError = parseError;
+  }
+
+  if (!exception_)
+  {
+     //This is called just to terminate parsing.
+    const int parseError = xmlParseChunk(context_, nullptr /* chunk */, 0 /* size */, 1 /* terminate (1 or 0) */);
+
+    if (parseError != XML_ERR_OK && firstParseError == XML_ERR_OK)
+      firstParseError = parseError;
+  }
+
+  auto error_str = format_xml_parser_error(context_);
+  if (error_str.empty() && firstParseError != XML_ERR_OK)
+    error_str = "Error code from xmlParseChunk(): " + std::to_string(firstParseError);
+
+  release_underlying(); // Free context_
+
+  check_for_exception();
+
+  if(!error_str.empty())
+  {
+    throw parse_error(error_str);
+  }
+}
+
+void SaxParser::parse_chunk(const std::string& chunk)
+{
+  parse_chunk_raw((const unsigned char*)chunk.c_str(), chunk.length());
+}
+
+void SaxParser::parse_chunk_raw(const unsigned char* contents, size_type bytes_count)
+{
+  xmlResetLastError();
+
+  if(!context_)
+  {
+    context_ = xmlCreatePushParserCtxt(
+      sax_handler_.get(),
+      nullptr,  // user_data
+      nullptr,  // chunk
+      0,        // size
+      nullptr); // no filename for fetching external entities
+
+    if(!context_)
+    {
+      throw internal_error("Could not create parser context\n" + format_xml_error());
+    }
+    initialize_context();
+  }
+  else
+    xmlCtxtResetLastError(context_);
+
+  int parseError = XML_ERR_OK;
+  if (!exception_)
+    parseError = xmlParseChunk(context_, (const char*)contents, bytes_count, 0 /* don't terminate */);
+
+  check_for_exception();
+
+  auto error_str = format_xml_parser_error(context_);
+  if (error_str.empty() && parseError != XML_ERR_OK)
+    error_str = "Error code from xmlParseChunk(): " + std::to_string(parseError);
+  if(!error_str.empty())
+  {
+    throw parse_error(error_str);
+  }
+}
+
+void SaxParser::finish_chunk_parsing()
+{
+  xmlResetLastError();
+  if(!context_)
+  {
+    context_ = xmlCreatePushParserCtxt(
+      sax_handler_.get(),
+      nullptr,  // user_data
+      nullptr,  // chunk
+      0,        // size
+      nullptr); // no filename for fetching external entities
+
+    if(!context_)
+    {
+      throw internal_error("Could not create parser context\n" + format_xml_error());
+    }
+    initialize_context();
+  }
+  else
+    xmlCtxtResetLastError(context_);
+
+  int parseError = XML_ERR_OK;
+  if (!exception_)
+    //This is called just to terminate parsing.
+    parseError = xmlParseChunk(context_, nullptr /* chunk */, 0 /* size */, 1 /* terminate (1 or 0) */);
+
+  auto error_str = format_xml_parser_error(context_);
+  if (error_str.empty() && parseError != XML_ERR_OK)
+    error_str = "Error code from xmlParseChunk(): " + std::to_string(parseError);
+
+  release_underlying(); // Free context_
+
+  check_for_exception();
+
+  if(!error_str.empty())
+  {
+    throw parse_error(error_str);
+  }
+}
+
+void SaxParser::release_underlying()
+{
+  Parser::release_underlying();
+}
+
+void SaxParser::initialize_context()
+{
+  Parser::initialize_context();
+}
+
+void SaxParserCallback::start_document(void* context)
+{
+  auto the_context = static_cast<_xmlParserCtxt*>(context);
+  auto parser = static_cast<SaxParser*>(the_context->_private);
+
+  try
+  {
+    parser->on_start_document();
+  }
+  catch (...)
+  {
+    parser->handle_exception();
+  }
+}
+
+void SaxParserCallback::end_document(void* context)
+{
+  auto the_context = static_cast<_xmlParserCtxt*>(context);
+  auto parser = static_cast<SaxParser*>(the_context->_private);
+
+  if (parser->exception_)
+    return;
+
+  try
+  {
+    parser->on_end_document();
+  }
+  catch (...)
+  {
+    parser->handle_exception();
+  }
+}
+
+void SaxParserCallback::start_element(void* context,
+                                        const xmlChar* name,
+                                        const xmlChar** p)
+{
+  auto the_context = static_cast<_xmlParserCtxt*>(context);
+  auto parser = static_cast<SaxParser*>(the_context->_private);
+
+  try
+  {
+    parser->on_start_element(name, p);
+  }
+  catch (...)
+  {
+    parser->handle_exception();
+  }
+}
+
+void SaxParserCallback::end_element(void* context, const xmlChar* name)
+{
+  auto the_context = static_cast<_xmlParserCtxt*>(context);
+  auto parser = static_cast<SaxParser*>(the_context->_private);
+
+  try
+  {
+    parser->on_end_element(name);
+  }
+  catch (...)
+  {
+    parser->handle_exception();
+  }
+}
+
+void SaxParserCallback::warning(void* context, const char* fmt, ...)
+{
+  auto the_context = static_cast<_xmlParserCtxt*>(context);
+  auto parser = static_cast<SaxParser*>(the_context->_private);
+
+  va_list arg;
+  va_start(arg, fmt);
+  const std::string buff = format_printf_message(fmt, arg);
+  va_end(arg);
+
+  try
+  {
+    parser->on_warning(buff);
+  }
+  catch (...)
+  {
+    parser->handle_exception();
+  }
+}
+
+void SaxParserCallback::error(void* context, const char* fmt, ...)
+{
+  auto the_context = static_cast<_xmlParserCtxt*>(context);
+  auto parser = static_cast<SaxParser*>(the_context->_private);
+
+  if (parser->exception_)
+    return;
+
+  va_list arg;
+  va_start(arg, fmt);
+  const std::string buff = format_printf_message(fmt, arg);
+  va_end(arg);
+
+  try
+  {
+    parser->on_error(buff);
+  }
+  catch (...)
+  {
+    parser->handle_exception();
+  }
+}
+
+void SaxParserCallback::fatal_error(void* context, const char* fmt, ...)
+{
+  auto the_context = static_cast<_xmlParserCtxt*>(context);
+  auto parser = static_cast<SaxParser*>(the_context->_private);
+
+  va_list arg;
+  va_start(arg, fmt);
+  const std::string buff = format_printf_message(fmt, arg);
+  va_end(arg);
+
+  try
+  {
+    parser->on_fatal_error(buff);
+  }
+  catch (...)
+  {
+    parser->handle_exception();
+  }
+}
+
+} // namespace xmlpp

--- a/src/parsers/saxparser.cc
+++ b/src/parsers/saxparser.cc
@@ -89,12 +89,12 @@ void SaxParser::on_end_document()
 }
 
 
-void SaxParser::on_start_element(const xmlChar* name,
-                                 const xmlChar** p)
+void SaxParser::on_start_element(const char* name,
+                                 const char** p)
 {
 }
 
-void SaxParser::on_end_element(const xmlChar* name)
+void SaxParser::on_end_element(const char* name)
 {
 }
 
@@ -376,7 +376,7 @@ void SaxParserCallback::start_element(void* context,
 
   try
   {
-    parser->on_start_element(name, p);
+    parser->on_start_element(reinterpret_cast<const char *>(name), reinterpret_cast<const char **>(p));
   }
   catch (...)
   {
@@ -391,7 +391,7 @@ void SaxParserCallback::end_element(void* context, const xmlChar* name)
 
   try
   {
-    parser->on_end_element(name);
+    parser->on_end_element(reinterpret_cast<const char *>(name));
   }
   catch (...)
   {

--- a/src/parsers/wrapped_exception.cc
+++ b/src/parsers/wrapped_exception.cc
@@ -1,0 +1,42 @@
+/* Copyright (C) 2015  The libxml++ development team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "parsers/wrapped_exception.h"
+
+namespace xmlpp
+{
+
+wrapped_exception::wrapped_exception(std::exception_ptr exception_ptr)
+  : exception("Wrapped exception"), exception_ptr_(exception_ptr)
+{
+}
+
+wrapped_exception::~wrapped_exception() noexcept
+{
+}
+
+void wrapped_exception::raise() const
+{
+  std::rethrow_exception(exception_ptr_);
+}
+
+exception* wrapped_exception::clone() const
+{
+  return new wrapped_exception(exception_ptr_);
+}
+
+} // namespace xmlpp

--- a/src/process_request.cpp
+++ b/src/process_request.cpp
@@ -128,13 +128,17 @@ void respond_error(const http::exception &e, request &r) {
 
   } else {
     std::string message(e.what());
+
+    std::string message_error_header = message;
+    std::replace(message_error_header.begin(), message_error_header.end(), '\n', ' ');   // replace newline by space (newlines screw up HTTP header)
+
     std::ostringstream message_size;
     message_size << message.size();
 
     r.status(e.code())
       .add_header("Content-Type", "text/plain")
       .add_header("Content-Length", message_size.str())
-      .add_header("Error", message)
+      .add_header("Error", message_error_header)
       .add_header("Cache-Control", "no-cache")
       .put(message);   // output the message as well
   }


### PR DESCRIPTION
- Lots of technical details when dealing with libxml are now hidden in a SAX parsing framework
- Better error handling
- No additional external dependencies. Small parts covering SAX parsing have been extracted from libxml++ and heavily adapted to cover the bare minimum required.

Closes #208