### PR TITLE
Add create single node endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ test/.deps/
 test/.libs/
 test/test_core
 test/test_apidb_backend_nodes
+test/test_apidb_backend_node_changes
 test/test_apidb_backend_oauth
 test/test_apidb_backend_oauth2
 test/test_apidb_backend_historic

--- a/Makefile.am
+++ b/Makefile.am
@@ -75,6 +75,7 @@ cgimap_api06_changeset_upload_include_HEADERS = \
 	include/cgimap/api06/changeset_upload/osmchange_input_format.hpp \
 	include/cgimap/api06/changeset_upload/osmchange_tracking.hpp \
 	include/cgimap/api06/changeset_upload/osmobject.hpp \
+	include/cgimap/api06/changeset_upload/osmobject_input_format.hpp \
 	include/cgimap/api06/changeset_upload/relation.hpp \
 	include/cgimap/api06/changeset_upload/relation_updater.hpp \
 	include/cgimap/api06/changeset_upload/way_updater.hpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,7 @@ cgimap_api06_include_HEADERS = \
 	include/cgimap/api06/changeset_upload_handler.hpp \
 	include/cgimap/api06/handler_utils.hpp \
 	include/cgimap/api06/map_handler.hpp \
+	include/cgimap/api06/node_create_handler.hpp \
 	include/cgimap/api06/node_handler.hpp \
 	include/cgimap/api06/node_history_handler.hpp \
 	include/cgimap/api06/node_relations_handler.hpp \
@@ -123,6 +124,7 @@ endif
 if ENABLE_APIDB
 TESTS += \
 	test/test_apidb_backend_nodes \
+	test/test_apidb_backend_node_changes \
 	test/test_apidb_backend_oauth \
 	test/test_apidb_backend_oauth2 \
 	test/test_apidb_backend_historic \

--- a/include/cgimap/api06/changeset_upload/node_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/node_input_format.hpp
@@ -48,7 +48,7 @@ protected:
       case context::in_object:
         if (!std::strcmp(element, "tag")) {
           m_context = context::in_tag;
-          // add_tag(attrs); // TODO
+          add_tag(*m_node, attrs);
         }
         else
           throw xml_error{ "Unknown element, expecting tag" };
@@ -131,6 +131,35 @@ private:
         node.set_lat(value);
       }
     });
+  }
+
+  void add_tag(OSMObject &o, const char **attrs) {
+
+    std::optional<std::string> k;
+    std::optional<std::string> v;
+
+    check_attributes(attrs, [&k, &v](const char *name, const char *value) {
+
+      if (name[0] == 'k' && name[1] == 0) {
+        k = value;
+      } else if (name[0] == 'v' && name[1] == 0) {
+        v = value;
+      }
+    });
+
+    if (!k)
+      throw xml_error{
+        fmt::format("Mandatory field k missing in tag element for {}",
+         o.to_string())
+      };
+
+    if (!v)
+      throw xml_error{
+        fmt::format("Mandatory field v missing in tag element for {}",
+         o.to_string())
+      };
+
+    o.add_tag(*k, *v);
   }
 
   // Include XML message location information where error occurred in exception

