### PR TITLE
CGIMAP_* environment parameter blocks --help

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,6 @@ jobs:
             - libyajl-dev
             - postgresql-12
             - postgresql-client-12
-            - postgresql-all
             - postgresql-common
             - postgresql-server-dev-all
 script:

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,10 +14,10 @@ cgimap_include_HEADERS = \
 	include/cgimap/data_update.hpp \
 	include/cgimap/handler.hpp \
 	include/cgimap/http.hpp \
-        include/cgimap/infix_ostream_iterator.hpp \
+	include/cgimap/infix_ostream_iterator.hpp \
 	include/cgimap/logger.hpp \
 	include/cgimap/mime_types.hpp \
-        include/cgimap/basicauth.hpp \
+	include/cgimap/basicauth.hpp \
 	include/cgimap/oauth.hpp \
 	include/cgimap/output_buffer.hpp \
 	include/cgimap/output_formatter.hpp \
@@ -67,15 +67,15 @@ cgimap_api06_include_HEADERS = \
 
 cgimap_api06_changeset_upload_includedir=$(includedir)/cgimap/api06/changeset_upload
 cgimap_api06_changeset_upload_include_HEADERS = \
-        include/cgimap/api06/changeset_upload/changeset_updater.hpp \
-        include/cgimap/api06/changeset_upload/node_updater.hpp \
+	include/cgimap/api06/changeset_upload/changeset_updater.hpp \
+	include/cgimap/api06/changeset_upload/node_updater.hpp \
 	include/cgimap/api06/changeset_upload/osmchange_handler.hpp \
 	include/cgimap/api06/changeset_upload/osmchange_input_format.hpp \
 	include/cgimap/api06/changeset_upload/osmchange_tracking.hpp \
-        include/cgimap/api06/changeset_upload/osmobject.hpp \
-        include/cgimap/api06/changeset_upload/relation.hpp \
-        include/cgimap/api06/changeset_upload/relation_updater.hpp \
-        include/cgimap/api06/changeset_upload/way_updater.hpp 
+	include/cgimap/api06/changeset_upload/osmobject.hpp \
+	include/cgimap/api06/changeset_upload/relation.hpp \
+	include/cgimap/api06/changeset_upload/relation_updater.hpp \
+	include/cgimap/api06/changeset_upload/way_updater.hpp
 
 if ENABLE_APIDB
 cgimap_apidb_includedir=$(includedir)/cgimap/backend/apidb

--- a/include/cgimap/api06/changeset_upload/way.hpp
+++ b/include/cgimap/api06/changeset_upload/way.hpp
@@ -25,15 +25,15 @@ public:
     osm_nwr_signed_id_t _waynode = 0;
 
     try {
-	_waynode = std::stol(waynode);
+      _waynode = std::stol(waynode);
     } catch (std::invalid_argument& e) {
-	throw xml_error("Way node is not numeric");
+      throw xml_error("Way node is not numeric");
     } catch (std::out_of_range& e) {
-	throw xml_error("Way node value is too large");
+      throw xml_error("Way node value is too large");
     }
 
     if (_waynode == 0) {
-	throw xml_error("Way node value may not be 0");
+      throw xml_error("Way node value may not be 0");
     }
 
     add_way_node(_waynode);

--- a/include/cgimap/http.hpp
+++ b/include/cgimap/http.hpp
@@ -15,10 +15,6 @@
 #endif
 #include "cgimap/output_buffer.hpp"
 
