### PR TITLE
Use vector::reserve in bbox::parse to optimize allocations

### DIFF
--- a/src/bbox.cpp
+++ b/src/bbox.cpp
@@ -24,6 +24,7 @@ bool bbox::operator==(const bbox &other) const {
 
 bool bbox::parse(const std::string &s) {
   vector<string> strs;
+  strs.reserve(4);
   al::split(strs, s, al::is_any_of(","));
 
   if (strs.size() != 4)


### PR DESCRIPTION
The `strs` vector in `bbox::parse()` usually requires 4 elements for parsing a `bbox` from a string. Reserve enough space in advance for the expected number of elements to avoid repeated (re-)allocations.