--- a/include/cgimap/api06/changeset_upload/node_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/node_input_format.hpp
@@ -1,0 +1,165 @@
+#ifndef NODE_INPUT_FORMAT_HPP
+#define NODE_INPUT_FORMAT_HPP
+
+#include "cgimap/api06/changeset_upload/node.hpp"
+#include "parsers/saxparser.hpp"
+
+namespace api06 {
+
+class NodeXMLParser : private xmlpp::SaxParser {
+
+public:
+
+  std::unique_ptr<Node> process_message(const std::string &data) {
+
+    try {
+      parse_memory(data);
+    } catch (const xmlpp::exception& e) {
+      throw http::bad_request(e.what());    // rethrow XML parser error as HTTP 400 Bad request
+    }
+    assert(m_node);
+
+    return std::move(m_node);
+  }
+
+protected:
+
+  void on_start_element(const char *element, const char **attrs) override {
+
+    switch (m_context) {
+      case context::root:
+        if (!std::strcmp(element, "osm"))
+          m_context = context::top;
+        else
+          throw xml_error{ "Unknown top-level element, expecting osm"  };
+        break;
+
+      case context::top:
+        if (!std::strcmp(element, "node")) {
+          m_context = context::in_object;
+          m_node.reset(new Node{});
+          init_object(*m_node, attrs);
+          init_node(*m_node, attrs);
+        }
+        else
+          throw xml_error{ "Unknown element, expecting node" };
+        break;
+
+      case context::in_object:
+        if (!std::strcmp(element, "tag")) {
+          m_context = context::in_tag;
+          // add_tag(attrs); // TODO
+        }
+        else
+          throw xml_error{ "Unknown element, expecting tag" };
+        break;
+
+      case context::in_tag:
+        // intentionally not implemented
+        break;
+    }
+  }
+
+  void on_end_element(const char *element) override {
+
+    switch (m_context) {
+      case context::root:
+        assert(false);
+        break;
+
+      case context::top:
+        assert(!std::strcmp(element, "osm"));
+        m_context = context::root;
+        if (!m_node)
+          throw xml_error{ "Cannot parse valid node from xml string. XML doesn't contain an osm/node element" };
+        break;
+
+      case context::in_object:
+        assert(!std::strcmp(element, "node"));
+        m_context = context::top;
+        break;
+
+      case context::in_tag:
+        assert(!std::strcmp(element, "tag"));
+        m_context = context::in_object;
+        break;
+    }
+  }
+
+  void on_enhance_exception(xmlParserInputPtr& location) override {
+
+    try {
+        throw;
+    } catch (const xml_error& e) {
+      throw_with_context(e, location);
+    }
+  }
+
+private:
+
+  template <typename T>
+  static void check_attributes(const char **attrs, T check) {
+
+    if (attrs == NULL)
+      return;
+
+    while (*attrs) {
+      check(attrs[0], attrs[1]);
+      attrs += 2;
+    }
+  }
+  
+  void init_object(OSMObject &object, const char **attrs) {
+
+    check_attributes(attrs, [&object](const char *name, const char *value) {
+      if (!std::strcmp(name, "id")) {
+        object.set_id(value);
+      } else if (!std::strcmp(name, "changeset")) {
+        object.set_changeset(value);
+      } else if (!std::strcmp(name, "version")) {
+        object.set_version(value);
+      }
+    });
+  }
+
+  void init_node(Node &node, const char **attrs) {
+
+    check_attributes(attrs, [&node](const char *name, const char *value) {
+      if (!std::strcmp(name, "lon")) {
+        node.set_lon(value);
+      } else if (!std::strcmp(name, "lat")) {
+        node.set_lat(value);
+      }
+    });
+  }
+
+  // Include XML message location information where error occurred in exception
+  template <typename TEx>
+  void throw_with_context(TEx& e, xmlParserInputPtr& location) {
+
+    // Location unknown
+    if (location == nullptr)
+      throw e;
+
+    throw TEx{ fmt::format("{} at line {:d}, column {:d}",
+               e.what(),
+               location->line,
+               location->col ) };
+  }
+
+  enum class context {
+    root,
+    top,
+    in_object,
+    in_tag
+  };
+  
+  context m_context = context::root;
+
+  std::unique_ptr<Node> m_node;
+
+};
+
+} // namespace api06
+
+#endif // NODE_INPUT_FORMAT_HPP

--- a/include/cgimap/api06/changeset_upload/node_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/node_input_format.hpp
@@ -1,12 +1,11 @@
 #ifndef NODE_INPUT_FORMAT_HPP
 #define NODE_INPUT_FORMAT_HPP
 