-// Maximum bytes
-const unsigned long STDIN_MAX = 50000000;    // TODO: configurable parameter?
-
-
 /**
  * Contains the generic HTTP methods and classes involved in the
  * application. CGI-specific stuff is elsewhere, but this stuff

--- a/openstreetmap-cgimap.1
+++ b/openstreetmap-cgimap.1
@@ -9,6 +9,7 @@ openstreetmap-cgimap \- FCGI version of the OpenStreetMap API
 [\fB\-\-instances \fIINSTANCES\fR]
 [\fB\-\-pidfile \fIPIDFILE\fR]
 [\fB\-\-logfile \fILOGFILE\fR]
+[\fB\-\-configfile \fICONFIGFILE\fR]
 [\fB\-\-memcache \fISPEC\fR]
 [\fB\-\-ratelimit \fILIMIT\fR]
 [\fB\-\-maxdebt \fIDEBT\fR]
@@ -25,12 +26,19 @@ openstreetmap-cgimap \- FCGI version of the OpenStreetMap API
 [\fB\-\-cachesize \fISIZE\fR]
 [\fB\-\-dbport \fIPORT\fR]
 ] [
-[\fB\-\-dbname \fIDBNAME\fR]
-[\fB\-\-host \fIHOST\fR]
-[\fB\-\-username \fIUSER\fR]
-[\fB\-\-password \fIPASS\fR]
-[\fB\-\-charset \fICHARSET\fR]
-[\fB\-\-dbport \fIPORT\fR]
+[\fB\-\-oauth\-dbname \fIOAUTHDBNAME\fR]
+[\fB\-\-oauth\-host \fIOAUTHHOST\fR]
+[\fB\-\-oauth\-username \fIOAUTHUSER\fR]
+[\fB\-\-oauth\-password \fIOAUTHPASS\fR]
+[\fB\-\-oauth\-charset \fIOAUTHCHARSET\fR]
+[\fB\-\-oauth\-dbport \fIOAUTHPORT\fR]
+] [
+[\fB\-\-update\-dbname \fIUPDATEDBNAME\fR]
+[\fB\-\-update\-host \fIUPDATEHOST\fR]
+[\fB\-\-update\-username \fIUPDATEUSER\fR]
+[\fB\-\-update\-password \fIUPDATEPASS\fR]
+[\fB\-\-update\-charset \fIUPDATECHARSET\fR]
+[\fB\-\-update\-dbport \fIUPDATEPORT\fR]
 ] [
 [\fB\-\-file \fIFILE\fR]
 ]
@@ -103,6 +111,42 @@ Default is 1000.
 .TP
 .BR \-\-dbport =\fIPORT\fR
 Database port number or UNIX socket file name.
+.TP
+.BR \-\-oauth\-dbname =\fIOAUTHDBNAME\fR
+Database name to use for OAuth, if different from \-\-dbname.
+.TP
+.BR \-\-oauth\-host =\fIOAUTHHOST\fR
+Database server host to use for OAuth, if different from \-\-host.
+.TP
+.BR \-\-oauth\-username =\fIOAUTHUSER\fR
+Database user name to use for OAuth, if different from \-\-username.
+.TP
+.BR \-\-oauth\-password =\fIOAUTHPASS\fR
+Database password to use for OAuth, if different from \-\-password.
+.TP
+.BR \-\-oauth\-charset =\fIOAUTHCHARSET\fR
+Database character set to use for OAuth, if different from \-\-charset.
+.TP
+.BR \-\-oauth\-dbport =\fIOAUTHPORT\fR
+Database port number or UNIX socket file name to use for OAuth, if different from \-\-dbport.
+.TP
+.BR \-\-update\-dbname =\fIUPDATEDBNAME\fR
+Database name to use for API write operations, if different from \-\-dbname.
+.TP
+.BR \-\-update\-host =\fIUPDATEHOST\fR
+Database server host to use for API write operations, if different from \-\-host.
+.TP
+.BR \-\-update\-username =\fIUPDATEUSER\fR
+Database user name to use for API write operations, if different from \-\-username.
+.TP
+.BR \-\-update\-password =\fIUPDATEPASS\fR
+Database password to use for API write operations, if different from \-\-password.
+.TP
+.BR \-\-update\-charset =\fIUPDATECHARSET\fR
+Database character set to use for API write operations, if different from \-\-charset.
+.TP
+.BR \-\-update\-dbport =\fIUPDATEPORT\fR
+Database port number or UNIX socket file name to use for API write operations, if different from \-\-dbport.
 .SS Static XML backend options:
 .TP
 .BR \-\-file =\fIFILE\fR

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -104,7 +104,7 @@ void registry::setup_options(int argc, char *argv[],
         ptr = itr->second;
       }
       else {
-	throw std::runtime_error((boost::format("unknown backend provided, available options are: %1%") %
+        throw std::runtime_error((boost::format("unknown backend provided, available options are: %1%") %
 	       all_backends.str()).str());
       }
     }

--- a/src/backend/apidb/changeset_upload/way_updater.cpp
+++ b/src/backend/apidb/changeset_upload/way_updater.cpp
@@ -29,7 +29,7 @@ ApiDB_Way_Updater::~ApiDB_Way_Updater() = default;
 void ApiDB_Way_Updater::add_way(osm_changeset_id_t changeset_id,
                                 osm_nwr_signed_id_t old_id,
                                 const api06::WayNodeList &nodes,
-				const api06::TagList &tags) {
+                                const api06::TagList &tags) {
 
   way_t new_way{};
   new_way.version = 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,13 +147,13 @@ static void get_options(int argc, char **argv, po::variables_map &options) {
     po::store(po::parse_config_file(ifs, desc), options);
   }
 
-  po::notify(options);
-
   if (options.count("help")) {
     std::cout << desc << std::endl;
     output_backend_options(std::cout);
     exit(1);
   }
+
+  po::notify(options);
 
   // for ability to accept both the old --port option in addition to socket if not available.
   if (options.count("daemon") != 0 && options.count("socket") == 0 && options.count("port") == 0) {
@@ -205,7 +205,7 @@ static void process_requests(int socket, const po::variables_map &options) {
 
     // get the next request
     if (req.accept_r() >= 0) {
-	std::chrono::system_clock::time_point now(std::chrono::system_clock::now());
+      std::chrono::system_clock::time_point now(std::chrono::system_clock::now());
       req.set_current_time(now);
       process_request(req, limiter, generator, route, factory, update_factory, oauth_store);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,23 +75,6 @@ static string get_generator_string() {
 }
 
 /**
- * convert an environment variable name to an option name
- */
-static string environment_option_name(string name){
-  string option;
-
-  if (name.substr(0, 7) == "CGIMAP_") {
-    std::transform(name.begin() + 7, name.end(),
-                   std::back_inserter(option),
-                   [](unsigned char c) {
-                     return c == '_' ? '-' : std::tolower(c);
-                   });
-  }
-
-  return option;
-}
-
-/**
  * parse the comment line and environment for options.
  */
 static void get_options(int argc, char **argv, po::variables_map &options) {
@@ -136,7 +119,24 @@ static void get_options(int argc, char **argv, po::variables_map &options) {
   desc.add(expert);
 
   po::store(po::parse_command_line(argc, argv, desc), options);
-  po::store(po::parse_environment(desc, environment_option_name), options);
+  po::store(po::parse_environment(desc,
+    [desc](const std::string &name) {
+          std::string option;
+          // convert an environment variable name to an option name
+          if (name.substr(0, 7) == "CGIMAP_") {
+            std::transform(name.begin() + 7, name.end(),
+                           std::back_inserter(option),
+                           [](unsigned char c) {
+                           return c == '_' ? '-' : std::tolower(c);
+                   });
+            for (const auto &d : desc.options()) {
+              if (d->long_name() == option)
+                return option;
+            }
+            std::cout << "Ignoring unknown environment variable: " << name << std::endl;
+          }
+          return std::string("");
+        }), options);
 
   if (options.count("configfile")) {
     auto config_fname = options["configfile"].as<std::string>();
@@ -147,13 +147,13 @@ static void get_options(int argc, char **argv, po::variables_map &options) {
     po::store(po::parse_config_file(ifs, desc), options);
   }
 
+  po::notify(options);
+
   if (options.count("help")) {
     std::cout << desc << std::endl;
     output_backend_options(std::cout);
     exit(1);
   }
-
-  po::notify(options);
 
   // for ability to accept both the old --port option in addition to socket if not available.
   if (options.count("daemon") != 0 && options.count("socket") == 0 && options.count("port") == 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,8 +119,16 @@ static void get_options(int argc, char **argv, po::variables_map &options) {
   desc.add(expert);
 
   po::store(po::parse_command_line(argc, argv, desc), options);
+
+  // Show help after parsing command line parameters
+  if (options.count("help")) {
+    std::cout << desc << std::endl;
+    output_backend_options(std::cout);
+    exit(1);
+  }
+
   po::store(po::parse_environment(desc,
-    [desc](const std::string &name) {
+    [&desc](const std::string &name) {
           std::string option;
           // convert an environment variable name to an option name
           if (name.substr(0, 7) == "CGIMAP_") {
@@ -148,12 +156,6 @@ static void get_options(int argc, char **argv, po::variables_map &options) {
   }
 
   po::notify(options);
-
-  if (options.count("help")) {
-    std::cout << desc << std::endl;
-    output_backend_options(std::cout);
-    exit(1);
-  }
 
   // for ability to accept both the old --port option in addition to socket if not available.
   if (options.count("daemon") != 0 && options.count("socket") == 0 && options.count("port") == 0) {


### PR DESCRIPTION
References https://github.com/zerebubuth/openstreetmap-cgimap/issues/199

Refactored `environment_option_name` into a validation lambda that checks against the options in `po::options_description`.

Fixed up a few places in the code and Makefile where tabs and spaces didn't match and was causing visual alignment issues.

Updated `man` page to include config file description and oauth/update database command line arguments.