### PR TITLE
Fix #291: Add Retry-After http header in 509 response

### DIFF
--- a/include/cgimap/http.hpp
+++ b/include/cgimap/http.hpp
@@ -157,7 +157,8 @@ public:
  */
 class bandwidth_limit_exceeded : public exception {
 public:
-  bandwidth_limit_exceeded(const std::string &message);
+  bandwidth_limit_exceeded(int retry_seconds);
+  int retry_seconds;
 };
 
 /**

--- a/include/cgimap/rate_limiter.hpp
+++ b/include/cgimap/rate_limiter.hpp
@@ -10,7 +10,7 @@ struct rate_limiter {
 
   // check if the key is below the rate limit. return true to indicate that it
   // is.
-  virtual bool check(const std::string &key, bool moderator) = 0;
+  virtual std::tuple<bool, int> check(const std::string &key, bool moderator) = 0;
 
   // update the limit for the key to say it has consumed this number of bytes.
   virtual void update(const std::string &key, int bytes, bool moderator) = 0;
@@ -19,7 +19,7 @@ struct rate_limiter {
 struct null_rate_limiter
   : public rate_limiter {
   ~null_rate_limiter();
-  bool check(const std::string &key, bool moderator);
+  std::tuple<bool, int> check(const std::string &key, bool moderator);
   void update(const std::string &key, int bytes, bool moderator);
 };
 
@@ -31,7 +31,7 @@ public:
    */
   memcached_rate_limiter(const boost::program_options::variables_map &options);
   ~memcached_rate_limiter();