-#include "cgimap/api06/changeset_upload/node.hpp"
-#include "parsers/saxparser.hpp"
+#include "cgimap/api06/changeset_upload/osmobject_input_format.hpp"
 
 namespace api06 {
 
-class NodeXMLParser : private xmlpp::SaxParser {
+class NodeXMLParser : private OSMObjectXMLParser {
 
 public:
 
@@ -86,95 +85,7 @@ protected:
     }
   }
 
-  void on_enhance_exception(xmlParserInputPtr& location) override {
-
-    try {
-        throw;
-    } catch (const xml_error& e) {
-      throw_with_context(e, location);
-    }
-  }
-
 private:
-
-  template <typename T>
-  static void check_attributes(const char **attrs, T check) {
-
-    if (attrs == NULL)
-      return;
-
-    while (*attrs) {
-      check(attrs[0], attrs[1]);
-      attrs += 2;
-    }
-  }
-  
-  void init_object(OSMObject &object, const char **attrs) {
-
-    check_attributes(attrs, [&object](const char *name, const char *value) {
-      if (!std::strcmp(name, "id")) {
-        object.set_id(value);
-      } else if (!std::strcmp(name, "changeset")) {
-        object.set_changeset(value);
-      } else if (!std::strcmp(name, "version")) {
-        object.set_version(value);
-      }
-    });
-  }
-
-  void init_node(Node &node, const char **attrs) {
-
-    check_attributes(attrs, [&node](const char *name, const char *value) {
-      if (!std::strcmp(name, "lon")) {
-        node.set_lon(value);
-      } else if (!std::strcmp(name, "lat")) {
-        node.set_lat(value);
-      }
-    });
-  }
-
-  void add_tag(OSMObject &o, const char **attrs) {
-
-    std::optional<std::string> k;
-    std::optional<std::string> v;
-
-    check_attributes(attrs, [&k, &v](const char *name, const char *value) {
-
-      if (name[0] == 'k' && name[1] == 0) {
-        k = value;
-      } else if (name[0] == 'v' && name[1] == 0) {
-        v = value;
-      }
-    });
-
-    if (!k)
-      throw xml_error{
-        fmt::format("Mandatory field k missing in tag element for {}",
-         o.to_string())
-      };
-
-    if (!v)
-      throw xml_error{
-        fmt::format("Mandatory field v missing in tag element for {}",
-         o.to_string())
-      };
-
-    o.add_tag(*k, *v);
-  }
-
-  // Include XML message location information where error occurred in exception
-  template <typename TEx>
-  void throw_with_context(TEx& e, xmlParserInputPtr& location) {
-
-    // Location unknown
-    if (location == nullptr)
-      throw e;
-
-    throw TEx{ fmt::format("{} at line {:d}, column {:d}",
-               e.what(),
-               location->line,
-               location->col ) };
-  }
 
   enum class context {
     root,

--- a/include/cgimap/api06/changeset_upload/osmchange_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/osmchange_input_format.hpp
@@ -102,15 +102,18 @@ protected:
       if (!std::strcmp(element, "node")) {
         m_node.reset(new Node{});
         init_object(*m_node, attrs);
+        require_object_attributes(*m_node);
         init_node(*m_node, attrs);
         m_context.push_back(context::node);
       } else if (!std::strcmp(element, "way")) {
         m_way.reset(new Way{});
         init_object(*m_way, attrs);
+        require_object_attributes(*m_way);
         m_context.push_back(context::way);
       } else if (!std::strcmp(element, "relation")) {
         m_relation.reset(new Relation{});
         init_object(*m_relation, attrs);
+        require_object_attributes(*m_relation);
         m_context.push_back(context::relation);
       } else {
         throw xml_error{
@@ -295,9 +298,12 @@ private:
         object.set_version(value);
       } // don't parse any other attributes here
     });
+  }
+  
+  void require_object_attributes(OSMObject &object) {
 
     if (!object.has_id()) {
-	throw xml_error{ "Mandatory field id missing in object" };
+      throw xml_error{ "Mandatory field id missing in object" };
     }
 
     if (!object.has_changeset()) {

--- a/include/cgimap/api06/changeset_upload/osmchange_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/osmchange_input_format.hpp
@@ -1,8 +1,8 @@
 #ifndef OSMCHANGE_INPUT_FORMAT_HPP
 #define OSMCHANGE_INPUT_FORMAT_HPP
 
+#include "cgimap/api06/changeset_upload/osmobject_input_format.hpp"
 #include "cgimap/api06/changeset_upload/node.hpp"
-#include "cgimap/api06/changeset_upload/osmobject.hpp"
 #include "cgimap/api06/changeset_upload/parser_callback.hpp"
 #include "cgimap/api06/changeset_upload/relation.hpp"
 #include "cgimap/api06/changeset_upload/way.hpp"
@@ -20,11 +20,10 @@
 #include <optional>
 #include <sstream>
 #include <string>
-#include "parsers/saxparser.hpp"
 
 namespace api06 {
 
-class OSMChangeXMLParser : private xmlpp::SaxParser {
+class OSMChangeXMLParser : private OSMObjectXMLParser {
 
 public:
   explicit OSMChangeXMLParser(Parser_Callback& callback)
@@ -250,18 +249,7 @@ protected:
     }
   }
 
-
-  void on_enhance_exception(xmlParserInputPtr& location) override {
-
-    try {
-        throw;
-    } catch (const xml_error& e) {
-      throw_with_context(e, location);
-    }
-  }
-
 private:
-
 
   enum class context {
     root,
@@ -275,31 +263,6 @@ private:
     in_object
   };
 
-  template <typename T>
-  static void check_attributes(const char **attrs, T check) {
-    if (attrs == NULL)
-      return;
-
-    while (*attrs) {
-      check(attrs[0], attrs[1]);
-      attrs += 2;
-    }
-  }
-
-  void init_object(OSMObject &object, const char **attrs) {
-
-    check_attributes(attrs, [&object](const char *name, const char *value) {
-
-      if (!std::strcmp(name, "id")) {
-        object.set_id(value);
-      } else if (!std::strcmp(name, "changeset")) {
-        object.set_changeset(value);
-      } else if (!std::strcmp(name, "version")) {
-        object.set_version(value);
-      } // don't parse any other attributes here
-    });
-  }
-  
   void require_object_attributes(OSMObject &object) {
 
     if (!object.has_id()) {
@@ -328,60 +291,6 @@ private:
                           object.version(), object.to_string()) };
       }
     }
-  }
-
-  void init_node(Node &node, const char **attrs) {
-    check_attributes(attrs, [&node](const char *name, const char *value) {
-
-      if (!std::strcmp(name, "lon")) {
-        node.set_lon(value);
-      } else if (!std::strcmp(name, "lat")) {
-        node.set_lat(value);
-      }
-    });
-  }
-
-  void add_tag(OSMObject &o, const char **attrs) {
-
-    std::optional<std::string> k;
-    std::optional<std::string> v;
-
-    check_attributes(attrs, [&k, &v](const char *name, const char *value) {
-
-      if (name[0] == 'k' && name[1] == 0) {
-        k = value;
-      } else if (name[0] == 'v' && name[1] == 0) {
-        v = value;
-      }
-    });
-
-    if (!k)
-      throw xml_error{
-        fmt::format("Mandatory field k missing in tag element for {}",
-         o.to_string())
-      };
-
-    if (!v)
-      throw xml_error{
-        fmt::format("Mandatory field v missing in tag element for {}",
-         o.to_string())
-      };
-
-    o.add_tag(*k, *v);
-  }
-
-  // Include XML message location information where error occurred in exception
-  template <typename TEx>
-  void throw_with_context(TEx& e, xmlParserInputPtr& location) {
-
-    // Location unknown
-    if (location == nullptr)
-      throw e;
-
-    throw TEx{ fmt::format("{} at line {:d}, column {:d}",
-  	e.what(),
-  	location->line,
-  	location->col ) };
   }
 
   operation m_operation = operation::op_undefined;

