### PR TITLE
Undo "Replace custom array parser by pqxx::array_parser"

### DIFF
--- a/include/cgimap/backend/apidb/utils.hpp
+++ b/include/cgimap/backend/apidb/utils.hpp
@@ -3,46 +3,6 @@
 
 #include <pqxx/pqxx>
 
-/* Converts an array_agg array value into a string of comma-separated values */
-
-inline std::string friendly_name(pqxx::array_parser&& parser)
-{
-  std::string result;
-
-  auto obj = parser.get_next();
-  while (obj.first != pqxx::array_parser::done)
-  {
-    if (obj.first == pqxx::array_parser::string_value) {
-      if (!result.empty())
-        result += ",";
-      result += obj.second;
-    }
-    obj = parser.get_next();
-  }
-  return result;
-}
-
-/* Converts an array_agg array value into a vector of strings */
-inline std::vector<std::string> psql_array_to_vector(pqxx::array_parser&& parser) {
-  std::vector<std::string> result;
-
-  auto obj = parser.get_next();
-  while (obj.first != pqxx::array_parser::done)
-  {
-    if (obj.first == pqxx::array_parser::string_value) {
-      result.push_back(obj.second);
-    }
-    obj = parser.get_next();
-  }
-  return result;
-}
-
-inline std::vector<std::string> psql_array_to_vector(std::string str)
-{
-  return psql_array_to_vector(pqxx::array_parser(str.c_str()));
-}
-
-
 /* checks that the postgres version is sufficient to run cgimap.
  *
  * some queries (e.g: LATERAL join) and functions (multi-parameter unnest) only

--- a/include/cgimap/data_selection.hpp
+++ b/include/cgimap/data_selection.hpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <sstream>
 #include <vector>
-#include <pqxx/array.hxx>
 
 /**
  * represents a selected set of data which can be written out to
@@ -190,5 +189,9 @@ public:
   };
 };
 
+
+// parses psql array based on specs given
+// https://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
+std::vector<std::string> psql_array_to_vector(std::string str);
 
 #endif /* DATA_SELECTION_HPP */

--- a/include/cgimap/util.hpp
+++ b/include/cgimap/util.hpp
@@ -16,7 +16,6 @@
 #include <sstream>
 #include <string>
 
-#include <pqxx/array.hxx>
 
 
 inline size_t unicode_strlen(const std::string & s)
@@ -55,6 +54,15 @@ inline std::string escape(std::string input)
 	result += "\"";
 
 	return result;
+}
+
+
+// array_agg returns some curly brackets in the response. remove them for output
+// TODO: find a better way to do this.
+
+inline std::string friendly_name(const std::string & input)
+{
+  return input.substr(1, input.size() - 2);
 }
 
 

--- a/src/backend/apidb/changeset_upload/node_updater.cpp
+++ b/src/backend/apidb/changeset_upload/node_updater.cpp
@@ -796,7 +796,7 @@ ApiDB_Node_Updater::is_node_still_referenced(const std::vector<node_t> &nodes) {
         throw http::precondition_failed(
             fmt::format("Node {:d} is still used by ways {}.",
              row["node_id"].as<osm_nwr_id_t>(),
-             friendly_name(row["way_ids"].as_array())));
+             friendly_name(row["way_ids"].c_str())));
       }
 
       if (ids_if_unused.find(node_id) != ids_if_unused.end()) {
@@ -839,7 +839,7 @@ ApiDB_Node_Updater::is_node_still_referenced(const std::vector<node_t> &nodes) {
         throw http::precondition_failed(
             fmt::format("Node {:d} is still used by relations {}.",
                 row["member_id"].as<osm_nwr_id_t>(),
-                friendly_name(row["relation_ids"].as_array())));
+                friendly_name(row["relation_ids"].c_str())));
       }
 
       if (ids_if_unused.find(node_id) != ids_if_unused.end())