-  bool check(const std::string &key, bool moderator);
+  std::tuple<bool, int> check(const std::string &key, bool moderator);
   void update(const std::string &key, int bytes, bool moderator);
 
 private:

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -103,8 +103,8 @@ const char *precondition_failed::what() const noexcept { return fullstring.c_str
 payload_too_large::payload_too_large(const string &message)
     : exception(413, "Payload Too Large", message) {}
 
-bandwidth_limit_exceeded::bandwidth_limit_exceeded(const string &message)
-    : exception(509, "Bandwidth Limit Exceeded", message) {}
+bandwidth_limit_exceeded::bandwidth_limit_exceeded(int retry_seconds)
+    : exception(509, "Bandwidth Limit Exceeded", fmt::format("You have downloaded too much data. Please try again in {} seconds.", retry_seconds)), retry_seconds(retry_seconds) {}
 
 gone::gone(const string &message)
     : exception(410, "Gone", message) {}

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -147,8 +147,8 @@ void global_settings_via_options::set_oauth_10_support(const po::variables_map &
 void global_settings_via_options::set_ratelimiter_ratelimit(const po::variables_map &options) {
   if (options.count("ratelimit")) {
     auto parsed_bytes_per_sec = options["ratelimit"].as<long>();
-    if (parsed_bytes_per_sec < 0)
-      throw std::invalid_argument("ratelimit must be a positive number");
+    if (parsed_bytes_per_sec <= 0)
+      throw std::invalid_argument("ratelimit must be greater than zero");
     if (parsed_bytes_per_sec > 1024 * 1024 * 1024)
       throw std::invalid_argument("ratelimit must be 1GB or less");
     m_ratelimiter_ratelimit = parsed_bytes_per_sec;
@@ -156,8 +156,8 @@ void global_settings_via_options::set_ratelimiter_ratelimit(const po::variables_
 
   if (options.count("moderator-ratelimit")) {
     auto parsed_bytes_per_sec = options["moderator-ratelimit"].as<long>();
-    if (parsed_bytes_per_sec < 0)
-      throw std::invalid_argument("moderator-ratelimit must be a positive number");
+    if (parsed_bytes_per_sec <= 0)
+      throw std::invalid_argument("moderator-ratelimit must be greater than zero");
     if (parsed_bytes_per_sec > 1024 * 1024 * 1024)
       throw std::invalid_argument("moderator-ratelimit must be 1GB or less");
     m_moderator_ratelimiter_ratelimit = parsed_bytes_per_sec;
@@ -167,8 +167,8 @@ void global_settings_via_options::set_ratelimiter_ratelimit(const po::variables_
 void global_settings_via_options::set_ratelimiter_maxdebt(const po::variables_map &options) {
  if (options.count("maxdebt")) {
     auto parsed_max_bytes = options["maxdebt"].as<long>();
-    if (parsed_max_bytes < 0)
-      throw std::invalid_argument("maxdebt must be a positive number");
+    if (parsed_max_bytes <= 0)
+      throw std::invalid_argument("maxdebt must be greater than zero");
     if (parsed_max_bytes > 3500)
       throw std::invalid_argument("maxdebt (in MB) must be 3500 or less");
     m_ratelimiter_maxdebt = parsed_max_bytes * 1024 * 1024;
@@ -176,8 +176,8 @@ void global_settings_via_options::set_ratelimiter_maxdebt(const po::variables_ma
 
   if (options.count("moderator-maxdebt")) {
     auto parsed_max_bytes = options["moderator-maxdebt"].as<long>();
-    if (parsed_max_bytes < 0)
-      throw std::invalid_argument("moderator-maxdebt must be a positive number");
+    if (parsed_max_bytes <= 0)
+      throw std::invalid_argument("moderator-maxdebt must be greater than zero");
     if (parsed_max_bytes > 3500)
       throw std::invalid_argument("moderator-maxdebt (in MB) must be 3500 or less");
     m_moderator_ratelimiter_maxdebt = parsed_max_bytes * 1024 * 1024;

--- a/src/process_request.cpp
+++ b/src/process_request.cpp
@@ -65,7 +65,7 @@ void check_db_readonly_mode (const data_update& data_update)
 // https://github.com/zerebubuth/openstreetmap-cgimap/pull/125#issuecomment-272720417
 void respond_404(const http::not_found &e, request &r) {
   r.status(e.code())
-    .add_header("Content-Type", "text/plain; charset=utf-8")
+    .add_header("Content-Type", "text/html; charset=utf-8")
     .add_header("Content-Length", "0")
     .add_header("Cache-Control", "no-cache")
     .put("");
@@ -145,9 +145,10 @@ void respond_error(const http::exception &e, request &r) {
       .add_header("Cache-Control", "no-cache");
 
     if (e.code() == 509) {
-      auto bandwidth_exception = dynamic_cast<const http::bandwidth_limit_exceeded&>(e);
-      r.add_header("Retry-After",
-                    std::to_string(bandwidth_exception.retry_seconds));
+      if (auto bandwidth_exception = dynamic_cast<const http::bandwidth_limit_exceeded*>(&e)) {
+        r.add_header("Retry-After",
+                      std::to_string(bandwidth_exception->retry_seconds));
+      }
     }
 
     r.put(message);   // output the message as well

--- a/test/test_apidb_backend_oauth.cpp
+++ b/test/test_apidb_backend_oauth.cpp
@@ -304,9 +304,9 @@ struct recording_rate_limiter
   : public rate_limiter {
   ~recording_rate_limiter() = default;
 
-  bool check(const std::string &key, bool moderator) {
+  std::tuple<bool, int> check(const std::string &key, bool moderator) {
     m_keys_seen.insert(key);
-    return true;
+    return std::make_tuple(false, 0);
   }
 
   void update(const std::string &key, int bytes, bool moderator) {

--- a/test/test_apidb_backend_oauth2.cpp
+++ b/test/test_apidb_backend_oauth2.cpp
@@ -241,9 +241,9 @@ struct recording_rate_limiter
   : public rate_limiter {
   ~recording_rate_limiter() = default;
 
-  bool check(const std::string &key, bool moderator) {
+  std::tuple<bool, int> check(const std::string &key, bool moderator) {
     m_keys_seen.insert(key);
-    return true;
+    return std::make_tuple(false, 0);
   }
 
   void update(const std::string &key, int bytes, bool moderator) {


### PR DESCRIPTION
Let me know how ugly solution it is from 0 to 10 to do `if (e.code() == 509)` and then `dynamic_cast`. It shows that my language is C# :P