--- a/include/cgimap/api06/changeset_upload/osmobject_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/osmobject_input_format.hpp
@@ -1,0 +1,105 @@
+#ifndef OSMOBJECT_INPUT_FORMAT_HPP
+#define OSMOBJECT_INPUT_FORMAT_HPP
+
+#include "cgimap/api06/changeset_upload/node.hpp"
+
+#include "parsers/saxparser.hpp"
+
+namespace api06 {
+
+class OSMObjectXMLParser : protected xmlpp::SaxParser {
+
+protected:
+
+  void on_enhance_exception(xmlParserInputPtr& location) override {
+
+    try {
+        throw;
+    } catch (const xml_error& e) {
+      throw_with_context(e, location);
+    }
+  }
+
+  template <typename T>
+  static void check_attributes(const char **attrs, T check) {
+
+    if (attrs == NULL)
+      return;
+
+    while (*attrs) {
+      check(attrs[0], attrs[1]);
+      attrs += 2;
+    }
+  }
+
+  void init_object(OSMObject &object, const char **attrs) {
+
+    check_attributes(attrs, [&object](const char *name, const char *value) {
+      if (!std::strcmp(name, "id")) {
+        object.set_id(value);
+      } else if (!std::strcmp(name, "changeset")) {
+        object.set_changeset(value);
+      } else if (!std::strcmp(name, "version")) {
+        object.set_version(value);
+      }
+    });
+  }
+
+  void init_node(Node &node, const char **attrs) {
+
+    check_attributes(attrs, [&node](const char *name, const char *value) {
+      if (!std::strcmp(name, "lon")) {
+        node.set_lon(value);
+      } else if (!std::strcmp(name, "lat")) {
+        node.set_lat(value);
+      }
+    });
+  }
+
+  void add_tag(OSMObject &o, const char **attrs) {
+
+    std::optional<std::string> k;
+    std::optional<std::string> v;
+
+    check_attributes(attrs, [&k, &v](const char *name, const char *value) {
+
+      if (name[0] == 'k' && name[1] == 0) {
+        k = value;
+      } else if (name[0] == 'v' && name[1] == 0) {
+        v = value;
+      }
+    });
+
+    if (!k)
+      throw xml_error{
+        fmt::format("Mandatory field k missing in tag element for {}",
+         o.to_string())
+      };
+
+    if (!v)
+      throw xml_error{
+        fmt::format("Mandatory field v missing in tag element for {}",
+         o.to_string())
+      };
+
+    o.add_tag(*k, *v);
+  }
+
+  // Include XML message location information where error occurred in exception
+  template <typename TEx>
+  void throw_with_context(TEx& e, xmlParserInputPtr& location) {
+
+    // Location unknown
+    if (location == nullptr)
+      throw e;
+
+    throw TEx{ fmt::format("{} at line {:d}, column {:d}",
+               e.what(),
+               location->line,
+               location->col ) };
+  }
+};
+
+} // namespace api06
+
+#endif // OSMOBJECT_INPUT_FORMAT_HPP

