### PR TITLE
Vagrant fix

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-apt-get update;
-
 apt-get install -y git build-essential automake autoconf libtool;
 
 apt-get install -y libxml2-dev libpqxx-dev libfcgi-dev \

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+apt-get update;
+
 apt-get install -y git build-essential automake autoconf libtool;
 
 apt-get install -y libxml2-dev libpqxx-dev libfcgi-dev \

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -308,11 +308,6 @@ handler_ptr_t route_resource(request &req, const string &path,
   // split the URL into bits to be matched.
   list<string> path_components;
   al::split(path_components, resource.first, al::is_any_of("/"));
-  // remove empty trailing components to allow for "/api/0.6/changeset/create/"
-  // like the rails port instead on only allowing  "/api/0.6/changeset/create"
-  // which fails on the out of the box rails port
-  if (path_components.rbegin()->compare("") == 0)
-    path_components.pop_back();
 
   handler_ptr_t hptr(r->match(path_components, req));
 


### PR DESCRIPTION
Refs #215 
Update `apt-get` before installing anything so that `libpqxx-dev`, `libboost-regex-dev`, `libboost-date-time-dev`, `libboost-filesystem-dev`, `libboost-system-dev`, `libboost-locale-dev`, and `libcrypto++-dev` are available to install.