--- a/src/backend/apidb/changeset_upload/relation_updater.cpp
+++ b/src/backend/apidb/changeset_upload/relation_updater.cpp
@@ -1618,7 +1618,7 @@ ApiDB_Relation_Updater::is_relation_still_referenced(
       throw http::precondition_failed(
           fmt::format("The relation {:d} is used in relations {}.",
            row["member_id"].as<osm_nwr_id_t>(),
-           friendly_name(row["relation_ids"].as_array())));
+           friendly_name(row["relation_ids"].c_str())));
     }
 
     if (ids_if_unused.find(rel_id) != ids_if_unused.end()) {

--- a/src/backend/apidb/changeset_upload/way_updater.cpp
+++ b/src/backend/apidb/changeset_upload/way_updater.cpp
@@ -860,7 +860,7 @@ ApiDB_Way_Updater::is_way_still_referenced(const std::vector<way_t> &ways) {
       throw http::precondition_failed(
           fmt::format("Way {:d} is still used by relations {}.",
            row["member_id"].as<osm_nwr_id_t>(),
-           friendly_name(row["relation_ids"].as_array())));
+           friendly_name(row["relation_ids"].c_str())));
     }
 
     if (ids_if_unused.find(way_id) != ids_if_unused.end()) {

--- a/src/backend/apidb/common_pgsql_selection.cpp
+++ b/src/backend/apidb/common_pgsql_selection.cpp
@@ -76,8 +76,8 @@ void extract_changeset(const pqxx_tuple &row,
 void extract_tags(const pqxx_tuple &row, tags_t &tags) {
   tags.clear();
 
-  auto keys   = psql_array_to_vector(row["tag_k"].as_array());
-  auto values = psql_array_to_vector(row["tag_v"].as_array());
+  auto keys   = psql_array_to_vector(row["tag_k"].c_str());
+  auto values = psql_array_to_vector(row["tag_v"].c_str());
 
   if (keys.size()!=values.size()) {
     throw std::runtime_error("Mismatch in tags key and value size");
@@ -89,7 +89,7 @@ void extract_tags(const pqxx_tuple &row, tags_t &tags) {
 
 void extract_nodes(const pqxx_tuple &row, nodes_t &nodes) {
   nodes.clear();
-  auto ids = psql_array_to_vector(row["node_ids"].as_array());
+  auto ids = psql_array_to_vector(row["node_ids"].c_str());
   for (const auto & id : ids)
     nodes.push_back(std::stol(id));
 }
@@ -126,9 +126,9 @@ void extract_members(const pqxx_tuple &row, members_t &members) {
   member_info member;
   members.clear();
 
-  auto types = psql_array_to_vector(row["member_types"].as_array());
-  auto ids   = psql_array_to_vector(row["member_ids"].as_array());
-  auto roles = psql_array_to_vector(row["member_roles"].as_array());
+  auto types = psql_array_to_vector(row["member_types"].c_str());
+  auto ids   = psql_array_to_vector(row["member_ids"].c_str());
+  auto roles = psql_array_to_vector(row["member_roles"].c_str());
 
   if (types.size()!=ids.size() || ids.size()!=roles.size()) {
     throw std::runtime_error("Mismatch in members types, ids and roles size");
@@ -146,10 +146,10 @@ void extract_comments(const pqxx_tuple &row, comments_t &comments) {
   changeset_comment_info comment;
   comments.clear();
 
-  auto author_id    = psql_array_to_vector(row["comment_author_id"].as_array());
-  auto display_name = psql_array_to_vector(row["comment_display_name"].as_array());
-  auto body         = psql_array_to_vector(row["comment_body"].as_array());
-  auto created_at   = psql_array_to_vector(row["comment_created_at"].as_array());
+  auto author_id    = psql_array_to_vector(row["comment_author_id"].c_str());
+  auto display_name = psql_array_to_vector(row["comment_display_name"].c_str());
+  auto body         = psql_array_to_vector(row["comment_body"].c_str());
+  auto created_at   = psql_array_to_vector(row["comment_created_at"].c_str());
 
   if (author_id.size()!=display_name.size() || display_name.size()!=body.size()
       || body.size()!=created_at.size()) {

--- a/src/data_selection.cpp
+++ b/src/data_selection.cpp
@@ -1,3 +1,55 @@
 #include "cgimap/data_selection.hpp"
 
 
+std::vector<std::string> psql_array_to_vector(std::string str) {
+  std::vector<std::string> strs;
+  std::ostringstream value;
+  bool quotedValue = false;
+  bool escaped = false;
+  bool write = false;
+
+  if (str == "{NULL}" || str == "")
+    return strs;
+
+  for (unsigned int i=1; i<str.size(); i++) {
+    if (str[i]==',') {
+      if (quotedValue) {
+        value<<",";
+      } else {
+        write = true;
+      }
+    } else if (str[i]=='\"') {
+      if (escaped) {
+        value << "\"";
+        escaped = false;
+      } else if (quotedValue) {
+        quotedValue=false;
+      } else {
+        quotedValue = true;
+      }
+    } else if (str[i]=='\\'){
+      if (escaped) {
+        value << "\\";
+        escaped = false;
+      } else {
+        escaped = true;
+      }
+    } else if (str[i]=='}') {
+      if(quotedValue){
+        value << "}";
+      } else {
+        write = true;
+      }
+    } else {
+      value<<str[i];
+    }
+
+    if (write) {
+      strs.push_back(value.str());
+      value.str("");
+      value.clear();
+      write=false;
+    }
+  }
+  return strs;
+}

--- a/test/test_apidb_backend_nodes.cpp
+++ b/test/test_apidb_backend_nodes.cpp
@@ -200,6 +200,23 @@ void test_psql_array_to_vector() {
   if (values != actual_values) {
     throw std::runtime_error("Psql array parse failed for " + test + " " +values[0] + " " +values[1]);
   }
+
+  // test with semicolon in key
+  test = R"({use_sidepath,secondary,3,1,yes,50,"Rijksweg Noord",asphalt,left|through;right})";
+  values = psql_array_to_vector(test);
+  actual_values.clear();
+  actual_values.push_back("use_sidepath");
+  actual_values.push_back("secondary");
+  actual_values.push_back("3");
+  actual_values.push_back("1");
+  actual_values.push_back("yes");
+  actual_values.push_back("50");
+  actual_values.push_back("Rijksweg Noord");
+  actual_values.push_back("asphalt");
+  actual_values.push_back("left|through;right");
+  if (values != actual_values) {
+    throw std::runtime_error("Psql array parse failed for " + test + " " +values[0] + " " +values[1]);
+  }
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Fixes https://github.com/zerebubuth/openstreetmap-cgimap/issues/276
Reverts https://github.com/zerebubuth/openstreetmap-cgimap/pull/261

libpqxx seems to treat semicolons as a separator character regardless of the actual field type (Postgresql docs mention that only box type uses semicolon, all other standard types use comma only).

As our payload in varchar fields may contain semicolons, the array_agg() result would throw off the libpqxx array parser.

So for now we revert to the previous custom parser implementation.

Further upstream issue analysis to follow.