--- a/include/cgimap/api06/node_create_handler.hpp
+++ b/include/cgimap/api06/node_create_handler.hpp
@@ -1,0 +1,34 @@
+#ifndef API06_NODE_CREATE_HANDLER_HPP
+#define API06_NODE_CREATE_HANDLER_HPP
+
+#include <string>
+
+#include "cgimap/text_responder.hpp"
+#include "cgimap/handler.hpp"
+#include "cgimap/request.hpp"
+
+namespace api06 {
+
+class node_create_responder : public text_responder {
+public:
+  node_create_responder(mime::type, data_update &,
+                        const std::string &,
+                        std::optional<osm_user_id_t>);
+};
+
+class node_create_handler : public payload_enabled_handler {
+public:
+  node_create_handler(request &req);
+
+  std::string log_name() const override;
+  responder_ptr_t responder(data_selection &x) const override;
+  
+  responder_ptr_t responder(data_update &,
+                            const std::string &payload,
+                            std::optional<osm_user_id_t> user_id) const override;
+  bool requires_selection_after_update() const override;
+};
+
+} // namespace api06
+
+#endif /* API06_NODE_CREATE_HANDLER_HPP */

--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -49,6 +49,7 @@ $HTTP["request-method"] == "POST" {
 
 $HTTP["request-method"] == "PUT" {
   url.rewrite-once = (
+    "^/api/0\.6/node/create.*$" => "/dispatch.map",
     "^/api/0\.6/changeset/[[:digit:]]+/close.*$" => "/dispatch.map",
     "^/api/0\.6/changeset/[[:digit:]]+$" => "/dispatch.map",
     "^/api/0\.6/changeset/create.*$" => "/dispatch.map",

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,6 +18,7 @@ if ENABLE_APIDB
 lib_LTLIBRARIES+=libcgimap_apidb.la
 check_PROGRAMS+=\
 	../test/test_apidb_backend_nodes \
+	../test/test_apidb_backend_node_changes \
 	../test/test_apidb_backend_oauth \
 	../test/test_apidb_backend_oauth2 \
 	../test/test_apidb_backend_historic \
@@ -27,6 +28,7 @@ check_PROGRAMS+=\
 ___openstreetmap_cgimap_LDADD+=libcgimap_apidb.la
 ___test_test_core_LDADD+=libcgimap_apidb.la
 ___test_test_apidb_backend_nodes_LDADD=libcgimap_core.la libcgimap_apidb.la
+___test_test_apidb_backend_node_changes_LDADD=libcgimap_core.la libcgimap_apidb.la
 ___test_test_apidb_backend_oauth_LDADD=libcgimap_core.la libcgimap_apidb.la
 ___test_test_apidb_backend_oauth2_LDADD=libcgimap_core.la libcgimap_apidb.la
 ___test_test_apidb_backend_historic_LDADD=libcgimap_core.la libcgimap_apidb.la
@@ -61,6 +63,7 @@ ___test_test_parse_changeset_input_LDADD=libcgimap_core.la @LIBXML_LIBS@ @BOOST_
 
 if ENABLE_APIDB
 ___test_test_apidb_backend_nodes_LDADD+=libcgimap_core.la @BOOST_PROGRAM_OPTIONS_LIB@ @LIBPQXX_LIBS@ @CRYPTOPP_LIBS@ @ARGON2_LIBS@
+___test_test_apidb_backend_node_changes_LDADD+=libcgimap_core.la @BOOST_PROGRAM_OPTIONS_LIB@ @LIBPQXX_LIBS@ @CRYPTOPP_LIBS@ @ARGON2_LIBS@
 ___test_test_apidb_backend_oauth_LDADD+=libcgimap_core.la @BOOST_PROGRAM_OPTIONS_LIB@ @LIBPQXX_LIBS@ @CRYPTOPP_LIBS@ @ARGON2_LIBS@
 ___test_test_apidb_backend_oauth2_LDADD+=libcgimap_core.la @BOOST_PROGRAM_OPTIONS_LIB@ @LIBPQXX_LIBS@ @CRYPTOPP_LIBS@ @ARGON2_LIBS@
 ___test_test_apidb_backend_historic_LDADD+=libcgimap_core.la @BOOST_PROGRAM_OPTIONS_LIB@ @LIBPQXX_LIBS@ @CRYPTOPP_LIBS@ @ARGON2_LIBS@
@@ -106,6 +109,11 @@ ___test_test_parse_changeset_input_SOURCES=\
 if ENABLE_APIDB
 ___test_test_apidb_backend_nodes_SOURCES=\
 	../test/test_apidb_backend_nodes.cpp \
+	../test/test_formatter.cpp \
+	../test/test_database.cpp \
+	../test/test_request.cpp
+___test_test_apidb_backend_node_changes_SOURCES=\
+	../test/test_apidb_backend_node_changes.cpp \
 	../test/test_formatter.cpp \
 	../test/test_database.cpp \
 	../test/test_request.cpp
@@ -197,6 +205,7 @@ libcgimap_core_la_SOURCES+=\
 	api06/handler_utils.cpp \
 	api06/id_version_io.cpp \
 	api06/map_handler.cpp \
+	api06/node_create_handler.cpp \
 	api06/node_handler.cpp \
 	api06/node_history_handler.cpp \
 	api06/node_relations_handler.cpp \

--- a/src/api06/node_create_handler.cpp
+++ b/src/api06/node_create_handler.cpp
@@ -1,3 +1,4 @@
+#include "cgimap/api06/changeset_upload/node_input_format.hpp"
 #include "cgimap/api06/node_create_handler.hpp"
 
 namespace api06 {
@@ -13,8 +14,9 @@ node_create_responder::node_create_responder(
   auto node_updater = upd.get_node_updater(change_tracking);
 
   changeset_updater->lock_current_changeset(true);
-  std::map<std::string, std::string> tags;
-  node_updater->add_node(12, 34, cid, -1, tags); // TODO get lat, lon, tags
+  NodeXMLParser parser;
+  auto node = parser.process_message(payload);
+  node_updater->add_node(node->lat(), node->lon(), cid, -1, node->tags());
   node_updater->process_new_nodes();
   changeset_updater->update_changeset(node_updater->get_num_changes(),
                                       node_updater->bbox());

--- a/src/api06/node_create_handler.cpp
+++ b/src/api06/node_create_handler.cpp
@@ -1,0 +1,36 @@
+#include "cgimap/api06/node_create_handler.hpp"
+
+namespace api06 {
+
+node_create_responder::node_create_responder(
+    mime::type mt, data_update & upd, const std::string &payload,
+    std::optional<osm_user_id_t> user_id)
+    : text_responder(mt) {
+  output_text = "1234567";
+}
+
+node_create_handler::node_create_handler(request &)
+    : payload_enabled_handler(mime::text_plain,
+                              http::method::PUT | http::method::OPTIONS) {}
+
+std::string node_create_handler::log_name() const {
+  return "node/create";
+}
+
+responder_ptr_t
+node_create_handler::responder(data_selection &) const {
+  throw http::server_error(
+      "node_create_handler: data_selection unsupported");
+}
+
+responder_ptr_t node_create_handler::responder(
+    data_update & upd, const std::string &payload, std::optional<osm_user_id_t> user_id) const {
+  return responder_ptr_t(
+      new node_create_responder(mime_type, upd, payload, user_id));
+}
+
+bool node_create_handler::requires_selection_after_update() const {
+  return false;
+}
+
+} // namespace api06

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -7,6 +7,7 @@
 
 #include "cgimap/api06/node_handler.hpp"
 #include "cgimap/api06/node_version_handler.hpp"
+#include "cgimap/api06/node_create_handler.hpp"
 #include "cgimap/api06/nodes_handler.hpp"
 #include "cgimap/api06/node_history_handler.hpp"
 
@@ -236,6 +237,7 @@ routes::routes()
     // make sure that *_version_handler is listed before matching *_handler
       .GET<node_history_handler>(root_ / "node" / osm_id_ / "history")
       .GET<node_version_handler>(root_ / "node" / osm_id_ / osm_id_ )
+      .PUT<node_create_handler>(root_ / "node" / "create")
       .GET<node_handler>(root_ / "node" / osm_id_)
       .GET<nodes_handler>(root_ / "nodes")
 

--- a/test/test_apidb_backend_node_changes.cpp
+++ b/test/test_apidb_backend_node_changes.cpp
@@ -28,11 +28,17 @@ void test_end_to_end(test_database &tdb, const std::string& title, const std::st
 
     INSERT INTO changesets (id, user_id, created_at, closed_at, num_changes)
     VALUES
-      (1, 1, now() at time zone 'utc', now() at time zone 'utc' + '1 hour' ::interval, 0);
+      (1, 1, now() at time zone 'utc' - '12 hour' ::interval,
+             now() at time zone 'utc' - '11 hour' ::interval, 0),
+      (2, 1, now() at time zone 'utc', now() at time zone 'utc' + '1 hour' ::interval, 0);
   )");
 
   const std::string baseauth = "Basic ZGVtbzpwYXNzd29yZA==";
   const std::string generator = "Test";
+  const osm_nwr_id_t target_version = 1;
+  const osm_changeset_id_t target_changeset_id = 2;
+  const osm_user_id_t target_user_id = 1;
+  const std::string target_display_name = "demo";
 
   auto sel_factory = tdb.get_data_selection_factory();
   auto upd_factory = tdb.get_data_update_factory();
@@ -72,7 +78,7 @@ void test_end_to_end(test_database &tdb, const std::string& title, const std::st
   assert_equal<size_t>(f.m_nodes.size(), 1, fmt::format("number of nodes written for {}", title));
   assert_equal<test_formatter::node_t>(
     test_formatter::node_t(
-      element_info(node_id, 1, 1, f.m_nodes[0].elem.timestamp, 1, std::string("demo"), true),
+      element_info(node_id, target_version, target_changeset_id, f.m_nodes[0].elem.timestamp, target_user_id, target_display_name, true),
       target_lon, target_lat, target_tags
     ),
     f.m_nodes[0], title);
@@ -88,7 +94,7 @@ int main(int, char **) {
       test_end_to_end(tdb, "node without tags",
         R"(<?xml version="1.0" encoding="UTF-8"?>
         <osm>
-          <node lat="12" lon="34" changeset="1"/>
+          <node lat="12" lon="34" changeset="2"/>
         </osm>)",
         12, 34, tags_t());
     });
@@ -96,7 +102,7 @@ int main(int, char **) {
       test_end_to_end(tdb, "node with tags",
         R"(<?xml version="1.0" encoding="UTF-8"?>
         <osm>
-          <node lat="21" lon="43" changeset="1">
+          <node lat="21" lon="43" changeset="2">
             <tag k="natural" v="tree"/>
             <tag k="height" v="19"/>
           </node>

--- a/test/test_apidb_backend_node_changes.cpp
+++ b/test/test_apidb_backend_node_changes.cpp
@@ -92,6 +92,17 @@ int main(int, char **) {
         </osm>)",
         12, 34, tags_t());
     });
+    tdb.run_update([](test_database &tdb) {
+      test_end_to_end(tdb, "node with tags",
+        R"(<?xml version="1.0" encoding="UTF-8"?>
+        <osm>
+          <node lat="21" lon="43" changeset="1">
+            <tag k="natural" v="tree"/>
+            <tag k="height" v="19"/>
+          </node>
+        </osm>)",
+        21, 43, tags_t({{"natural", "tree"}, {"height", "19"}}));
+    });
   } catch (const test_database::setup_error &e) {
     std::cout << "Unable to set up test database: " << e.what() << std::endl;
     return 77;

--- a/test/test_apidb_backend_node_changes.cpp
+++ b/test/test_apidb_backend_node_changes.cpp
@@ -1,0 +1,75 @@
+#include "cgimap/rate_limiter.hpp"
+#include "cgimap/routes.hpp"
+#include "cgimap/process_request.hpp"
+
+#include "test_formatter.hpp"
+#include "test_database.hpp"
+#include "test_request.hpp"
+
+namespace {
+
+void test_end_to_end(test_database &tdb) {
+
+  // Prepare users, changesets
+
+  tdb.run_sql(R"(
+    INSERT INTO users (id, email, pass_crypt, pass_salt, creation_time, display_name, data_public, status)
+    VALUES
+      (1, 'demo@example.com', '3wYbPiOxk/tU0eeIDjUhdvi8aDP3AbFtwYKKxF1IhGg=',
+                              'sha512!10000!OUQLgtM7eD8huvanFT5/WtWaCwdOdrir8QOtFwxhO0A=',
+                              '2013-11-14T02:10:00Z', 'demo', true, 'confirmed');
+
+    INSERT INTO changesets (id, user_id, created_at, closed_at, num_changes)
+    VALUES
+      (1, 1, now() at time zone 'utc', now() at time zone 'utc' + '1 hour' ::interval, 0);
+  )");
+
+  const std::string baseauth = "Basic ZGVtbzpwYXNzd29yZA==";
+  const std::string generator = "Test";
+
+  auto sel_factory = tdb.get_data_selection_factory();
+  auto upd_factory = tdb.get_data_update_factory();
+
+  null_rate_limiter limiter;
+  routes route;
+
+  // create a node without tags
+  {
+    test_request req;
+    req.set_header("REQUEST_METHOD", "PUT");
+    req.set_header("REQUEST_URI", "/api/0.6/node/create");
+    req.set_header("HTTP_AUTHORIZATION", baseauth);
+    req.set_header("REMOTE_ADDR", "127.0.0.1");
+    req.set_payload(R"(<?xml version="1.0" encoding="UTF-8"?>
+      <osm>
+        <node lon="12" lat="34" changeset="1"/>
+      </osm>)");
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+
+    if (req.response_status() != 200)
+      throw std::runtime_error("Expected HTTP 200 OK: Create new node");
+  }
+}
+
+} // anonymous namespace
+
+int main(int, char **) {
+  try {
+    test_database tdb;
+    tdb.setup();
+    tdb.run_update(std::function<void(test_database&)>(&test_end_to_end));
+  } catch (const test_database::setup_error &e) {
+    std::cout << "Unable to set up test database: " << e.what() << std::endl;
+    return 77;
+
+  } catch (const std::exception &e) {
+    std::cout << "Error: " << e.what() << std::endl;
+    return 1;
+
+  } catch (...) {
+    std::cout << "Unknown exception type." << std::endl;
+    return 99;
+  }
+
+  return 0;
+}

--- a/test/test_apidb_backend_node_changes.cpp
+++ b/test/test_apidb_backend_node_changes.cpp
@@ -8,6 +8,13 @@
 
 namespace {
 
+template <typename T>
+void assert_equal(const T& a, const T&b, const std::string &message) {
+  if (a != b) {
+    throw std::runtime_error(fmt::format("Expecting {} to be equal, but {} != {}", message, a, b));
+  }
+}
+
 void test_end_to_end(test_database &tdb) {
 
   // Prepare users, changesets
@@ -35,6 +42,10 @@ void test_end_to_end(test_database &tdb) {
 
   // create a node without tags
   {
+    assert_equal<int>(
+      tdb.run_sql("SELECT id FROM current_nodes"), 0,
+      "number of nodes before single node create");
+  
     test_request req;
     req.set_header("REQUEST_METHOD", "PUT");
     req.set_header("REQUEST_URI", "/api/0.6/node/create");
@@ -48,6 +59,28 @@ void test_end_to_end(test_database &tdb) {
 
     if (req.response_status() != 200)
       throw std::runtime_error("Expected HTTP 200 OK: Create new node");
+
+    assert_equal<int>(
+      tdb.run_sql("SELECT id FROM current_nodes"), 1,
+      "number of nodes after single node create");
+
+    osm_nwr_id_t node_id;
+    req.body() >> node_id;
+    auto sel = tdb.get_data_selection();
+    
+    if (sel->check_node_visibility(node_id) != data_selection::exists)
+      throw std::runtime_error("Node should be visible, but isn't");
+
+    sel->select_nodes({ node_id });
+    test_formatter f;
+    sel->write_nodes(f);
+    assert_equal<size_t>(f.m_nodes.size(), 1, "number of nodes written");
+    assert_equal<test_formatter::node_t>(
+      test_formatter::node_t(
+        element_info(node_id, 1, 1, f.m_nodes[0].elem.timestamp, 1, std::string("demo"), true),
+        34, 12, tags_t()
+      ),
+      f.m_nodes[0], "node written");
   }
 }
 

--- a/test/test_apidb_backend_node_changes.cpp
+++ b/test/test_apidb_backend_node_changes.cpp
@@ -53,7 +53,7 @@ void test_end_to_end(test_database &tdb) {
     req.set_header("REMOTE_ADDR", "127.0.0.1");
     req.set_payload(R"(<?xml version="1.0" encoding="UTF-8"?>
       <osm>
-        <node lon="12" lat="34" changeset="1"/>
+        <node lon="34" lat="12" changeset="1"/>
       </osm>)");
     process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
 


### PR DESCRIPTION
Currently cgimap is missing single-element write api calls. If all write calls were in one place, maybe it would be easier to implement rate limits and other checks for uploaded data?

Here's an attempt to add `PUT node/create`. I started doing it before the new user rate limiter code was added. Not sure how compatible it is with the latest changes. Is it a good idea at all?