### PR TITLE
Update make clang-format target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -139,19 +139,22 @@ if HAVE_CLANG_FORMAT
 .PHONY: clang-format
 clang-format:
 	@echo "Reformatting files..."; \
-	for i in include/api06/*.hpp; do @CLANG_FORMAT@ -style=file -i $$i; done; \
-	for i in include/cgimap/api06/*.hpp; do @CLANG_FORMAT@ -style=file -i $$i; done; \
-	for i in include/cgimap/api07/*.hpp; do @CLANG_FORMAT@ -style=file -i $$i; done; \
-	for i in include/cgimap/backend/apidb/*.hpp; do @CLANG_FORMAT@ -style=file -i $$i; done; \
-	for i in include/cgimap/backend/staticxml/*.hpp; do @CLANG_FORMAT@ -style=file -i $$i; done; \
-	for i in include/cgimap/*.hpp; do @CLANG_FORMAT@ -style=file -i $$i; done; \
-	for i in include/*.hpp; do @CLANG_FORMAT@ -style=file -i $$i; done; \
-	for i in src/api06/*.cpp; do @CLANG_FORMAT@ -style=file -i $$i; done; \
-	for i in src/api07/*.cpp; do @CLANG_FORMAT@ -style=file -i $$i; done; \
-	for i in src/backend/apidb/*.cpp; do @CLANG_FORMAT@ -style=file -i $$i; done; \
-	for i in src/backend/staticxml/*.cpp; do @CLANG_FORMAT@ -style=file -i $$i; done; \
-	for i in src/*.cpp; do @CLANG_FORMAT@ -style=file -i $$i; done; \
-	for i in test/*.cpp; do @CLANG_FORMAT@ -style=file -i $$i; done;
+	for i in include/cgimap/*.hpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in include/cgimap/api06/*.hpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in include/cgimap/api06/changeset_upload/*.hpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in include/cgimap/api07/*.hpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in include/cgimap/backend/apidb/*.hpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in include/cgimap/backend/apidb/changeset_upload/*.hpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in include/cgimap/backend/staticxml/*.hpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in src/*.cpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in src/api06/*.cpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in src/api06/changeset_upload/*.cpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in src/api07/*.cpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in src/backend/apidb/*.cpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in src/backend/apidb/changeset_upload/*.cpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in src/backend/staticxml/*.cpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in test/*.cpp; do @CLANG_FORMAT@ -i $$i; done; \
+	for i in test/*.hpp; do @CLANG_FORMAT@ -i $$i; done;
 endif
 
 man1_MANS = openstreetmap-cgimap.1

--- a/configure.ac
+++ b/configure.ac
@@ -125,7 +125,7 @@ AC_ARG_WITH([clang-format],
 	[AS_HELP_STRING([--with-clang-format@<:@=ARG@:>@],
 	   [Enable re-formatting source code with clang-format. @<:@ARG=no@:>@ ])],
 	[case "${withval}" in
-	  yes ) prog_clang_format="clang-format-3.6" ;;
+	  yes ) prog_clang_format="clang-format" ;;
 	  no ) prog_clang_format="no" ;;
 	  * ) prog_clang_format="${withval}" ;;
 	 esac],


### PR DESCRIPTION
This at least allows it to run again. The `.clang-format` style file produces some suboptimal results and should be updated.