### PR TITLE
Replace deprecated std::iterator with direct member type declarations

### DIFF
--- a/include/cgimap/infix_ostream_iterator.hpp
+++ b/include/cgimap/infix_ostream_iterator.hpp
@@ -4,18 +4,24 @@
 #include <ios>
 #include <ostream>
 #include <iterator>
+#include <cstddef>
 
 /**
  * output iterator which infixes its delimiter string between the output items.
  */
 template <typename _Tp, typename _CharT = char,
           typename _Traits = std::char_traits<_CharT> >
-class infix_ostream_iterator
-    : public std::iterator<std::output_iterator_tag, void, void, void, void> {
+class infix_ostream_iterator {
 public:
   using char_type = _CharT;
   using traits_type = _Traits ;
   using ostream_type = std::basic_ostream<_CharT, _Traits>;
+  using iterator_concept = std::output_iterator_tag;
+  using iterator_category = std::output_iterator_tag;
+  using value_type = void;
+  using difference_type = std::ptrdiff_t;
+  using pointer = void;
+  using reference = void;
 
 private:
   ostream_type *_M_stream;


### PR DESCRIPTION
The [std::iterator](https://en.cppreference.com/w/cpp/iterator/iterator) helper class has been deprecated in C++ 17 in favor of direct declaration of the iterator member types. This causes the compiler to emit a ton of deprecation warnings, once for every source file that somehow includes the affected `infix_ostream_iterator.hpp` header.

* Fixed deprecation warnings by directly declaring the required member types and no longer deriving from std::iterator.
* `difference_type` changed to `std::ptrdiff_t` instead of `void` for [C++ 20 compatibility](https://en.cppreference.com/w/cpp/iterator/ostream_iterator).
* Add `iterator_concept` member type for [C++ 20 compatibility](https://en.cppreference.com/w/cpp/iterator/iterator_tags)