### PR TITLE
Added changeset upload rate limiting

### DIFF
--- a/include/cgimap/backend/apidb/pgsql_update.hpp
+++ b/include/cgimap/backend/apidb/pgsql_update.hpp
@@ -32,6 +32,8 @@ public:
 
   bool is_api_write_disabled() const;
 
+  uint32_t get_rate_limit(osm_user_id_t uid);
+
   /**
    * abstracts the creation of transactions for the
    * data updates.

--- a/include/cgimap/data_update.hpp
+++ b/include/cgimap/data_update.hpp
@@ -46,6 +46,9 @@ public:
 
   virtual bool is_api_write_disabled() const = 0;
 
+  // get the current rate limit for changeset uploads for a given user id
+  virtual uint32_t get_rate_limit(osm_user_id_t) = 0;
+
   /**
    * factory for the creation of data updates. this abstracts away
    * the creation process of transactions, and allows some up-front

--- a/include/cgimap/http.hpp
+++ b/include/cgimap/http.hpp
@@ -144,6 +144,17 @@ public:
 
 
 /**
+ * The HTTP 429 Too Many Requests response status code indicates
+ * the user has sent too many requests in a given amount of time ("rate limiting").
+ */
+
+class too_many_requests : public exception {
+public:
+  too_many_requests(const std::string &message);
+};
+
+
+/**
  * The request resource could not be found, or is not handled
  * by the server.
  */

--- a/include/cgimap/options.hpp
+++ b/include/cgimap/options.hpp
@@ -27,6 +27,7 @@ public:
   virtual bool get_oauth_10_support() const = 0;
   virtual uint32_t get_ratelimiter_ratelimit(bool) const = 0;
   virtual uint32_t get_ratelimiter_maxdebt(bool) const = 0;
+  virtual bool get_ratelimiter_upload() const = 0;
 };
 
 class global_settings_default : public global_settings_base {
@@ -92,6 +93,10 @@ public:
        return 1024 * 1024 * 1024; // 1GB
     }
     return 250 * 1024 * 1024; // 250 MB
+  }
+
+  virtual bool get_ratelimiter_upload() const override {
+    return false;
   }
 };
 
@@ -175,6 +180,10 @@ public:
     return m_ratelimiter_maxdebt;
   }
 
+  virtual bool get_ratelimiter_upload() const override {
+    return m_ratelimiter_upload;
+  }
+
 private:
   void init_fallback_values(const global_settings_base &def);
   void set_new_options(const po::variables_map &options);
@@ -192,6 +201,7 @@ private:
   void set_oauth_10_support(const po::variables_map &options);
   void set_ratelimiter_ratelimit(const po::variables_map &options);
   void set_ratelimiter_maxdebt(const po::variables_map &options);
+  void set_ratelimiter_upload(const po::variables_map &options);
   bool validate_timeout(const std::string &timeout) const;
 
   uint32_t m_payload_max_size;
@@ -210,6 +220,7 @@ private:
   uint32_t m_moderator_ratelimiter_ratelimit;
   uint32_t m_ratelimiter_maxdebt;
   uint32_t m_moderator_ratelimiter_maxdebt;
