### PR TITLE
Automatically create github release for tagged versions

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,70 @@
+name: Create release for tagged versions
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    name: Create release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Log in to the github container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=sha,format=long
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+
+      - name: Build Docker images
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
+        with:
+          file: Dockerfile2204
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Get first docker image tag
+        env:
+          DOCKER_IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        id: image_tag
+        run: echo "TAG=${DOCKER_IMAGE_TAGS%%[[:space:]]*}" >> "$GITHUB_OUTPUT"
+
+      - uses: shrink/actions-docker-extract@v3
+        id: extract
+        with:
+          image: ${{ steps.image_tag.outputs.TAG }}
+          path: /usr/local/bin/openstreetmap-cgimap
+
+      - name: Create release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ steps.extract.outputs.destination }}/openstreetmap-cgimap


### PR DESCRIPTION
Use github actions to automatically create a release for versions tagged with `v*.*.*`

- Build a docker image and upload to github container repository.
- Upload pre-built binary as release artifact.

Currently based on Ubuntu 22.04 docker image