### PR TITLE
Use MIME type application/xml for better Rails compatibility

### DIFF
--- a/include/cgimap/mime_types.hpp
+++ b/include/cgimap/mime_types.hpp
@@ -11,7 +11,7 @@ namespace mime {
 enum type {
   unspecified_type, // a "null" type, used to indicate no choice.
   text_plain,
-  text_xml,
+  application_xml,
 #ifdef HAVE_YAJL
   application_json,
 #endif

--- a/src/api06/changeset_update_handler.cpp
+++ b/src/api06/changeset_update_handler.cpp
@@ -56,7 +56,7 @@ changeset_update_responder::~changeset_update_responder() = default;
 changeset_update_sel_responder::~changeset_update_sel_responder() = default;
 
 changeset_update_handler::changeset_update_handler(request &req, osm_changeset_id_t id_)
-    : payload_enabled_handler(mime::text_xml,
+    : payload_enabled_handler(mime::application_xml,
                               http::method::PUT | http::method::OPTIONS),
       id(id_) {}
 

--- a/src/choose_formatter.cpp
+++ b/src/choose_formatter.cpp
@@ -118,7 +118,8 @@ struct http_accept_grammar
 };
 /*
       = lit("* / *")      [_val = mime::any_type]
-      | lit("text/xml") [_val = mime::text_xml]
+      | lit("text/xml") [_val = mime::application_xml]
+      | lit("application/xml") [_val = mime::application_xml]
 #ifdef HAVE_YAJL
       | lit("application/json")[_val = mime::application_json]
 #endif
@@ -262,7 +263,7 @@ shared_ptr<output_formatter> create_formatter(request &req,
                                               shared_ptr<output_buffer> out) {
   shared_ptr<output_formatter> o_formatter;
 
-  if (best_type == mime::text_xml) {
+  if (best_type == mime::application_xml) {
     auto *xwriter = new xml_writer(out, true);
     o_formatter = shared_ptr<output_formatter>(new xml_formatter(xwriter));
 

--- a/src/mime_types.cpp
+++ b/src/mime_types.cpp
@@ -11,8 +11,8 @@ string to_string(type t) {
     return "*/*";
   } else if (text_plain == t) {
     return "text/plain";
-  } else if (text_xml == t) {
-    return "text/xml";
+  } else if (application_xml == t) {
+    return "application/xml";
 #ifdef HAVE_YAJL
   } else if (application_json == t) {
     return "application/json";
@@ -33,8 +33,10 @@ type parse_from(const std::string &name) {
     t = any_type;
   } else if (name == "text/plain") {
     t = text_plain;
-  } else if (name == "text/xml") {
-    t = text_xml;
+  } else if (name == "text/xml") {     // alias according to RFC 7303, section 9.2
+    t = application_xml;
+  } else if (name == "application/xml") {
+    t = application_xml;
 #ifdef HAVE_YAJL
   } else if (name == "application/json") {
     t = application_json;

--- a/src/osm_responder.cpp
+++ b/src/osm_responder.cpp
@@ -11,7 +11,7 @@ osm_responder::~osm_responder() = default;
 
 list<mime::type> osm_responder::types_available() const {
   list<mime::type> types;
-  types.push_back(mime::text_xml);
+  types.push_back(mime::application_xml);
 #ifdef HAVE_YAJL
   types.push_back(mime::application_json);
 #endif

--- a/src/osmchange_responder.cpp
+++ b/src/osmchange_responder.cpp
@@ -222,7 +222,7 @@ osmchange_responder::~osmchange_responder() = default;
 
 list<mime::type> osmchange_responder::types_available() const {
   list<mime::type> types;
-  types.push_back(mime::text_xml);
+  types.push_back(mime::application_xml);
   return types;
 }
 

--- a/src/process_request.cpp
+++ b/src/process_request.cpp
@@ -116,7 +116,7 @@ void respond_error(const http::exception &e, request &r) {
 
   if (error_format && al::iequals(error_format, "xml")) {
     r.status(200)
-     .add_header("Content-Type", "text/xml; charset=utf-8");
+     .add_header("Content-Type", "application/xml; charset=utf-8");
 
     ostringstream ostr;
     ostr << "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n"

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -275,7 +275,7 @@ routes::~routes() = default;
 namespace {
 /**
  * figures out the mime type from the path specification, e.g: a resource ending
- * in .xml should be text/xml, .json should be application/json, etc...
+ * in .xml should be application/xml, .json should be application/json, etc...
  */
   pair<string, mime::type> resource_mime_type(const string &path) {
 
@@ -293,7 +293,7 @@ namespace {
       std::size_t xml_found = path.rfind(".xml");
 
       if (xml_found != string::npos && xml_found == path.length() - 4) {
-	  return make_pair(path.substr(0, xml_found), mime::text_xml);
+	  return make_pair(path.substr(0, xml_found), mime::application_xml);
       }
     }
 

--- a/src/xml_formatter.cpp
+++ b/src/xml_formatter.cpp
@@ -32,7 +32,7 @@ xml_formatter::xml_formatter(xml_writer *w) : writer(w) {}
 
 xml_formatter::~xml_formatter() = default;
 
-mime::type xml_formatter::mime_type() const { return mime::text_xml; }
+mime::type xml_formatter::mime_type() const { return mime::application_xml; }
 
 void xml_formatter::start_document(
   const std::string &generator, const std::string &root_name) {

--- a/test/anon.testcore/single_node.case
+++ b/test/anon.testcore/single_node.case
@@ -5,7 +5,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=-0.0005,-0.0005,0.0005,0.0005
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Disposition: attachment; filename="map.osm"
 Status: 200 OK
 ---

--- a/test/changesets.testcore/download.case
+++ b/test/changesets.testcore/download.case
@@ -3,7 +3,7 @@ Request-URI: /api/0.6/changeset/1/download
 Date: 2017-02-20T15:22:00Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/changesets.testcore/download_changeset_2.case
+++ b/test/changesets.testcore/download_changeset_2.case
@@ -3,7 +3,7 @@ Request-URI: /api/0.6/changeset/3/download
 Date: 2017-03-13T09:54:00Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/changesets.testcore/download_changeset_4.case
+++ b/test/changesets.testcore/download_changeset_4.case
@@ -5,7 +5,7 @@ Request-URI: /api/0.6/changeset/4/download
 Date: 2017-03-13T09:54:00Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/changesets.testcore/download_changeset_rel10.case
+++ b/test/changesets.testcore/download_changeset_rel10.case
@@ -3,7 +3,7 @@ Request-URI: /api/0.6/changeset/10/download
 Date: 2017-03-13T16:27:00Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/changesets.testcore/download_changeset_sort11.case
+++ b/test/changesets.testcore/download_changeset_sort11.case
@@ -5,7 +5,7 @@ Request-URI: /api/0.6/changeset/11/download
 Date: 2017-03-13T16:32:00Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/changesets.testcore/download_changeset_way6.case
+++ b/test/changesets.testcore/download_changeset_way6.case
@@ -3,7 +3,7 @@ Request-URI: /api/0.6/changeset/6/download
 Date: 2017-03-13T15:43:00Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/changesets.testcore/download_changeset_way7.case
+++ b/test/changesets.testcore/download_changeset_way7.case
@@ -3,7 +3,7 @@ Request-URI: /api/0.6/changeset/7/download
 Date: 2017-03-13T15:44:00Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/changesets.testcore/download_changeset_way9.case
+++ b/test/changesets.testcore/download_changeset_way9.case
@@ -3,7 +3,7 @@ Request-URI: /api/0.6/changeset/9/download
 Date: 2017-03-13T16:12:00Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/changesets.testcore/empty.case
+++ b/test/changesets.testcore/empty.case
@@ -4,7 +4,7 @@ Request-URI: /api/0.6/changeset/2/download
 Date: 2017-03-13T16:58:00Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***"/>

--- a/test/changesets.testcore/read.case
+++ b/test/changesets.testcore/read.case
@@ -4,7 +4,7 @@ HTTP-X-Error-Format: xml
 Date: 2015-08-09T11:33:13Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/changesets.testcore/read_discussion.case
+++ b/test/changesets.testcore/read_discussion.case
@@ -4,7 +4,7 @@ HTTP-X-Error-Format: xml
 Date: 2015-08-09T11:33:13Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/changesets.testcore/read_nonpublic.case
+++ b/test/changesets.testcore/read_nonpublic.case
@@ -4,7 +4,7 @@ HTTP-X-Error-Format: xml
 Date: 2015-09-05T20:17:10Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/changesets.testcore/read_open.case
+++ b/test/changesets.testcore/read_open.case
@@ -4,7 +4,7 @@ HTTP-X-Error-Format: xml
 Date: 2015-08-09T10:33:13Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/empty.testcore/accept_any.case
+++ b/test/empty.testcore/accept_any.case
@@ -2,7 +2,7 @@ Request-Method: GET
 Request-URI: /api/0.6/map?bbox=0,0,0,0
 HTTP-Accept: *
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Disposition: attachment; filename="map.osm"
 Status: 200 OK
 ---

--- a/test/empty.testcore/accept_any_any.case
+++ b/test/empty.testcore/accept_any_any.case
@@ -2,7 +2,7 @@ Request-Method: GET
 Request-URI: /api/0.6/map?bbox=0,0,0,0
 HTTP-Accept: */*
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Disposition: attachment; filename="map.osm"
 Status: 200 OK
 ---

--- a/test/empty.testcore/accept_application_xml.case
+++ b/test/empty.testcore/accept_application_xml.case
@@ -1,5 +1,6 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=0,0,0,0
+HTTP-Accept: application/xml
 ---
 Content-Type: application/xml; charset=utf-8
 Content-Disposition: attachment; filename="map.osm"

--- a/test/empty.testcore/accept_josm_nonsense.case
+++ b/test/empty.testcore/accept_josm_nonsense.case
@@ -4,7 +4,7 @@ Request-Method: GET
 Request-URI: /api/0.6/map?bbox=0,0,0,0
 HTTP-Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Disposition: attachment; filename="map.osm"
 Status: 200 OK
 ---

--- a/test/empty.testcore/accept_text_any.case
+++ b/test/empty.testcore/accept_text_any.case
@@ -2,7 +2,7 @@ Request-Method: GET
 Request-URI: /api/0.6/map?bbox=0,0,0,0
 HTTP-Accept: text/*
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Disposition: attachment; filename="map.osm"
 Status: 200 OK
 ---

--- a/test/empty.testcore/accept_text_xml.case
+++ b/test/empty.testcore/accept_text_xml.case
@@ -2,7 +2,7 @@ Request-Method: GET
 Request-URI: /api/0.6/map?bbox=0,0,0,0
 HTTP-Accept: text/xml
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Disposition: attachment; filename="map.osm"
 Status: 200 OK
 ---

--- a/test/empty.testcore/http_origin.case
+++ b/test/empty.testcore/http_origin.case
@@ -3,7 +3,7 @@ Request-URI: /api/0.6/map?bbox=0,0,0,0
 HTTP-Accept: *
 HTTP-Origin: http://localhost
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Disposition: attachment; filename="map.osm"
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Methods: GET, HEAD, OPTIONS

--- a/test/map.testcore/empty_response.case
+++ b/test/map.testcore/empty_response.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=-0.01,-0.01,-0.0005,-0.0005
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Disposition: attachment; filename="map.osm"
 Status: 200 OK
 ---

--- a/test/map.testcore/multiple_node.case
+++ b/test/map.testcore/multiple_node.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=-0.0005,-0.0005,0.0015,0.0015
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Disposition: attachment; filename="map.osm"
 Status: 200 OK
 ---

--- a/test/map.testcore/single_node.case
+++ b/test/map.testcore/single_node.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=-0.0005,-0.0005,0.0005,0.0005
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Disposition: attachment; filename="map.osm"
 Status: 200 OK
 ---

--- a/test/map.testcore/used_node.case
+++ b/test/map.testcore/used_node.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=0.2995,-0.0005,0.3005,0.3005
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Disposition: attachment; filename="map.osm"
 Status: 200 OK
 ---

--- a/test/map.testcore/used_way.case
+++ b/test/map.testcore/used_way.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/map?bbox=0.1995,-0.0005,0.2005,0.3005
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Disposition: attachment; filename="map.osm"
 Status: 200 OK
 ---

--- a/test/message.testcore/map_400_xml.case
+++ b/test/message.testcore/map_400_xml.case
@@ -3,7 +3,7 @@ Request-URI: /api/0.6/map
 HTTP-X-Error-Format: xml
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 ---
 <?xml version="1.0" encoding="utf-8" ?>
 <osmError>

--- a/test/node.testcore/large_id_1.case
+++ b/test/node.testcore/large_id_1.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/node/8589934592
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/node.testcore/large_id_2.case
+++ b/test/node.testcore/large_id_2.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/node/9223372036854775807
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/node.testcore/node_1.case
+++ b/test/node.testcore/node_1.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/node/1
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/node.testcore/node_2.case
+++ b/test/node.testcore/node_2.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/node/2
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/node.testcore/node_history.case
+++ b/test/node.testcore/node_history.case
@@ -3,7 +3,7 @@ Request-Method: GET
 Request-URI: /api/0.6/node/3/history
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/node.testcore/node_version.case
+++ b/test/node.testcore/node_version.case
@@ -3,7 +3,7 @@ Request-Method: GET
 Request-URI: /api/0.6/node/3/1
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/node.testcore/node_version_deleted.case
+++ b/test/node.testcore/node_version_deleted.case
@@ -3,7 +3,7 @@ Request-Method: GET
 Request-URI: /api/0.6/node/3/2
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/node.testcore/nodes.case
+++ b/test/node.testcore/nodes.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/nodes?nodes=1,2,3
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/node.testcore/nodes_dup.case
+++ b/test/node.testcore/nodes_dup.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/nodes?nodes=1,1,1
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/node.testcore/nodes_dup2.case
+++ b/test/node.testcore/nodes_dup2.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/nodes?nodes=1,2,2,3
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/node.testcore/nodes_history.case
+++ b/test/node.testcore/nodes_history.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/nodes?nodes=3v1,3
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/node.testcore/nodes_history_dup.case
+++ b/test/node.testcore/nodes_history_dup.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/nodes?nodes=3v2,3
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/node_relations.testcore/node_1.case
+++ b/test/node_relations.testcore/node_1.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/node/1/relations
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/node_relations.testcore/node_2.case
+++ b/test/node_relations.testcore/node_2.case
@@ -3,7 +3,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/node/2/relations
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/node_ways.testcore/node_1.case
+++ b/test/node_ways.testcore/node_1.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/node/1/ways
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/node_ways.testcore/node_2.case
+++ b/test/node_ways.testcore/node_2.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/node/2/ways
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/node_ways.testcore/node_4.case
+++ b/test/node_ways.testcore/node_4.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/node/4/ways
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/node_ways.testcore/node_5.case
+++ b/test/node_ways.testcore/node_5.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/node/5/ways
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/redactions.testcore/changeset_download.case
+++ b/test/redactions.testcore/changeset_download.case
@@ -5,7 +5,7 @@ Request-URI: /api/0.6/changeset/2/download
 Date: 2017-03-13T16:47:00Z
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***"/>

--- a/test/redactions.testcore/changeset_download_moderator.case
+++ b/test/redactions.testcore/changeset_download_moderator.case
@@ -7,7 +7,7 @@ Date: 2017-03-13T16:47:00Z
 Http-Authorization: OAuth realm="http://cgimap.example.com/api/0.6/changeset/2/download", oauth_consumer_key="heqfjrcolc", oauth_token="scgncknxqr", oauth_nonce="dqndteqmzduesxyjetrd", oauth_timestamp="1489423620", oauth_signature_method="HMAC-SHA1", oauth_version="1.0", oauth_signature="2KQpmh%2FAJi9xTpZvCIo82inmdho%3D"
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 ---
 <osmChange version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/redactions.testcore/node_history.case
+++ b/test/redactions.testcore/node_history.case
@@ -4,7 +4,7 @@ Request-Method: GET
 Request-URI: /api/0.6/node/1/history?show_redactions=true
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/redactions.testcore/node_history_moderator.case
+++ b/test/redactions.testcore/node_history_moderator.case
@@ -6,7 +6,7 @@ Date: 2017-02-03T17:11:00Z
 Http-Authorization: OAuth realm="http://cgimap.example.com/api/0.6/node/1/history", oauth_consumer_key="heqfjrcolc", oauth_token="scgncknxqr", oauth_nonce="ylxApRr7uw94cVGRwxbx", oauth_timestamp="1486141860", oauth_signature_method="HMAC-SHA1", oauth_version="1.0", oauth_signature="IcgPfe%2F4C4Rh5HlnZQg388bn5Fo%3D"
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/redactions.testcore/node_version_moderator.case
+++ b/test/redactions.testcore/node_version_moderator.case
@@ -6,7 +6,7 @@ Date: 2017-01-23T20:25:00Z
 Http-Authorization: OAuth realm="http://cgimap.example.com/api/0.6/node/1/2", oauth_consumer_key="heqfjrcolc", oauth_token="scgncknxqr", oauth_nonce="ykvbwrcver", oauth_timestamp="1485203100", oauth_signature_method="HMAC-SHA1", oauth_version="1.0", oauth_signature="NzUgxE%2B%2BueNwfnHtbLyJBTxdVus%3D"
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <?xml version="1.0"?>

--- a/test/redactions.testcore/nodes_moderator.case
+++ b/test/redactions.testcore/nodes_moderator.case
@@ -6,7 +6,7 @@ Date: 2017-02-03T17:22:00Z
 Http-Authorization: OAuth realm="http://cgimap.example.com/api/0.6/nodes", oauth_consumer_key="heqfjrcolc", oauth_token="scgncknxqr", oauth_nonce="X1VcT5srCUFk7NMbDBBi", oauth_timestamp="1486142520", oauth_signature_method="HMAC-SHA1", oauth_version="1.0", oauth_signature="LanUZRlaRV7uJYaXgTJ30Mqog3M%3D"
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/redactions.testcore/relation_history.case
+++ b/test/redactions.testcore/relation_history.case
@@ -4,7 +4,7 @@ Request-Method: GET
 Request-URI: /api/0.6/relation/1/history
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/redactions.testcore/relation_history_moderator.case
+++ b/test/redactions.testcore/relation_history_moderator.case
@@ -6,7 +6,7 @@ Date: 2017-02-03T17:15:00Z
 Http-Authorization: OAuth realm="http://cgimap.example.com/api/0.6/relation/1/history", oauth_consumer_key="heqfjrcolc", oauth_token="scgncknxqr", oauth_nonce="i89B012BEg0Y5KHiiG5j", oauth_timestamp="1486142100", oauth_signature_method="HMAC-SHA1", oauth_version="1.0", oauth_signature="dI%2F6nEplWIcCUtwXul3LYC8ZuZI%3D"
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/redactions.testcore/relation_version_moderator.case
+++ b/test/redactions.testcore/relation_version_moderator.case
@@ -7,7 +7,7 @@ Date: 2017-02-03T16:37:00Z
 Http-Authorization: OAuth realm="http://cgimap.example.com/api/0.6/relation/1/2", oauth_consumer_key="heqfjrcolc", oauth_token="scgncknxqr", oauth_nonce="OFP9OGKNWTfBUw7hvB3A", oauth_timestamp="1486139820", oauth_signature_method="HMAC-SHA1", oauth_version="1.0", oauth_signature="N9V4%2FqNx5an7gOmmL4MhDBfKec0%3D"
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <?xml version="1.0"?>

--- a/test/redactions.testcore/relations_moderator.case
+++ b/test/redactions.testcore/relations_moderator.case
@@ -6,7 +6,7 @@ Date: 2017-02-03T17:26:00Z
 Http-Authorization: OAuth realm="http://cgimap.example.com/api/0.6/relations", oauth_consumer_key="heqfjrcolc", oauth_token="scgncknxqr", oauth_nonce="s5ikn2rEXP8sEY4yWioL", oauth_timestamp="1486142760", oauth_signature_method="HMAC-SHA1", oauth_version="1.0", oauth_signature="OQMjxYyDtdnAkz%2Fz%2FYVN7cQDj6w%3D"
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/redactions.testcore/way_history.case
+++ b/test/redactions.testcore/way_history.case
@@ -4,7 +4,7 @@ Request-Method: GET
 Request-URI: /api/0.6/way/1/history
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/redactions.testcore/way_history_moderator.case
+++ b/test/redactions.testcore/way_history_moderator.case
@@ -6,7 +6,7 @@ Date: 2017-02-03T17:13:00Z
 Http-Authorization: OAuth realm="http://cgimap.example.com/api/0.6/way/1/history", oauth_consumer_key="heqfjrcolc", oauth_token="scgncknxqr", oauth_nonce="EsHFWX0Ru330NARIKysY", oauth_timestamp="1486141980", oauth_signature_method="HMAC-SHA1", oauth_version="1.0", oauth_signature="Mkx4Sg%2BXWQkd7P0lhmPyszo2zIo%3D"
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/redactions.testcore/way_version_moderator.case
+++ b/test/redactions.testcore/way_version_moderator.case
@@ -7,7 +7,7 @@ Date: 2017-02-03T16:31:00Z
 Http-Authorization: OAuth realm="http://cgimap.example.com/api/0.6/way/1/2", oauth_consumer_key="heqfjrcolc", oauth_token="scgncknxqr", oauth_nonce="ng8dUT94UOvYmX98sAof", oauth_timestamp="1486139460", oauth_signature_method="HMAC-SHA1", oauth_version="1.0", oauth_signature="QnliNV2%2BjeQWVDPZUXwTxrc%2BhDQ%3D"
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <?xml version="1.0"?>

--- a/test/redactions.testcore/ways_moderator.case
+++ b/test/redactions.testcore/ways_moderator.case
@@ -6,7 +6,7 @@ Date: 2017-02-03T17:24:00Z
 Http-Authorization: OAuth realm="http://cgimap.example.com/api/0.6/ways", oauth_consumer_key="heqfjrcolc", oauth_token="scgncknxqr", oauth_nonce="sD8ADXbFprXuraBKHyH5", oauth_timestamp="1486142640", oauth_signature_method="HMAC-SHA1", oauth_version="1.0", oauth_signature="fQdcQw1OdVF%2BEhrPrFzxCD3c5Y0%3D"
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/relation.testcore/large_id_1.case
+++ b/test/relation.testcore/large_id_1.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relation/8589934592
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/relation.testcore/large_id_2.case
+++ b/test/relation.testcore/large_id_2.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relation/9223372036854775807
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/relation.testcore/relation_1.case
+++ b/test/relation.testcore/relation_1.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relation/1
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/relation.testcore/relation_history.case
+++ b/test/relation.testcore/relation_history.case
@@ -3,7 +3,7 @@ Request-Method: GET
 Request-URI: /api/0.6/relation/2/history
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/relation.testcore/relation_version.case
+++ b/test/relation.testcore/relation_version.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relation/2/1
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/relation.testcore/relation_version_deleted.case
+++ b/test/relation.testcore/relation_version_deleted.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relation/2/2
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/relation.testcore/relations.case
+++ b/test/relation.testcore/relations.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relations?relations=1,2
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/relation.testcore/relations_historic.case
+++ b/test/relation.testcore/relations_historic.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relations?relations=2v1,2
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/relation.testcore/relations_historic_dup.case
+++ b/test/relation.testcore/relations_historic_dup.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relations?relations=2v2,2
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/relation_full.testcore/relation_1.case
+++ b/test/relation_full.testcore/relation_1.case
@@ -3,7 +3,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relation/1/full
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/relation_full.testcore/relation_4.case
+++ b/test/relation_full.testcore/relation_4.case
@@ -3,7 +3,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relation/4/full
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/relation_full.testcore/relation_5.case
+++ b/test/relation_full.testcore/relation_5.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relation/5/full
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/relation_full.testcore/relation_6.case
+++ b/test/relation_full.testcore/relation_6.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relation/6/full
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/relation_full.testcore/relation_7.case
+++ b/test/relation_full.testcore/relation_7.case
@@ -3,7 +3,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relation/7/full
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/relation_relations.testcore/relation_1.case
+++ b/test/relation_relations.testcore/relation_1.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relation/1/relations
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/relation_relations.testcore/relation_2.case
+++ b/test/relation_relations.testcore/relation_2.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relation/2/relations
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/relation_relations.testcore/relation_3.case
+++ b/test/relation_relations.testcore/relation_3.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/relation/3/relations
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/test_core.cpp
+++ b/test/test_core.cpp
@@ -451,6 +451,7 @@ void check_response(std::istream &expected, std::istream &actual) {
     const std::string content_type =
         expected_headers.find("Content-Type")->second;
     if (content_type.substr(0, 8) == "text/xml" ||
+	content_type.substr(0, 15) == "application/xml" ||
         content_type.substr(0, 9) == "text/html") {
       check_content_body_xml(expected, actual);
 

--- a/test/way.testcore/large_id_1.case
+++ b/test/way.testcore/large_id_1.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/way/8589934592
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/way.testcore/large_id_2.case
+++ b/test/way.testcore/large_id_2.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/way/9223372036854775807
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/way.testcore/way_1.case
+++ b/test/way.testcore/way_1.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/way/1
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/way.testcore/way_history.case
+++ b/test/way.testcore/way_history.case
@@ -3,7 +3,7 @@ Request-Method: GET
 Request-URI: /api/0.6/way/2/history
 ---
 Status: 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">

--- a/test/way.testcore/way_version.case
+++ b/test/way.testcore/way_version.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/way/2/1
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/way.testcore/way_version_deleted.case
+++ b/test/way.testcore/way_version_deleted.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/way/2/2
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/way.testcore/ways.case
+++ b/test/way.testcore/ways.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/ways?ways=1,2
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/way.testcore/ways_history.case
+++ b/test/way.testcore/ways_history.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/ways?ways=2v1,2
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/way.testcore/ways_history_dup.case
+++ b/test/way.testcore/ways_history_dup.case
@@ -2,7 +2,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/ways?ways=2v2,2
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/way_full.testcore/way_1.case
+++ b/test/way_full.testcore/way_1.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/way/1/full
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition: 
 Status: 200 OK
 ---

--- a/test/way_relations.testcore/way_1.case
+++ b/test/way_relations.testcore/way_1.case
@@ -1,7 +1,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/way/1/relations
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---

--- a/test/way_relations.testcore/way_2.case
+++ b/test/way_relations.testcore/way_2.case
@@ -3,7 +3,7 @@
 Request-Method: GET
 Request-URI: /api/0.6/way/2/relations
 ---
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 !Content-Disposition:
 Status: 200 OK
 ---


### PR DESCRIPTION
Align MIME type handling: Rails accepts both text/xml and application/xml, and returns content type application/xml

Closes #220 
