### PR TITLE
Fix program option --instances

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -377,7 +377,7 @@ void daemon_mode(const po::variables_map &options, int socket)
 
 void non_daemon_mode(const po::variables_map &options, int socket)
 {
-  if (options.count("instances")) {
+  if (options.count("instances") && !options["instances"].defaulted()) {
     std::cerr << "[WARN] The --instances parameter is ignored in non-daemon mode, running as single process only.\n"
                  "[WARN] If the process terminates, it must be restarted externally.\n";
   }


### PR DESCRIPTION
See https://github.com/zerebubuth/openstreetmap-cgimap/pull/336#issuecomment-1848958961 

Commit message should be really "defaulted value" rather  "default value". A warning is also shown when adding `--instances=5`, even though 5 is the default value.

Also moved some static functions in main.cpp to an anonymous namespace and removed "static".
