### PR TITLE
Adapt new command line options to gnu style

### DIFF
--- a/include/cgimap/options.hpp
+++ b/include/cgimap/options.hpp
@@ -109,16 +109,16 @@ public:
   }
 
 private:
-  void init_fallback_values(const global_settings_base & def);
-  void set_new_options(const po::variables_map & options);
-  void set_payload_max_size(const po::variables_map & options);
-  void set_map_max_nodes(const po::variables_map & options);
-  void set_map_area_max(const po::variables_map & options);
-  void set_changeset_timeout_open_max(const po::variables_map & options);
-  void set_changeset_timeout_idle(const po::variables_map & options);
-  void set_changeset_max_elements(const po::variables_map & options);
-  void set_way_max_nodes(const po::variables_map & options);
-  void set_scale(const po::variables_map & options);
+  void init_fallback_values(const global_settings_base &def);
+  void set_new_options(const po::variables_map &options);
+  void set_payload_max_size(const po::variables_map &options);
+  void set_map_max_nodes(const po::variables_map &options);
+  void set_map_area_max(const po::variables_map &options);
+  void set_changeset_timeout_open_max(const po::variables_map &options);
+  void set_changeset_timeout_idle(const po::variables_map &options);
+  void set_changeset_max_elements(const po::variables_map &options);
+  void set_way_max_nodes(const po::variables_map &options);
+  void set_scale(const po::variables_map &options);
   bool validate_timeout(const std::string &timeout) const;
 
   long m_payload_max_size;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,14 +120,14 @@ static void get_options(int argc, char **argv, po::variables_map &options) {
 
   // clang-format off
   expert.add_options()
-    ("max_payload_size", po::value<int>(), "Maximum size of HTTP body payload accepted by uploads, after decompression (in bytes)")
-    ("map_nodes_max", po::value<int>(), "Maximum number of nodes returned by the /map endpoint")
-    ("map_area_max", po::value<double>(), "Maximum permitted area for /map endpoint")
-    ("changeset_timeout_open_max", po::value<string>(), "Maximum permitted open time period for a changeset")
-    ("changeset_timeout_idle", po::value<string>(), "Time period that a changeset will remain open after the last edit")
-    ("changeset_max_elements", po::value<int>(), "Maximum number of elements permitted in one changeset")
-    ("way_max_nodes", po::value<int>(), "Maximum number of nodes permitted in a way")
-    ("scale", po::value<int>(), "Conversion factor from double lat/lon format to internal int format used for database persistence")
+    ("max-payload", po::value<long>(), "max size of HTTP payload allowed for uploads, after decompression (in bytes)")
+    ("map-nodes", po::value<int>(), "max number of nodes allowed for /map endpoint")
+    ("map-area", po::value<double>(), "max area size allowed for /map endpoint")
+    ("changeset-timeout-open", po::value<string>(), "max open time period for a changeset")
+    ("changeset-timeout-idle", po::value<string>(), "time period a changeset will remain open after last edit")
+    ("max-changeset-elements", po::value<int>(), "max number of elements allowed in one changeset")
+    ("max-way-nodes", po::value<int>(), "max number of nodes allowed in one way (!!)")
+    ("scale", po::value<long>(), "conversion factor from double lat/lon to internal int format (!!)")
     ;
   // clang-format on
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -7,7 +7,7 @@ global_settings_base::~global_settings_base() = default;
 std::unique_ptr<global_settings_base> global_settings::settings = std::unique_ptr<global_settings_base>(new global_settings_default());
 
 
-void global_settings_via_options::init_fallback_values(const global_settings_base & def) {
+void global_settings_via_options::init_fallback_values(const global_settings_base &def) {
 
   m_payload_max_size = def.get_payload_max_size();
   m_map_max_nodes = def.get_map_max_nodes();
@@ -19,7 +19,7 @@ void global_settings_via_options::init_fallback_values(const global_settings_bas
   m_scale = def.get_scale();
 }
 
-void global_settings_via_options::set_new_options(const po::variables_map & options) {
+void global_settings_via_options::set_new_options(const po::variables_map &options) {
 
   set_payload_max_size(options);
   set_map_max_nodes(options);
@@ -31,64 +31,64 @@ void global_settings_via_options::set_new_options(const po::variables_map & opti
   set_scale(options);
 }
 
-void global_settings_via_options::set_payload_max_size(const po::variables_map & options)  {
-  if (options.count("max_payload_size")) {
-    m_payload_max_size = options["max_payload_size"].as<long>();
+void global_settings_via_options::set_payload_max_size(const po::variables_map &options)  {
+  if (options.count("max-payload")) {
+    m_payload_max_size = options["max-payload"].as<long>();
     if (m_payload_max_size <= 0)
-      throw std::invalid_argument("max_payload_size must be a positive number");
+      throw std::invalid_argument("max-payload must be a positive number");
   }
 }
 
-void global_settings_via_options::set_map_max_nodes(const po::variables_map & options)  {
-  if (options.count("map_nodes_max")) {
-    m_map_max_nodes = options["map_nodes_max"].as<int>();
+void global_settings_via_options::set_map_max_nodes(const po::variables_map &options)  {
+  if (options.count("map-nodes")) {
+    m_map_max_nodes = options["map-nodes"].as<int>();
     if (m_map_max_nodes <= 0)
-	throw std::invalid_argument("map_nodes_max must be a positive number");
+	throw std::invalid_argument("map-nodes must be a positive number");
   }
 }
 
-void global_settings_via_options::set_map_area_max(const po::variables_map & options) {
-  if (options.count("map_area_max")) {
-   m_map_area_max = options["map_area_max"].as<double>();
+void global_settings_via_options::set_map_area_max(const po::variables_map &options) {
+  if (options.count("map-area")) {
+   m_map_area_max = options["map-area"].as<double>();
    if (m_map_area_max <= 0)
-     throw std::invalid_argument("map_area_max must be a positive number");
+     throw std::invalid_argument("map-area must be a positive number");
   }
 }
 
-void global_settings_via_options::set_changeset_timeout_open_max(const po::variables_map & options) {
-  if (options.count("changeset_timeout_open_max")) {
-    m_changeset_timeout_open_max = options["changeset_timeout_open_max"].as<std::string>();
+void global_settings_via_options::set_changeset_timeout_open_max(const po::variables_map &options) {
+  if (options.count("changeset-timeout-open")) {
+    m_changeset_timeout_open_max = options["changeset-timeout-open"].as<std::string>();
     if (!validate_timeout(m_changeset_timeout_open_max))
       throw std::invalid_argument("Invalid changeset max open timeout value");
   }
 }
 
-void global_settings_via_options::set_changeset_timeout_idle(const po::variables_map & options)  {
-  if (options.count("changeset_timeout_idle")) {
-    m_changeset_timeout_idle = options["changeset_timeout_idle"].as<std::string>();
+void global_settings_via_options::set_changeset_timeout_idle(const po::variables_map &options)  {
+  if (options.count("changeset-timeout-idle")) {
+    m_changeset_timeout_idle = options["changeset-timeout-idle"].as<std::string>();
     if (!validate_timeout(m_changeset_timeout_idle)) {
       throw std::invalid_argument("Invalid changeset idle timeout value");
     }
   }
 }
 
-void global_settings_via_options::set_changeset_max_elements(const po::variables_map & options)  {
-  if (options.count("changeset_max_elements")) {
-    m_changeset_max_elements = options["changeset_max_elements"].as<int>();
+void global_settings_via_options::set_changeset_max_elements(const po::variables_map &options)  {
+  if (options.count("max-changeset-elements")) {
+    m_changeset_max_elements = options["max-changeset-elements"].as<int>();
     if (m_changeset_max_elements <= 0)
-      throw std::invalid_argument("changeset_max_elements must be a positive number");
+      throw std::invalid_argument("max-changeset-elements must be a positive number");
   }
 }
 
-void global_settings_via_options::set_way_max_nodes(const po::variables_map & options)  {
-  if (options.count("way_max_nodes")) {
-    m_way_max_nodes = options["way_max_nodes"].as<int>();
+void global_settings_via_options::set_way_max_nodes(const po::variables_map &options)  {
+  if (options.count("max-way-nodes")) {
+    m_way_max_nodes = options["max-way-nodes"].as<int>();
     if (m_way_max_nodes <= 0)
-      throw std::invalid_argument("way_max_nodes must be a positive number");
+      throw std::invalid_argument("max-way-nodes must be a positive number");
   }
 }
 
-void global_settings_via_options::set_scale(const po::variables_map & options) {
+void global_settings_via_options::set_scale(const po::variables_map &options) {
   if (options.count("scale")) {
     m_scale = options["scale"].as<long>();
     if (m_scale <= 0)


### PR DESCRIPTION
Style guide recommends one to three words and no underscores.