+  bool m_ratelimiter_upload;
 };
 
 class global_settings final {
@@ -260,6 +271,9 @@ public:
 
   // Maximum debt in bytes to allow each client/moderator before rate limiting
   static uint32_t get_ratelimiter_maxdebt(bool moderator) { return settings->get_ratelimiter_maxdebt(moderator);  }
+
+  // Use ratelimiter for changeset uploads
+  static bool get_ratelimiter_upload() { return settings->get_ratelimiter_upload(); }
 
 private:
   static std::unique_ptr<global_settings_base> settings;  // gets initialized with global_settings_default instance

--- a/src/api06/changeset_upload_handler.cpp
+++ b/src/api06/changeset_upload_handler.cpp
@@ -48,8 +48,25 @@ changeset_upload_responder::changeset_upload_responder(
   // store diffresult for output handling in class osm_diffresult_responder
   m_diffresult = change_tracking.assemble_diffresult();
 
-  changeset_updater->update_changeset(handler.get_num_changes(),
-                                      handler.get_bbox());
+  const auto new_changes = handler.get_num_changes();
+
+  if (global_settings::get_ratelimiter_upload()) {
+
+    auto max_changes = upd.get_rate_limit(uid);
+    if (new_changes > max_changes)
+    {
+      logger::message(
+          fmt::format(
+              "Upload of {} changes by user {} in changeset {} blocked due to rate limiting, max. {} changes allowed",
+              new_changes, uid, changeset, max_changes));
+      throw http::too_many_requests(
+          fmt::format(
+              "Upload of {} changes has been blocked due to rate limiting. You may upload at most {} changes at this time.",
+              new_changes, max_changes));
+    }
+  }
+
+  changeset_updater->update_changeset(new_changes, handler.get_bbox());
 
   upd.commit();
 }

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -103,6 +103,9 @@ const char *precondition_failed::what() const noexcept { return fullstring.c_str
 payload_too_large::payload_too_large(const string &message)
     : exception(413, "Payload Too Large", message) {}
 
+too_many_requests::too_many_requests(const string &message)
+    : exception(429, "Too Many Requests", message) {}
+
 bandwidth_limit_exceeded::bandwidth_limit_exceeded(int retry_seconds)
     : exception(509, "Bandwidth Limit Exceeded", fmt::format("You have downloaded too much data. Please try again in {} seconds.", retry_seconds)), retry_seconds(retry_seconds) {}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,6 +113,7 @@ static void get_options(int argc, char **argv, po::variables_map &options) {
     ("max-element-tags", po::value<int>(), "max number of tags per OSM element")
     ("basic_auth_support", po::value<bool>(), "enable HTTP basic authentication support")
     ("oauth_10_support", po::value<bool>(), "enable legacy OAuth 1.0 support")
+    ("ratelimit-upload", po::value<bool>(), "enable rate limiting for changeset upload")
     ;
   // clang-format on
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -25,6 +25,7 @@ void global_settings_via_options::init_fallback_values(const global_settings_bas
   m_moderator_ratelimiter_ratelimit = def.get_ratelimiter_ratelimit(true);
   m_ratelimiter_maxdebt = def.get_ratelimiter_maxdebt(false);
   m_moderator_ratelimiter_maxdebt = def.get_ratelimiter_maxdebt(true);
+  m_ratelimiter_upload = def.get_ratelimiter_upload();
 }
 
 void global_settings_via_options::set_new_options(const po::variables_map &options) {
@@ -43,6 +44,7 @@ void global_settings_via_options::set_new_options(const po::variables_map &optio
   set_oauth_10_support(options);
   set_ratelimiter_ratelimit(options);
   set_ratelimiter_maxdebt(options);
+  set_ratelimiter_upload(options);
 }
 
 void global_settings_via_options::set_payload_max_size(const po::variables_map &options)  {
@@ -181,6 +183,12 @@ void global_settings_via_options::set_ratelimiter_maxdebt(const po::variables_ma
     if (parsed_max_bytes > 3500)
       throw std::invalid_argument("moderator-maxdebt (in MB) must be 3500 or less");
     m_moderator_ratelimiter_maxdebt = parsed_max_bytes * 1024 * 1024;
+  }
+}
+
+void global_settings_via_options::set_ratelimiter_upload(const po::variables_map &options) {
+  if (options.count("ratelimit-upload")) {
+    m_ratelimiter_upload = options["ratelimit-upload"].as<bool>();
   }
 }
 


### PR DESCRIPTION
See https://github.com/openstreetmap/openstreetmap-website/pull/4319 for details

## Key features

* Introduces a new parameter `--ratelimit-upload` to rate limit changeset uploads
* Check is done using a Postgresql plpgsql database function `api_rate_limit`, which accepts a user id as input parameter, and returns the number of permitted database changes for this user.
* Details of this database function are out of scope for CGImap. The respective implementation can be found in https://github.com/openstreetmap/openstreetmap-website -> lib/database_functions.rb
* The database function MUST be deployed before enabling upload rate limiting on CGImap, otherwise the upload will fail with HTTP 500 Internal Server Error.
* Once rate limiting has been enabled, the log file should show entries like  `Executed prepared statement api_rate_limit in 0 ms, returning 1 rows, 1 affected rows` as part of a changeset upload.
* Violations of rate limited are returned as HTTP 429 error, along with a description of how many changes have been uploaded, as well as the max. number of changes currently permitted for this user.
* In addition, violations are logged in the log file, and can be used to extract some stats. Example:
 `Upload of 2304 changes by user 13 in changeset 1874853 blocked due to rate limiting, max. 1803 changes allowed`

