### PR TITLE
cppcheck findings

### DIFF
--- a/include/cgimap/api06/changeset_close_handler.hpp
+++ b/include/cgimap/api06/changeset_close_handler.hpp
@@ -27,7 +27,7 @@ public:
 
 class changeset_close_handler : public payload_enabled_handler {
 public:
-  changeset_close_handler(request &req, osm_changeset_id_t id);
+  changeset_close_handler(const request &req, osm_changeset_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/changeset_create_handler.hpp
+++ b/include/cgimap/api06/changeset_create_handler.hpp
@@ -27,7 +27,7 @@ public:
 
 class changeset_create_handler : public payload_enabled_handler {
 public:
-  changeset_create_handler(request &req);
+  explicit changeset_create_handler(const request &req);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/changeset_download_handler.hpp
+++ b/include/cgimap/api06/changeset_download_handler.hpp
@@ -24,7 +24,7 @@ public:
 
 class changeset_download_handler : public handler {
 public:
-  changeset_download_handler(request &req, osm_changeset_id_t id);
+  changeset_download_handler(const request &req, osm_changeset_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/changeset_handler.hpp
+++ b/include/cgimap/api06/changeset_handler.hpp
@@ -24,7 +24,7 @@ public:
 
 class changeset_handler : public handler {
 public:
-  changeset_handler(request &req, osm_changeset_id_t id);
+  changeset_handler(const request &req, osm_changeset_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/changeset_update_handler.hpp
+++ b/include/cgimap/api06/changeset_update_handler.hpp
@@ -39,7 +39,7 @@ private:
 
 class changeset_update_handler : public payload_enabled_handler {
 public:
-  changeset_update_handler(request &req, osm_changeset_id_t id);
+  changeset_update_handler(const request &req, osm_changeset_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/changeset_upload/changeset_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/changeset_input_format.hpp
@@ -125,7 +125,7 @@ namespace api06 {
 
     std::map<std::string, std::string> tags() const { return m_tags; }
 
-    void add_tag(std::string key, std::string value) {
+    void add_tag(const std::string &key, const std::string &value) {
 
       if (key.empty())
 	throw xml_error("Key may not be empty");

--- a/include/cgimap/api06/changeset_upload/relation.hpp
+++ b/include/cgimap/api06/changeset_upload/relation.hpp
@@ -25,8 +25,8 @@ class RelationMember {
 public:
   RelationMember() = default;
 
-  RelationMember(std::string _m_type, osm_nwr_signed_id_t _m_ref, std::string _m_role) :
-    m_role(_m_role), m_ref(_m_ref), m_type(_m_type) {};
+  RelationMember(const std::string &m_type, osm_nwr_signed_id_t m_ref, const std::string &m_role) :
+    m_role(m_role), m_ref(m_ref), m_type(m_type) {};
 
   void set_type(const std::string &type) {
 

--- a/include/cgimap/api06/changeset_upload_handler.hpp
+++ b/include/cgimap/api06/changeset_upload_handler.hpp
@@ -27,7 +27,7 @@ public:
 
 class changeset_upload_handler : public payload_enabled_handler {
 public:
-  changeset_upload_handler(request &req, osm_changeset_id_t id);
+  changeset_upload_handler(const request &req, osm_changeset_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/handler_utils.hpp
+++ b/include/cgimap/api06/handler_utils.hpp
@@ -18,7 +18,7 @@
 
 namespace api06 {
 
-std::vector<id_version> parse_id_list_params(request &req,
+std::vector<id_version> parse_id_list_params(const request &req,
                                              std::string_view param_name);
 }
 

--- a/include/cgimap/api06/map_handler.hpp
+++ b/include/cgimap/api06/map_handler.hpp
@@ -26,14 +26,14 @@ public:
 
 class map_handler : public handler {
 public:
-  map_handler(request &req);
+  explicit map_handler(request &req);
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;
 
 private:
   bbox bounds;
 
-  static bbox validate_request(request &req);
+  static bbox validate_request(const request &req);
 };
 
 } // namespace api06

--- a/include/cgimap/api06/node_handler.hpp
+++ b/include/cgimap/api06/node_handler.hpp
@@ -27,7 +27,7 @@ private:
 
 class node_handler : public handler {
 public:
-  node_handler(request &req, osm_nwr_id_t id);
+  node_handler(const request &req, osm_nwr_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/node_history_handler.hpp
+++ b/include/cgimap/api06/node_history_handler.hpp
@@ -23,7 +23,7 @@ public:
 
 class node_history_handler : public handler {
 public:
-  node_history_handler(request &, osm_nwr_id_t);
+  node_history_handler(const request &, osm_nwr_id_t);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &) const override;

--- a/include/cgimap/api06/node_relations_handler.hpp
+++ b/include/cgimap/api06/node_relations_handler.hpp
@@ -27,7 +27,7 @@ private:
 
 class node_relations_handler : public handler {
 public:
-  node_relations_handler(request &req, osm_nwr_id_t id);
+  node_relations_handler(const request &req, osm_nwr_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/node_version_handler.hpp
+++ b/include/cgimap/api06/node_version_handler.hpp
@@ -24,7 +24,7 @@ public:
 
 class node_version_handler : public handler {
 public:
-  node_version_handler(request &req, osm_nwr_id_t id, osm_version_t v);
+  node_version_handler(const request &req, osm_nwr_id_t id, osm_version_t v);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/node_ways_handler.hpp
+++ b/include/cgimap/api06/node_ways_handler.hpp
@@ -27,7 +27,7 @@ private:
 
 class node_ways_handler : public handler {
 public:
-  node_ways_handler(request &req, osm_nwr_id_t id);
+  node_ways_handler(const request &req, osm_nwr_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/nodes_handler.hpp
+++ b/include/cgimap/api06/nodes_handler.hpp
@@ -27,7 +27,7 @@ public:
 
 class nodes_handler : public handler {
 public:
-  nodes_handler(request &req);
+  explicit nodes_handler(const request &req);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;
@@ -35,7 +35,7 @@ public:
 private:
   std::vector<id_version> ids;
 
-  static std::vector<id_version> validate_request(request &req);
+  static std::vector<id_version> validate_request(const request &req);
 };
 
 } // namespace api06

--- a/include/cgimap/api06/relation_full_handler.hpp
+++ b/include/cgimap/api06/relation_full_handler.hpp
@@ -27,7 +27,7 @@ private:
 
 class relation_full_handler : public handler {
 public:
-  relation_full_handler(request &req, osm_nwr_id_t id);
+  relation_full_handler(const request &req, osm_nwr_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/relation_handler.hpp
+++ b/include/cgimap/api06/relation_handler.hpp
@@ -27,7 +27,7 @@ private:
 
 class relation_handler : public handler {
 public:
-  relation_handler(request &req, osm_nwr_id_t id);
+  relation_handler(const request &req, osm_nwr_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/relation_history_handler.hpp
+++ b/include/cgimap/api06/relation_history_handler.hpp
@@ -23,7 +23,7 @@ public:
 
 class relation_history_handler : public handler {
 public:
-  relation_history_handler(request &, osm_nwr_id_t);
+  relation_history_handler(const request &, osm_nwr_id_t);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &) const override;

--- a/include/cgimap/api06/relation_relations_handler.hpp
+++ b/include/cgimap/api06/relation_relations_handler.hpp
@@ -27,7 +27,7 @@ private:
 
 class relation_relations_handler : public handler {
 public:
-  relation_relations_handler(request &req, osm_nwr_id_t id);
+  relation_relations_handler(const request &req, osm_nwr_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/relation_version_handler.hpp
+++ b/include/cgimap/api06/relation_version_handler.hpp
@@ -24,7 +24,7 @@ public:
 
 class relation_version_handler : public handler {
 public:
-  relation_version_handler(request &req, osm_nwr_id_t id, osm_version_t v);
+  relation_version_handler(const request &req, osm_nwr_id_t id, osm_version_t v);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/relations_handler.hpp
+++ b/include/cgimap/api06/relations_handler.hpp
@@ -28,7 +28,7 @@ public:
 
 class relations_handler : public handler {
 public:
-  relations_handler(request &req);
+  explicit relations_handler(const request &req);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;
@@ -36,7 +36,7 @@ public:
 private:
   std::vector<id_version> ids;
 
-  static std::vector<id_version> validate_request(request &req);
+  static std::vector<id_version> validate_request(const request &req);
 };
 
 } // namespace api06

--- a/include/cgimap/api06/way_full_handler.hpp
+++ b/include/cgimap/api06/way_full_handler.hpp
@@ -27,7 +27,7 @@ private:
 
 class way_full_handler : public handler {
 public:
-  way_full_handler(request &req, osm_nwr_id_t id);
+  way_full_handler(const request &req, osm_nwr_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/way_handler.hpp
+++ b/include/cgimap/api06/way_handler.hpp
@@ -27,7 +27,7 @@ private:
 
 class way_handler : public handler {
 public:
-  way_handler(request &req, osm_nwr_id_t id);
+  way_handler(const request &req, osm_nwr_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/way_history_handler.hpp
+++ b/include/cgimap/api06/way_history_handler.hpp
@@ -23,7 +23,7 @@ public:
 
 class way_history_handler : public handler {
 public:
-  way_history_handler(request &, osm_nwr_id_t);
+  way_history_handler(const request &, osm_nwr_id_t);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &) const override;

--- a/include/cgimap/api06/way_relations_handler.hpp
+++ b/include/cgimap/api06/way_relations_handler.hpp
@@ -27,7 +27,7 @@ private:
 
 class way_relations_handler : public handler {
 public:
-  way_relations_handler(request &req, osm_nwr_id_t id);
+  way_relations_handler(const request &req, osm_nwr_id_t id);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/way_version_handler.hpp
+++ b/include/cgimap/api06/way_version_handler.hpp
@@ -24,7 +24,7 @@ public:
 
 class way_version_handler : public handler {
 public:
-  way_version_handler(request &req, osm_nwr_id_t id, osm_version_t v);
+  way_version_handler(const request &req, osm_nwr_id_t id, osm_version_t v);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;

--- a/include/cgimap/api06/ways_handler.hpp
+++ b/include/cgimap/api06/ways_handler.hpp
@@ -27,7 +27,7 @@ public:
 
 class ways_handler : public handler {
 public:
-  ways_handler(request &req);
+  explicit ways_handler(const request &req);
 
   std::string log_name() const override;
   responder_ptr_t responder(data_selection &x) const override;
@@ -35,7 +35,7 @@ public:
 private:
   std::vector<id_version> ids;
 
-  static std::vector<id_version> validate_request(request &req);
+  static std::vector<id_version> validate_request(const request &req);
 };
 
 } // namespace api06

--- a/include/cgimap/backend/apidb/transaction_manager.hpp
+++ b/include/cgimap/backend/apidb/transaction_manager.hpp
@@ -88,12 +88,11 @@ public:
   template<typename... Args>
   pqxx::result exec_prepared(const std::string &statement, Args&&... args) {
 
-    auto start = std::chrono::steady_clock::now();
-    pqxx::result res = m_txn.exec_prepared(statement, std::forward<Args>(args)...);
+    const auto start = std::chrono::steady_clock::now();
+    auto res(m_txn.exec_prepared(statement, std::forward<Args>(args)...));
+    const auto end = std::chrono::steady_clock::now();
 
-    auto end = std::chrono::steady_clock::now();
-
-    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
     logger::message(fmt::format("Executed prepared statement {} in {:d} ms, returning {:d} rows, {:d} affected rows",
                                statement,

--- a/include/cgimap/choose_formatter.hpp
+++ b/include/cgimap/choose_formatter.hpp
@@ -21,7 +21,7 @@
  * chooses and returns the best available mime type for a given request and
  * responder given the constraints in the Accept header and so forth.
  */
-mime::type choose_best_mime_type(request &req, const responder& hptr);
+mime::type choose_best_mime_type(const request &req, const responder& hptr);
 
 /**
  * creates and initialises an output formatter which matches the MIME type

--- a/include/cgimap/http.hpp
+++ b/include/cgimap/http.hpp
@@ -82,7 +82,7 @@ public:
  */
 class server_error : public exception {
 public:
-  server_error(const std::string &message);
+  explicit server_error(const std::string &message);
 };
 
 /**
@@ -91,7 +91,7 @@ public:
  */
 class bad_request : public exception {
 public:
-  bad_request(const std::string &message);
+  explicit bad_request(const std::string &message);
 };
 
 /**
@@ -101,7 +101,7 @@ public:
 
 class forbidden : public exception {
 public:
-   forbidden(const std::string &message);
+   explicit forbidden(const std::string &message);
 };
 
 /**
@@ -111,7 +111,7 @@ public:
  */
 class method_not_allowed : public exception {
 public:
-  method_not_allowed(const http::method method);
+  explicit method_not_allowed(http::method method);
   http::method allowed_methods;
 };
 
@@ -122,7 +122,7 @@ public:
  */
 class not_acceptable : public exception {
 public:
-  not_acceptable(const std::string &message);
+  explicit not_acceptable(const std::string &message);
 };
 
 /**
@@ -132,7 +132,7 @@ public:
  */
 class conflict : public exception {
 public:
-  conflict(const std::string &message);
+  explicit conflict(const std::string &message);
 };
 
 /**
@@ -141,7 +141,7 @@ public:
  */
 class precondition_failed : public exception {
 public:
-  precondition_failed(const std::string &message);
+  explicit precondition_failed(const std::string &message);
   const char *what() const noexcept override;
 private:
   std::string fullstring;
@@ -154,7 +154,7 @@ private:
 
 class payload_too_large : public exception {
 public:
-  payload_too_large(const std::string &message);
+  explicit payload_too_large(const std::string &message);
 };
 
 
@@ -165,7 +165,7 @@ public:
 
 class too_many_requests : public exception {
 public:
-  too_many_requests(const std::string &message);
+  explicit too_many_requests(const std::string &message);
 };
 
 
@@ -175,7 +175,7 @@ public:
  */
 class not_found : public exception {
 public:
-  not_found(const std::string &uri);
+  explicit not_found(const std::string &uri);
 };
 
 /**
@@ -183,7 +183,7 @@ public:
  */
 class bandwidth_limit_exceeded : public exception {
 public:
-  bandwidth_limit_exceeded(int retry_seconds);
+  explicit bandwidth_limit_exceeded(int retry_seconds);
   int retry_seconds;
 };
 
@@ -193,7 +193,7 @@ public:
 class gone : public exception {
 public:
   // TODO: fix up so that error message is meaningful
-  gone(const std::string &message = "");
+  explicit gone(const std::string &message = "");
 };
 
 /**
@@ -201,7 +201,7 @@ public:
  */
 class unauthorized : public exception {
 public:
-  unauthorized(const std::string &message);
+  explicit unauthorized(const std::string &message);
 };
 
 /**
@@ -210,7 +210,7 @@ public:
  */
 class unsupported_media_type : public exception {
 public:
-  unsupported_media_type(const std::string &message);
+  explicit unsupported_media_type(const std::string &message);
 };
 
 /**
@@ -251,7 +251,7 @@ private:
   const std::string name_;
 
 public:
-  encoding(std::string name) : name_(std::move(name)){}
+  explicit encoding(std::string name) : name_(std::move(name)){}
   virtual ~encoding() = default;
 
   const std::string &name() const { return name_; };

--- a/include/cgimap/infix_ostream_iterator.hpp
+++ b/include/cgimap/infix_ostream_iterator.hpp
@@ -38,7 +38,7 @@ private:
   bool _M_first{true};
 
 public:
-  infix_ostream_iterator(ostream_type &s)
+  explicit infix_ostream_iterator(ostream_type &s)
       : _M_stream(&s), _M_string(0) {}
   infix_ostream_iterator(ostream_type &s, const _CharT *c)
       : _M_stream(&s), _M_string(c) {}

--- a/include/cgimap/json_formatter.hpp
+++ b/include/cgimap/json_formatter.hpp
@@ -29,7 +29,7 @@ private:
   void write_common(const element_info &elem);
 
 public:
-  json_formatter(std::unique_ptr<json_writer> w);
+  explicit json_formatter(std::unique_ptr<json_writer> w);
   ~json_formatter() override;
 
   mime::type mime_type() const override;

--- a/include/cgimap/json_writer.hpp
+++ b/include/cgimap/json_writer.hpp
@@ -26,7 +26,7 @@ public:
   json_writer(json_writer &&) = default;
 
   // create a json writer using a callback object for output
-  json_writer(output_buffer &out, bool indent = false);
+  explicit json_writer(output_buffer &out, bool indent = false);
 
   // closes and flushes the buffer
   ~json_writer() noexcept override;

--- a/include/cgimap/oauth.hpp
+++ b/include/cgimap/oauth.hpp
@@ -113,7 +113,7 @@ using validity = std::variant<
 /**
  * Given a request, checks that the OAuth signature is valid.
  */
-validity::validity is_valid_signature(request &, secret_store &, nonce_store &,
+validity::validity is_valid_signature(const request &, secret_store &, nonce_store &,
                                       token_store &);
 
 namespace detail {
@@ -122,7 +122,7 @@ namespace detail {
  * Returns the hashed signature of the request, or none if that
  * can't be completed.
  */
-std::optional<std::string> hashed_signature(request &req, secret_store &store);
+std::optional<std::string> hashed_signature(const request &req, secret_store &store);
 
 /**
  * Given a request, returns the signature base string as defined
@@ -131,7 +131,7 @@ std::optional<std::string> hashed_signature(request &req, secret_store &store);
  * Returns none if the OAuth Authorization header could
  * not be parsed.
  */
-std::optional<std::string> signature_base_string(request &req);
+std::optional<std::string> signature_base_string(const request &req);
 
 /**
  * Given a request, returns a string containing the normalised
@@ -141,14 +141,14 @@ std::optional<std::string> signature_base_string(request &req);
  * Returns none if the OAuth Authorization header could
  * not be parsed.
  */
-std::optional<std::string> normalise_request_parameters(request &req);
+std::optional<std::string> normalise_request_parameters(const request &req);
 
 /**
  * Given a request, returns a string representing the normalised
  * URL according to the OAuth standard. See
  * http://oauth.net/core/1.0a/#rfc.section.9.1.2
  */
-std::string normalise_request_url(request &req);
+std::string normalise_request_url(const request &req);
 
 /**
  * Given a string, returns the base64 encoded version of that string,

--- a/include/cgimap/options.hpp
+++ b/include/cgimap/options.hpp
@@ -114,7 +114,7 @@ class global_settings_via_options : public global_settings_base {
 public:
   global_settings_via_options() = delete;
 
-  global_settings_via_options(const po::variables_map & options) {
+  explicit global_settings_via_options(const po::variables_map & options) {
 
     init_fallback_values(global_settings_default{}); // use default values as fallback
     set_new_options(options);

--- a/include/cgimap/osm_diffresult_responder.hpp
+++ b/include/cgimap/osm_diffresult_responder.hpp
@@ -23,7 +23,7 @@
 class osm_diffresult_responder : public osm_responder {
 public:
 
-  osm_diffresult_responder(mime::type);
+  explicit osm_diffresult_responder(mime::type);
 
   ~osm_diffresult_responder() override;
 

--- a/include/cgimap/osm_responder.hpp
+++ b/include/cgimap/osm_responder.hpp
@@ -30,7 +30,7 @@ class osm_responder : public responder {
 public:
   // construct, passing the mime type down to the responder.
   // optional bounds are stored at this level, but available to derived classes.
-  osm_responder(mime::type,
+  explicit osm_responder(mime::type,
                 std::optional<bbox> bounds = {});
 
   ~osm_responder() override = default;

--- a/include/cgimap/output_buffer.hpp
+++ b/include/cgimap/output_buffer.hpp
@@ -35,7 +35,7 @@ struct output_buffer {
 class identity_output_buffer : public output_buffer
 {
 public:
-    identity_output_buffer(output_buffer& o) : out(o) {}
+    explicit identity_output_buffer(output_buffer& o) : out(o) {}
 
     int write(const char *buffer, int len) override { return out.write(buffer, len); }
     int written() override { return out.written(); }

--- a/include/cgimap/output_writer.hpp
+++ b/include/cgimap/output_writer.hpp
@@ -44,7 +44,7 @@ public:
    */
   class write_error : public std::runtime_error {
   public:
-    write_error(const char *message);
+    explicit write_error(const char *message);
   };
 };
 

--- a/include/cgimap/process_request.hpp
+++ b/include/cgimap/process_request.hpp
@@ -24,7 +24,7 @@
  * process a single request.
  */
 void process_request(request &req, rate_limiter &limiter,
-                     const std::string &generator, routes &route,
+                     const std::string &generator, const routes &route,
                      data_selection::factory& factory,
                      data_update::factory* update_factory,
                      oauth::store* store);

--- a/include/cgimap/rate_limiter.hpp
+++ b/include/cgimap/rate_limiter.hpp
@@ -36,7 +36,7 @@ public:
   /**
    * Methods.
    */
-  memcached_rate_limiter(const boost::program_options::variables_map &options);
+  explicit memcached_rate_limiter(const boost::program_options::variables_map &options);
   ~memcached_rate_limiter() override;
   std::tuple<bool, int> check(const std::string &key, bool moderator) override;
   void update(const std::string &key, int bytes, bool moderator) override;

--- a/include/cgimap/request_helpers.hpp
+++ b/include/cgimap/request_helpers.hpp
@@ -18,7 +18,7 @@
  * Lookup a string from the request environment. Throws 500 error if the
  * string isn't there and no default value is given.
  */
-std::string fcgi_get_env(request &req, const char *name,
+std::string fcgi_get_env(const request &req, const char *name,
                          const char *default_value = nullptr);
 
 /**
@@ -29,22 +29,22 @@ std::string fcgi_get_env(request &req, const char *name,
  * case for doing routing/queueing in lighttpd. in that case, try and
  * parse the $REQUEST_URI.
  */
-std::string get_query_string(request &req);
+std::string get_query_string(const request &req);
 
 /**
  * get the path from the $REQUEST_URI variable.
  */
-std::string get_request_path(request &req);
+std::string get_request_path(const request &req);
 
 /**
  * get encoding to use for response.
  */
-std::unique_ptr<http::encoding> get_encoding(request &req);
+std::unique_ptr<http::encoding> get_encoding(const request &req);
 
 /**
  * return shared pointer to a buffer object which can be
  * used to write to the response body.
  */
-std::unique_ptr<output_buffer> make_output_buffer(request &req);
+std::unique_ptr<output_buffer> make_output_buffer(const request &req);
 
 #endif /* REQUEST_HELPERS_HPP */

--- a/include/cgimap/text_formatter.hpp
+++ b/include/cgimap/text_formatter.hpp
@@ -24,7 +24,7 @@ private:
   void write_common(const element_info &elem);
 
 public:
-  text_formatter(std::unique_ptr<text_writer> w);
+  explicit text_formatter(std::unique_ptr<text_writer> w);
   ~text_formatter() override = default;
 
   mime::type mime_type() const override;

--- a/include/cgimap/text_responder.hpp
+++ b/include/cgimap/text_responder.hpp
@@ -24,7 +24,7 @@ class text_responder : public responder {
 public:
   // construct, passing the mime type down to the responder.
   // optional bounds are stored at this level, but available to derived classes.
-  text_responder(mime::type);
+  explicit text_responder(mime::type);
 
   ~text_responder() override = default;
 

--- a/include/cgimap/text_writer.hpp
+++ b/include/cgimap/text_writer.hpp
@@ -27,7 +27,7 @@ public:
   text_writer(text_writer &&) = default;
 
   // create a new text writer using writer callback functions
-  text_writer(output_buffer &out, bool indent = false);
+  explicit text_writer(output_buffer &out, bool indent = false);
 
   // closes and flushes the text writer
   ~text_writer() noexcept override;

--- a/include/cgimap/xml_formatter.hpp
+++ b/include/cgimap/xml_formatter.hpp
@@ -25,7 +25,7 @@ private:
   void write_common(const element_info &elem);
 
 public:
-  xml_formatter(std::unique_ptr<xml_writer> w);
+  explicit xml_formatter(std::unique_ptr<xml_writer> w);
   ~xml_formatter() override = default;
 
   mime::type mime_type() const override;

--- a/include/cgimap/xml_writer.hpp
+++ b/include/cgimap/xml_writer.hpp
@@ -29,10 +29,10 @@ public:
 
   // create a new XML writer writing to file_name, which can be
   // "-" for stdout.
-  xml_writer(const std::string &file_name, bool indent = false);
+  explicit xml_writer(const std::string &file_name, bool indent = false);
 
   // create a new XML writer using writer callback functions
-  xml_writer(output_buffer &out, bool indent = false);
+  explicit xml_writer(output_buffer &out, bool indent = false);
 
   // closes and flushes the XML writer
   ~xml_writer() noexcept override;

--- a/include/cgimap/zlib.hpp
+++ b/include/cgimap/zlib.hpp
@@ -75,7 +75,7 @@ public:
 
 protected:
   ZLibBaseDecompressor() = default;
-  ZLibBaseDecompressor(int windowBits);
+  explicit ZLibBaseDecompressor(int windowBits);
 
 
 private:

--- a/src/api06/changeset_close_handler.cpp
+++ b/src/api06/changeset_close_handler.cpp
@@ -34,7 +34,7 @@ changeset_close_responder::changeset_close_responder(
 }
 
 
-changeset_close_handler::changeset_close_handler(request &,
+changeset_close_handler::changeset_close_handler(const request &,
                                                    osm_changeset_id_t id)
     : payload_enabled_handler(mime::text_plain,
                               http::method::PUT | http::method::OPTIONS),

--- a/src/api06/changeset_create_handler.cpp
+++ b/src/api06/changeset_create_handler.cpp
@@ -39,7 +39,7 @@ changeset_create_responder::changeset_create_responder(
   upd.commit();
 }
 
-changeset_create_handler::changeset_create_handler(request &)
+changeset_create_handler::changeset_create_handler(const request &)
     : payload_enabled_handler(mime::text_plain,
                               http::method::PUT | http::method::OPTIONS) {}
 

--- a/src/api06/changeset_download_handler.cpp
+++ b/src/api06/changeset_download_handler.cpp
@@ -26,7 +26,7 @@ changeset_download_responder::changeset_download_responder(
   sel.select_historical_by_changesets({id});
 }
 
-changeset_download_handler::changeset_download_handler(request &req, osm_changeset_id_t id)
+changeset_download_handler::changeset_download_handler(const request &req, osm_changeset_id_t id)
   : id(id) {
 }
 

--- a/src/api06/changeset_handler.cpp
+++ b/src/api06/changeset_handler.cpp
@@ -34,7 +34,7 @@ changeset_responder::changeset_responder(mime::type mt, osm_changeset_id_t id,
 }
 
 
-changeset_handler::changeset_handler(request &req, osm_changeset_id_t id)
+changeset_handler::changeset_handler(const request &req, osm_changeset_id_t id)
   : id(id), include_discussion(false) {
 
   std::string decoded = http::urldecode(get_query_string(req));

--- a/src/api06/changeset_update_handler.cpp
+++ b/src/api06/changeset_update_handler.cpp
@@ -55,7 +55,7 @@ changeset_update_sel_responder::changeset_update_sel_responder(
 }
 
 
-changeset_update_handler::changeset_update_handler(request &req, osm_changeset_id_t id)
+changeset_update_handler::changeset_update_handler(const request &req, osm_changeset_id_t id)
     : payload_enabled_handler(mime::application_xml,
                               http::method::PUT | http::method::OPTIONS),
       id(id) {}

--- a/src/api06/changeset_upload_handler.cpp
+++ b/src/api06/changeset_upload_handler.cpp
@@ -74,7 +74,7 @@ changeset_upload_responder::changeset_upload_responder(
   upd.commit();
 }
 
-changeset_upload_handler::changeset_upload_handler(request &,
+changeset_upload_handler::changeset_upload_handler(const request &,
                                                    osm_changeset_id_t id)
     : payload_enabled_handler(mime::unspecified_type,
                               http::method::POST | http::method::OPTIONS),

--- a/src/api06/handler_utils.cpp
+++ b/src/api06/handler_utils.cpp
@@ -79,7 +79,7 @@ bool valid_string(const std::string& str)
 		     [](char c){ return c >= 0 && c <= UCHAR_MAX; });
 }
 
-vector<id_version> parse_id_list_params(request &req, std::string_view param_name) {
+vector<id_version> parse_id_list_params(const request &req, std::string_view param_name) {
 
   string decoded = http::urldecode(get_query_string(req));
   const vector<pair<string, string> > params = http::parse_params(decoded);

--- a/src/api06/map_handler.cpp
+++ b/src/api06/map_handler.cpp
@@ -80,7 +80,7 @@ responder_ptr_t map_handler::responder(data_selection &x) const {
  * Validates an FCGI request, returning the valid bounding box or
  * throwing an error if there was no valid bounding box.
  */
-bbox map_handler::validate_request(request &req) {
+bbox map_handler::validate_request(const request &req) {
   string decoded = http::urldecode(get_query_string(req));
   const auto params = http::parse_params(decoded);
   auto itr =

--- a/src/api06/node_handler.cpp
+++ b/src/api06/node_handler.cpp
@@ -30,7 +30,7 @@ void node_responder::check_visibility(osm_nwr_id_t id) {
   }
 }
 
-node_handler::node_handler(request &, osm_nwr_id_t id) : id(id) {}
+node_handler::node_handler(const request &, osm_nwr_id_t id) : id(id) {}
 
 std::string node_handler::log_name() const { return "node"; }
 

--- a/src/api06/node_history_handler.cpp
+++ b/src/api06/node_history_handler.cpp
@@ -20,7 +20,7 @@ node_history_responder::node_history_responder(mime::type mt, osm_nwr_id_t id, d
   }
 }
 
-node_history_handler::node_history_handler(request &, osm_nwr_id_t id) : id(id) {}
+node_history_handler::node_history_handler(const request &, osm_nwr_id_t id) : id(id) {}
 
 std::string node_history_handler::log_name() const { return "node/history"; }
 

--- a/src/api06/node_relations_handler.cpp
+++ b/src/api06/node_relations_handler.cpp
@@ -26,7 +26,7 @@ bool node_relations_responder::is_visible(osm_nwr_id_t id) {
   return (!(sel.check_node_visibility(id) == data_selection::deleted));
 }
 
-node_relations_handler::node_relations_handler(request &, osm_nwr_id_t id) : id(id) {}
+node_relations_handler::node_relations_handler(const request &, osm_nwr_id_t id) : id(id) {}
 
 std::string node_relations_handler::log_name() const { return "node/relations"; }
 

--- a/src/api06/node_version_handler.cpp
+++ b/src/api06/node_version_handler.cpp
@@ -20,7 +20,7 @@ node_version_responder::node_version_responder(mime::type mt, osm_nwr_id_t id, o
   }
 }
 
-node_version_handler::node_version_handler(request &, osm_nwr_id_t id, osm_version_t v) : id(id), v(v) {}
+node_version_handler::node_version_handler(const request &, osm_nwr_id_t id, osm_version_t v) : id(id), v(v) {}
 
 std::string node_version_handler::log_name() const { return "node"; }
 

--- a/src/api06/node_ways_handler.cpp
+++ b/src/api06/node_ways_handler.cpp
@@ -26,7 +26,7 @@ bool node_ways_responder::is_visible(osm_nwr_id_t id) {
   return (!(sel.check_node_visibility(id) == data_selection::deleted));
 }
 
-node_ways_handler::node_ways_handler(request &, osm_nwr_id_t id) : id(id) {}
+node_ways_handler::node_ways_handler(const request &, osm_nwr_id_t id) : id(id) {}
 
 std::string node_ways_handler::log_name() const { return "node/ways"; }
 

--- a/src/api06/nodes_handler.cpp
+++ b/src/api06/nodes_handler.cpp
@@ -48,7 +48,7 @@ nodes_responder::nodes_responder(mime::type mt, const vector<id_version> &ids,
   }
 }
 
-nodes_handler::nodes_handler(request &req) : ids(validate_request(req)) {}
+nodes_handler::nodes_handler(const request &req) : ids(validate_request(req)) {}
 
 std::string nodes_handler::log_name() const {
   stringstream msg;
@@ -66,7 +66,7 @@ responder_ptr_t nodes_handler::responder(data_selection &x) const {
  * Validates an FCGI request, returning the valid list of ids or
  * throwing an error if there was no valid list of node ids.
  */
-vector<id_version> nodes_handler::validate_request(request &req) {
+vector<id_version> nodes_handler::validate_request(const request &req) {
   vector<id_version> ids = parse_id_list_params(req, "nodes");
 
   if (ids.empty()) {

--- a/src/api06/relation_full_handler.cpp
+++ b/src/api06/relation_full_handler.cpp
@@ -48,7 +48,7 @@ void relation_full_responder::check_visibility(osm_nwr_id_t id) {
   }
 }
 
-relation_full_handler::relation_full_handler(request &, osm_nwr_id_t id)
+relation_full_handler::relation_full_handler(const request &, osm_nwr_id_t id)
     : id(id) {
   logger::message(
       fmt::format("starting relation/full handler with id = {:d}", id));

--- a/src/api06/relation_handler.cpp
+++ b/src/api06/relation_handler.cpp
@@ -29,7 +29,7 @@ void relation_responder::check_visibility(osm_nwr_id_t id) {
   }
 }
 
-relation_handler::relation_handler(request &, osm_nwr_id_t id) : id(id) {}
+relation_handler::relation_handler(const request &, osm_nwr_id_t id) : id(id) {}
 
 std::string relation_handler::log_name() const { return "relation"; }
 

--- a/src/api06/relation_history_handler.cpp
+++ b/src/api06/relation_history_handler.cpp
@@ -20,7 +20,7 @@ relation_history_responder::relation_history_responder(mime::type mt, osm_nwr_id
   }
 }
 
-relation_history_handler::relation_history_handler(request &, osm_nwr_id_t id) : id(id) {}
+relation_history_handler::relation_history_handler(const request &, osm_nwr_id_t id) : id(id) {}
 
 std::string relation_history_handler::log_name() const { return "relation/history"; }
 

--- a/src/api06/relation_relations_handler.cpp
+++ b/src/api06/relation_relations_handler.cpp
@@ -27,7 +27,7 @@ bool relation_relations_responder::is_visible(osm_nwr_id_t id) {
   return (!(sel.check_relation_visibility(id) == data_selection::deleted));
 }
 
-relation_relations_handler::relation_relations_handler(request &, osm_nwr_id_t id) : id(id) {}
+relation_relations_handler::relation_relations_handler(const request &, osm_nwr_id_t id) : id(id) {}
 
 std::string relation_relations_handler::log_name() const { return "relation/relations"; }
 

--- a/src/api06/relation_version_handler.cpp
+++ b/src/api06/relation_version_handler.cpp
@@ -21,7 +21,7 @@ relation_version_responder::relation_version_responder(mime::type mt, osm_nwr_id
   }
 }
 
-relation_version_handler::relation_version_handler(request &, osm_nwr_id_t id, osm_version_t v) : id(id), v(v) {}
+relation_version_handler::relation_version_handler(const request &, osm_nwr_id_t id, osm_version_t v) : id(id), v(v) {}
 
 std::string relation_version_handler::log_name() const { return "relation"; }
 

--- a/src/api06/relations_handler.cpp
+++ b/src/api06/relations_handler.cpp
@@ -48,7 +48,7 @@ relations_responder::relations_responder(mime::type mt, const vector<id_version>
   }
 }
 
-relations_handler::relations_handler(request &req)
+relations_handler::relations_handler(const request &req)
     : ids(validate_request(req)) {}
 
 std::string relations_handler::log_name() const {
@@ -67,7 +67,7 @@ responder_ptr_t relations_handler::responder(data_selection &x) const {
  * Validates an FCGI request, returning the valid list of ids or
  * throwing an error if there was no valid list of node ids.
  */
-vector<id_version> relations_handler::validate_request(request &req) {
+vector<id_version> relations_handler::validate_request(const request &req) {
   vector<id_version> myids = parse_id_list_params(req, "relations");
 
   if (myids.empty()) {

--- a/src/api06/way_full_handler.cpp
+++ b/src/api06/way_full_handler.cpp
@@ -42,7 +42,7 @@ void way_full_responder::check_visibility(osm_nwr_id_t id) {
   }
 }
 
-way_full_handler::way_full_handler(request &, osm_nwr_id_t id) : id(id) {
+way_full_handler::way_full_handler(const request &, osm_nwr_id_t id) : id(id) {
   logger::message(
       fmt::format("starting way/full handler with id = {:d}", id));
 }

--- a/src/api06/way_handler.cpp
+++ b/src/api06/way_handler.cpp
@@ -30,7 +30,7 @@ void way_responder::check_visibility(osm_nwr_id_t id) {
   }
 }
 
-way_handler::way_handler(request &, osm_nwr_id_t id) : id(id) {}
+way_handler::way_handler(const request &, osm_nwr_id_t id) : id(id) {}
 
 std::string way_handler::log_name() const { return "way"; }
 

--- a/src/api06/way_history_handler.cpp
+++ b/src/api06/way_history_handler.cpp
@@ -20,7 +20,7 @@ way_history_responder::way_history_responder(mime::type mt, osm_nwr_id_t id, dat
   }
 }
 
-way_history_handler::way_history_handler(request &, osm_nwr_id_t id) : id(id) {}
+way_history_handler::way_history_handler(const request &, osm_nwr_id_t id) : id(id) {}
 
 std::string way_history_handler::log_name() const { return "way/history"; }
 

--- a/src/api06/way_relations_handler.cpp
+++ b/src/api06/way_relations_handler.cpp
@@ -27,7 +27,7 @@ bool way_relations_responder::is_visible(osm_nwr_id_t id) {
 }
 
 
-way_relations_handler::way_relations_handler(request &, osm_nwr_id_t id) : id(id) {}
+way_relations_handler::way_relations_handler(const request &, osm_nwr_id_t id) : id(id) {}
 
 std::string way_relations_handler::log_name() const { return "way/relations"; }
 

--- a/src/api06/way_version_handler.cpp
+++ b/src/api06/way_version_handler.cpp
@@ -22,7 +22,7 @@ way_version_responder::way_version_responder(mime::type mt, osm_nwr_id_t id, osm
   }
 }
 
-way_version_handler::way_version_handler(request &, osm_nwr_id_t id, osm_version_t v) : id(id), v(v) {}
+way_version_handler::way_version_handler(const request &, osm_nwr_id_t id, osm_version_t v) : id(id), v(v) {}
 
 std::string way_version_handler::log_name() const { return "way"; }
 

--- a/src/api06/ways_handler.cpp
+++ b/src/api06/ways_handler.cpp
@@ -43,7 +43,7 @@ ways_responder::ways_responder(mime::type mt, const std::vector<id_version>& ids
   }
 }
 
-ways_handler::ways_handler(request &req) : ids(validate_request(req)) {}
+ways_handler::ways_handler(const request &req) : ids(validate_request(req)) {}
 
 std::string ways_handler::log_name() const {
   std::stringstream msg;
@@ -61,7 +61,7 @@ responder_ptr_t ways_handler::responder(data_selection &x) const {
  * Validates an FCGI request, returning the valid list of ids or
  * throwing an error if there was no valid list of way ids.
  */
-std::vector<id_version> ways_handler::validate_request(request &req) {
+std::vector<id_version> ways_handler::validate_request(const request &req) {
   std::vector<id_version> myids = parse_id_list_params(req, "ways");
 
   if (myids.empty()) {

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -95,7 +95,7 @@ void registry::setup_options(int argc, char *argv[],
 
   po::variables_map vm = first_pass_argments(argc, argv, desc);
 
-  std::string backend = *default_backend;
+  std::string bcknd = *default_backend;
 
   // little hack - we want to print *all* the backends when --help is passed, so
   // we don't add one here when it's present. it's a nasty way to do it, but i
@@ -106,14 +106,14 @@ void registry::setup_options(int argc, char *argv[],
       auto itr =
           backends.find(vm["backend"].as<std::string>());
       if (itr != backends.end()) {
-        backend = itr->first;
+        bcknd = itr->first;
       }
       else {
         throw std::runtime_error(fmt::format("unknown backend provided, available options are: {}", all_backends));
       }
     }
 
-    desc.add(backends[backend]->options());
+    desc.add(backends[bcknd]->options());
   }
 }
 
@@ -125,48 +125,48 @@ void registry::output_options(std::ostream &out) {
 
 std::unique_ptr<data_selection::factory>
 registry::create(const po::variables_map &options) {
-  std::string backend = *default_backend;
+  std::string bcknd = *default_backend;
 
   if (options.count("backend")) {
     auto itr =
         backends.find(options["backend"].as<std::string>());
     if (itr != backends.end()) {
-      backend = itr->first;
+      bcknd = itr->first;
     }
   }
 
-  return backends[backend]->create(options);
+  return backends[bcknd]->create(options);
 }
 
 std::unique_ptr<data_update::factory>
 registry::create_data_update(const po::variables_map &options) {
-  std::string backend = *default_backend;
+  std::string bcknd = *default_backend;
 
   if (options.count("backend")) {
     auto itr =
         backends.find(options["backend"].as<std::string>());
     if (itr != backends.end()) {
-      backend = itr->first;
+      bcknd = itr->first;
     }
   }
 
-  return backends[backend]->create_data_update(options);
+  return backends[bcknd]->create_data_update(options);
 }
 
 
 std::unique_ptr<oauth::store>
 registry::create_oauth_store(const boost::program_options::variables_map &options) {
-  std::string backend = *default_backend;
+  std::string bcknd = *default_backend;
 
   if (options.count("backend")) {
     auto itr =
         backends.find(options["backend"].as<std::string>());
     if (itr != backends.end()) {
-      backend = itr->first;
+      bcknd = itr->first;
     }
   }
 
-  return backends[backend]->create_oauth_store(options);
+  return backends[bcknd]->create_oauth_store(options);
 }
 
 registry *registry_ptr = NULL;

--- a/src/choose_formatter.cpp
+++ b/src/choose_formatter.cpp
@@ -55,7 +55,7 @@ namespace {
 
 class acceptable_types {
 public:
-  acceptable_types(const std::string &accept_header);
+  explicit acceptable_types(const std::string &accept_header);
   bool is_acceptable(mime::type) const;
   // note: returns mime::unspecified_type if none were acceptable
   mime::type most_acceptable_of(const list<mime::type> &available) const;
@@ -205,13 +205,13 @@ acceptable_types::most_acceptable_of(const list<mime::type> &available) const {
  * figures out the preferred mime type(s) from the Accept headers, mapped to
  * their relative acceptability.
  */
-acceptable_types header_mime_type(request &req) {
+acceptable_types header_mime_type(const request &req) {
   // need to look at HTTP_ACCEPT request environment
   string accept_header = fcgi_get_env(req, "HTTP_ACCEPT", "*/*");
   return acceptable_types(accept_header);
 }
 
-std::string mime_types_to_string(const std::list<mime::type> mime_types)
+std::string mime_types_to_string(const std::list<mime::type> &mime_types)
 {
   std::string result;
 
@@ -226,7 +226,7 @@ std::string mime_types_to_string(const std::list<mime::type> mime_types)
 
 }
 
-mime::type choose_best_mime_type(request &req, const responder& hptr) {
+mime::type choose_best_mime_type(const request &req, const responder& hptr) {
   // figure out what, if any, the Accept-able resource mime types are
   acceptable_types types = header_mime_type(req);
   const list<mime::type> types_available = hptr.types_available();

--- a/src/fcgi_request.cpp
+++ b/src/fcgi_request.cpp
@@ -145,7 +145,6 @@ int fcgi_request::accept_r() {
   int status = FCGX_Accept_r(&m_impl->req);
   if (status < 0) {
     if (errno != EINTR) {
-      char err_buf[1024];
       std::ostringstream out;
 
       if (errno == ENOTSOCK) {
@@ -153,6 +152,7 @@ int fcgi_request::accept_r() {
                "--socket option (caused by ENOTSOCK).";
 
       } else {
+        char err_buf[1024];
         out << "error accepting request: ";
         if (strerror_r(errno, err_buf, sizeof err_buf) == 0) {
           out << err_buf;

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -172,7 +172,7 @@ unsupported_media_type::unsupported_media_type(const string &message)
 unauthorized::unauthorized(const std::string &message)
   : exception(401, message) {}
 
-method_not_allowed::method_not_allowed(const http::method method)
+method_not_allowed::method_not_allowed(http::method method)
    :  exception(405, http::list_methods(method)),
       allowed_methods(method) {}
 

--- a/src/oauth.cpp
+++ b/src/oauth.cpp
@@ -67,7 +67,7 @@ std::string upcase(const std::string &s) {
 }
 #endif /* HAVE_BOOST_LOCALE */
 
-std::string scheme(request &req) {
+std::string scheme(const request &req) {
   const char *https = req.get_param("HTTPS");
 
   if (https == NULL) {
@@ -78,7 +78,7 @@ std::string scheme(request &req) {
   }
 }
 
-std::string authority(request &req) {
+std::string authority(const request &req) {
   // from the OAuth 1.0a spec:
   // > URL scheme and authority MUST be lowercase and include the
   // > port number; http default port 80 and https default port 443
@@ -129,7 +129,7 @@ std::string authority(request &req) {
   return host;
 }
 
-std::string path(request &req) {
+std::string path(const request &req) {
   return get_request_path(req);
 }
 
@@ -240,7 +240,7 @@ bool parse_oauth_authorization(const char *auth_header, std::vector<param> &para
   return (success && (itr == end));
 }
 
-std::string request_method(request &req) {
+std::string request_method(const request &req) {
   const char *method = req.get_param("REQUEST_METHOD");
   if (method == NULL) {
     throw http::server_error("Request didn't set $REQUEST_METHOD parameter.");
@@ -252,7 +252,7 @@ std::string urlnormalise(const std::string &str) {
   return http::urlencode(http::urldecode(str));
 }
 
-bool get_all_request_parameters(request &req, std::vector<param> &params) {
+bool get_all_request_parameters(const request &req, std::vector<param> &params) {
   using params_t = std::vector<std::pair<std::string, std::string> >;
 
   { // add oauth params, except realm
@@ -294,7 +294,7 @@ bool get_all_request_parameters(request &req, std::vector<param> &params) {
   return true;
 }
 
-std::optional<std::string> find_auth_header_value(const std::string &key, request &req) {
+std::optional<std::string> find_auth_header_value(const std::string &key, const request &req) {
   std::vector<param> params;
   if (!get_all_request_parameters(req, params)) {
     return {};
@@ -310,15 +310,15 @@ std::optional<std::string> find_auth_header_value(const std::string &key, reques
   return {};
 }
 
-std::optional<std::string> signature_method(request &req) {
+std::optional<std::string> signature_method(const request &req) {
   return find_auth_header_value("oauth_signature_method", req);
 }
 
-std::optional<std::string> get_consumer_key(request &req) {
+std::optional<std::string> get_consumer_key(const request &req) {
   return find_auth_header_value("oauth_consumer_key", req);
 }
 
-std::optional<std::string> get_token_id(request &req) {
+std::optional<std::string> get_token_id(const request &req) {
   return find_auth_header_value("oauth_token", req);
 }
 
@@ -373,7 +373,7 @@ std::string base64_encode(const std::string &str) {
   return ostr.str();
 }
 
-std::optional<std::string> normalise_request_parameters(request &req) {
+std::optional<std::string> normalise_request_parameters(const request &req) {
   std::vector<param> params;
 
   if (!get_all_request_parameters(req, params)) {
@@ -392,7 +392,7 @@ std::optional<std::string> normalise_request_parameters(request &req) {
   return out.str();
 }
 
-std::string normalise_request_url(request &req) {
+std::string normalise_request_url(const request &req) {
   std::ostringstream out;
 
   out << downcase(scheme(req)) << "://"
@@ -406,7 +406,7 @@ std::string normalise_request_url(request &req) {
   return out.str();
 }
 
-std::optional<std::string> signature_base_string(request &req) {
+std::optional<std::string> signature_base_string(const request &req) {
   std::ostringstream out;
 
   std::optional<std::string> request_params =
@@ -423,7 +423,7 @@ std::optional<std::string> signature_base_string(request &req) {
   return out.str();
 }
 
-std::optional<std::string> hashed_signature(request &req, secret_store &store) {
+std::optional<std::string> hashed_signature(const request &req, secret_store &store) {
   std::optional<std::string> method = signature_method(req);
   if (!method || ((*method != "HMAC-SHA1") && (*method != "PLAINTEXT"))) {
     return {};
@@ -469,7 +469,7 @@ std::optional<std::string> hashed_signature(request &req, secret_store &store) {
 }
 
 validity::validity is_valid_signature(
-  request &req, secret_store &store,
+  const request &req, secret_store &store,
   nonce_store &nonces, token_store &tokens) {
 
   std::optional<std::string>
@@ -559,7 +559,7 @@ validity::validity is_valid_signature(
 } // namespace detail
 
 validity::validity is_valid_signature(
-  request &req, secret_store &store,
+  const request &req, secret_store &store,
   nonce_store &nonces, token_store &tokens) {
 
   try {

--- a/src/process_request.cpp
+++ b/src/process_request.cpp
@@ -170,7 +170,7 @@ void respond_error(const http::exception &e, request &r) {
  * Return a 405 error.
  */
 
-void process_not_allowed(request &req, handler& handler) {
+void process_not_allowed(request &req, const handler& handler) {
   req.status(405)
      .add_header("Allow", http::list_methods(handler.allowed_methods()))
      .add_header("Content-Type", "text/html")
@@ -241,7 +241,7 @@ std::size_t generate_response(request &req, responder &responder, const string &
  * process a GET request.
  */
 std::tuple<string, size_t>
-process_get_request(request &req, handler& handler,
+process_get_request(request &req, const handler& handler,
                     data_selection& selection,
                     const string &ip, const string &generator) {
   // request start logging
@@ -261,8 +261,8 @@ process_get_request(request &req, handler& handler,
  * process a POST/PUT request.
  */
 std::tuple<string, size_t>
-process_post_put_request(request &req, handler& handler,
-                    data_selection::factory& factory,
+process_post_put_request(request &req, const handler& handler,
+                    const data_selection::factory& factory,
                     data_update::factory& update_factory,
                     std::optional<osm_user_id_t> user_id,
                     const string &ip, const string &generator) {
@@ -274,7 +274,7 @@ process_post_put_request(request &req, handler& handler,
   logger::message(fmt::format("Started request for {} from {}", request_name, ip));
 
   try {
-    payload_enabled_handler& pe_handler = dynamic_cast< payload_enabled_handler& >(handler);
+    const auto & pe_handler = dynamic_cast< const payload_enabled_handler& >(handler);
 
     // Process request, perform database update
     {
@@ -324,7 +324,7 @@ process_post_put_request(request &req, handler& handler,
  * process a HEAD request.
  */
 std::tuple<string, size_t>
-process_head_request(request &req, handler& handler,
+process_head_request(request &req, const handler& handler,
                      data_selection& selection,
                      const string &ip) {
   // request start logging
@@ -364,7 +364,7 @@ process_head_request(request &req, handler& handler,
  * process an OPTIONS request.
  */
 std::tuple<string, size_t> process_options_request(
-  request &req, handler& handler) {
+  request &req, const handler& handler) {
 
   static const string request_name = "OPTIONS";
   const char *origin = req.get_param("HTTP_ORIGIN");
@@ -433,7 +433,7 @@ struct oauth_status_response  {
 
 // look in the request get parameters to see if the user requested that
 // redactions be shown
-bool show_redactions_requested(request &req) {
+bool show_redactions_requested(const request &req) {
   using params_t = std::vector<std::pair<std::string, std::string> >;
   std::string decoded = http::urldecode(get_query_string(req));
   const params_t params = http::parse_params(decoded);
@@ -447,7 +447,7 @@ bool show_redactions_requested(request &req) {
 
 
 // Determine user id and allow_api_write flag based on Basic Auth or OAuth header
-std::optional<osm_user_id_t> determine_user_id (request& req,
+std::optional<osm_user_id_t> determine_user_id (const request& req,
 			        data_selection& selection,
 			        oauth::store* store,
 			        bool& allow_api_write)
@@ -501,7 +501,7 @@ std::optional<osm_user_id_t> determine_user_id (request& req,
  * process a single request.
  */
 void process_request(request &req, rate_limiter &limiter,
-                     const string &generator, routes &route,
+                     const string &generator, const routes &route,
                      data_selection::factory& factory,
                      data_update::factory* update_factory,
                      oauth::store* store) {

--- a/src/request_helpers.cpp
+++ b/src/request_helpers.cpp
@@ -16,7 +16,7 @@
 
 using std::string;
 
-string fcgi_get_env(request &req, const char *name, const char *default_value) {
+string fcgi_get_env(const request &req, const char *name, const char *default_value) {
   assert(name);
   const char *v = req.get_param(name);
 
@@ -33,7 +33,7 @@ string fcgi_get_env(request &req, const char *name, const char *default_value) {
   return string(v);
 }
 
-string get_query_string(request &req) {
+string get_query_string(const request &req) {
   // try the query string that's supposed to be present first
   const char *query_string = req.get_param("QUERY_STRING");
 
@@ -62,7 +62,7 @@ string get_query_string(request &req) {
   }
 }
 
-std::string get_request_path(request &req) {
+std::string get_request_path(const request &req) {
   const char *request_uri = req.get_param("REQUEST_URI");
 
   if ((request_uri == NULL) || (strlen(request_uri) == 0)) {
@@ -89,7 +89,7 @@ std::string get_request_path(request &req) {
 /**
  * get encoding to use for response.
  */
-std::unique_ptr<http::encoding> get_encoding(request &req) {
+std::unique_ptr<http::encoding> get_encoding(const request &req) {
   const char *accept_encoding = req.get_param("HTTP_ACCEPT_ENCODING");
 
   if (accept_encoding) {
@@ -128,7 +128,7 @@ public:
 
   ~fcgi_output_buffer() override = default;
 
-  fcgi_output_buffer(request &req) : r(req) {}
+  explicit fcgi_output_buffer(request &req) : r(req) {}
 
 private:
   request &r;

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -20,11 +20,7 @@
 std::chrono::system_clock::time_point parse_time(const std::string &s) {
   // parse only YYYY-MM-DDTHH:MM:SSZ
   if ((s.size() == 20) && (s[19] == 'Z')) {
-    // chop off the trailing 'Z' so as not to interfere with the standard
-    // parsing.
-    std::string without_tz = s.substr(0, 19);
-
-    std::tm tm = {};
+    std::tm tm{};
     strptime(s.c_str(), "%FT%T%z", &tm);
     auto tp = std::chrono::system_clock::from_time_t(timegm(&tm));
 

--- a/src/zlib.cpp
+++ b/src/zlib.cpp
@@ -27,8 +27,6 @@ zlib_output_buffer::zlib_output_buffer(output_buffer& o,
   case gzip:
     windowBits = 15 + 16;
     break;
-  default:
-    throw;
   }
 
   stream.zalloc = Z_NULL;

--- a/test/test_apidb_backend_oauth2.cpp
+++ b/test/test_apidb_backend_oauth2.cpp
@@ -132,7 +132,7 @@ void add_common_headers(test_request& req)
 }
 
 
-int create_changeset(test_database &tdb, oauth::store& store, std::string token) {
+int create_changeset(test_database &tdb, oauth::store& store, const std::string &token) {
 
   // Test valid token, create empty changeset
   recording_rate_limiter limiter;
@@ -159,7 +159,7 @@ int create_changeset(test_database &tdb, oauth::store& store, std::string token)
   return (req.response_status());
 }
 
-int fetch_relation(test_database &tdb, oauth::store& store, std::string token) {
+int fetch_relation(test_database &tdb, oauth::store& store, const std::string &token) {
 
   recording_rate_limiter limiter;
   std::string generator("test_apidb_backend.cpp");

--- a/test/test_core.cpp
+++ b/test/test_core.cpp
@@ -479,7 +479,7 @@ void check_response(std::istream &expected, std::istream &actual) {
  *  - compares the result to what's expected in the test case.
  */
 void run_test(fs::path test_case, rate_limiter &limiter,
-              const std::string &generator, routes &route,
+              const std::string &generator, const routes &route,
               data_selection::factory& factory,
               oauth::store* store) {
   try {
@@ -530,7 +530,7 @@ osm_user_role_t parse_role(const std::string &str) {
 
 struct test_oauth : public oauth::store {
 
-  test_oauth(const pt::ptree &config) {
+  explicit test_oauth(const pt::ptree &config) {
     boost::optional<const pt::ptree &> consumers =
       config.get_child_optional("consumers");
     if (consumers) {

--- a/test/test_database.cpp
+++ b/test/test_database.cpp
@@ -19,7 +19,7 @@
 namespace fs = std::filesystem;
 namespace po = boost::program_options;
 
-test_database::setup_error::setup_error(std::string str)
+test_database::setup_error::setup_error(const std::string &str)
   : m_str(str) {
 }
 

--- a/test/test_database.hpp
+++ b/test/test_database.hpp
@@ -33,7 +33,7 @@ struct test_database {
   // allow the test to be skipped, as people might not have or want an
   // apidb database set up on their local machines.
   struct setup_error : public std::exception {
-    setup_error(std::string fmt);
+    explicit setup_error(const std::string &fmt);
     ~setup_error() noexcept override = default;
     const char *what() const noexcept override;
 

--- a/test/test_oauth.cpp
+++ b/test/test_oauth.cpp
@@ -275,14 +275,14 @@ struct test_secret_store
     , m_token_secret(token_secret) {
   }
 
-  std::optional<std::string> consumer_secret(const std::string &key) {
+  std::optional<std::string> consumer_secret(const std::string &key) override {
     if (key == m_consumer_key) {
       return m_consumer_secret;
     }
     return {};
   }
 
-  std::optional<std::string> token_secret(const std::string &id) {
+  std::optional<std::string> token_secret(const std::string &id) override {
     if (id == m_token_id) {
       return m_token_secret;
     }
@@ -290,7 +290,7 @@ struct test_secret_store
   }
 
   bool use_nonce(const std::string &nonce,
-                 uint64_t timestamp) {
+                 uint64_t timestamp) override {
     std::tuple<std::string, uint64_t> tuple =
       std::make_tuple(nonce, timestamp);
     if (m_nonces.count(tuple) > 0) {
@@ -300,26 +300,26 @@ struct test_secret_store
     return true;
   }
 
-  bool allow_read_api(const std::string &id) {
+  bool allow_read_api(const std::string &id) override {
     return id == m_token_id;
   }
 
-  bool allow_write_api(const std::string &id) {
+  bool allow_write_api(const std::string &id) override {
     return id == m_token_id;
   }
 
-  std::optional<osm_user_id_t> get_user_id_for_token(const std::string &id) {
+  std::optional<osm_user_id_t> get_user_id_for_token(const std::string &id) override {
     return {};
   }
 
-  std::optional<osm_user_id_t> get_user_id_for_oauth2_token(const std::string &token_id, bool& expired, bool& revoked, bool& allow_api_write) {
+  std::optional<osm_user_id_t> get_user_id_for_oauth2_token(const std::string &token_id, bool& expired, bool& revoked, bool& allow_api_write) override {
     expired = false;
     revoked = false;
     allow_api_write = false;
     return {};
   }
 
-  std::set<osm_user_role_t> get_roles_for_user(osm_user_id_t) {
+  std::set<osm_user_role_t> get_roles_for_user(osm_user_id_t) override {
     return std::set<osm_user_role_t>();
   }
 


### PR DESCRIPTION
Command: `cppcheck --enable=all src/**.cpp test/**.cpp -Iinclude/`

There are still a few left, though the majority of reported issues is gone now. Mostly const, explicit and override findings.