### PR TITLE
Reduce temporary allocations for xml serialization

### DIFF
--- a/include/cgimap/output_formatter.hpp
+++ b/include/cgimap/output_formatter.hpp
@@ -146,6 +146,11 @@ using comments_t = std::vector<changeset_comment_info>;
  * of course, that we want any other formats ;-)
  */
 struct output_formatter {
+  static constexpr const char * API_VERSION = "0.6";
+  static constexpr const char * COPYRIGHT = "OpenStreetMap and contributors";
+  static constexpr const char * ATTRIBUTION = "http://www.openstreetmap.org/copyright";
+  static constexpr const char * LICENSE = "http://opendatacommons.org/licenses/odbl/1-0/";
+
   virtual ~output_formatter() = default;
 
   // returns the mime type of the content that this formatter will

--- a/include/cgimap/util.hpp
+++ b/include/cgimap/util.hpp
@@ -24,6 +24,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <type_traits>
 
 
 

--- a/src/json_formatter.cpp
+++ b/src/json_formatter.cpp
@@ -64,11 +64,11 @@ void json_formatter::start_document(
   const std::string &generator, const std::string &root_name) {
   writer->start_object();
 
-  WRITE_KV("version", string, "0.6");
+  WRITE_KV("version", string, output_formatter::API_VERSION);
   WRITE_KV("generator", string, generator);
-  WRITE_KV("copyright", string, "OpenStreetMap and contributors");
-  WRITE_KV("attribution", string, "http://www.openstreetmap.org/copyright");
-  WRITE_KV("license", string, "http://opendatacommons.org/licenses/odbl/1-0/");
+  WRITE_KV("copyright", string, output_formatter::COPYRIGHT);
+  WRITE_KV("attribution", string, output_formatter::ATTRIBUTION);
+  WRITE_KV("license", string, output_formatter::LICENSE);
 }
 
 void json_formatter::write_bounds(const bbox &bounds) {

--- a/src/xml_formatter.cpp
+++ b/src/xml_formatter.cpp
@@ -43,14 +43,12 @@ mime::type xml_formatter::mime_type() const { return mime::application_xml; }
 void xml_formatter::start_document(
   const std::string &generator, const std::string &root_name) {
   writer->start(root_name);
-  writer->attribute("version", string("0.6"));
+  writer->attribute("version", output_formatter::API_VERSION);
   writer->attribute("generator", generator);
 
-  writer->attribute("copyright", string("OpenStreetMap and contributors"));
-  writer->attribute("attribution",
-                    string("http://www.openstreetmap.org/copyright"));
-  writer->attribute("license",
-                    string("http://opendatacommons.org/licenses/odbl/1-0/"));
+  writer->attribute("copyright", output_formatter::COPYRIGHT);
+  writer->attribute("attribution", output_formatter::ATTRIBUTION);
+  writer->attribute("license", output_formatter::LICENSE);
 }
 
 void xml_formatter::end_document() { writer->end(); }

--- a/src/xml_writer.cpp
+++ b/src/xml_writer.cpp
@@ -14,6 +14,8 @@
 #include <iostream>
 #include <utility>
 #include "cgimap/xml_writer.hpp"
+#include <fmt/core.h>
+#include <fmt/compile.h>
 
 struct xml_writer::pimpl_ {
   xmlTextWriterPtr writer;
@@ -121,11 +123,22 @@ void xml_writer::attribute(const char *name, const char *value) {
 }
 
 void xml_writer::attribute(const char *name, double value) {
-  int rc = xmlTextWriterWriteFormatAttribute(
-    pimpl->writer,
-    reinterpret_cast<const xmlChar *>(name),
-    "%.7f",
-    value);
+  const char* str = nullptr;
+
+#if FMT_VERSION >= 90000
+  std::array<char, 384> buf;
+  constexpr size_t max_chars = buf.size() - 1;
+  auto [end, n_written] = fmt::format_to_n(buf.begin(), max_chars, FMT_COMPILE("{:.7f}"), value);
+  if (n_written > max_chars)
+    throw write_error("cannot convert double-precision attribute to string.");
+  *end = '\0'; // Null terminate string
+  str = buf.data();
+#else
+  auto s = fmt::format("{:.7f}", value);
+  str = s.c_str();
+#endif
+
+  int rc = writeAttribute(name, str);
   if (rc < 0) {
     throw write_error("cannot write double-precision attribute.");
   }

--- a/src/xml_writer.cpp
+++ b/src/xml_writer.cpp
@@ -35,7 +35,7 @@ xml_writer::xml_writer(const std::string &file_name, bool indent)
 static int wrap_write(void *context, const char *buffer, int len) {
   auto *out = static_cast<output_buffer *>(context);
 
-  if (out == 0) {
+  if (out == nullptr) {
     throw xml_writer::write_error("Output buffer was NULL in wrap_write().");
   }
 
@@ -45,7 +45,7 @@ static int wrap_write(void *context, const char *buffer, int len) {
 static int wrap_close(void *context) {
   auto *out = static_cast<output_buffer *>(context);
 
-  if (out == 0) {
+  if (out == nullptr) {
     throw xml_writer::write_error("Output buffer was NULL in wrap_close().");
   }
 
@@ -99,80 +99,48 @@ xml_writer::~xml_writer() noexcept {
   xmlFreeTextWriter(pimpl->writer);
 }
 
-void xml_writer::start(const std::string &name) {
-  if (xmlTextWriterStartElement(pimpl->writer, reinterpret_cast<const xmlChar *>(name.c_str())) < 0) {
+void xml_writer::start(const char *name) {
+  if (xmlTextWriterStartElement(pimpl->writer, reinterpret_cast<const xmlChar *>(name)) < 0) {
     throw write_error("cannot start element.");
   }
 }
 
-void xml_writer::attribute(const std::string &name, const std::string &value) {
-  int rc = xmlTextWriterWriteAttribute(pimpl->writer, reinterpret_cast<const xmlChar *>(name.c_str()),
-				       reinterpret_cast<const xmlChar *>(value.c_str()));
+void xml_writer::attribute(const char *name, const std::string &value) {
+  int rc = writeAttribute(name, value.c_str());
   if (rc < 0) {
     throw write_error("cannot write attribute.");
   }
 }
 
-void xml_writer::attribute(const std::string &name, const char *value) {
-  const char *c_str = (value == NULL) ? "" : value;
-  int rc = xmlTextWriterWriteAttribute(pimpl->writer, reinterpret_cast<const xmlChar *>(name.c_str()),
-				       reinterpret_cast<const xmlChar *>(c_str));
+void xml_writer::attribute(const char *name, const char *value) {
+  const char *c_str = value ? value : "";
+  int rc = writeAttribute(name, c_str);
   if (rc < 0) {
     throw write_error("cannot write attribute.");
   }
 }
 
-void xml_writer::attribute(const std::string &name, double value) {
+void xml_writer::attribute(const char *name, double value) {
   int rc = xmlTextWriterWriteFormatAttribute(
-      pimpl->writer, reinterpret_cast<const xmlChar *>(name.c_str()), "%.7f", value);
+    pimpl->writer,
+    reinterpret_cast<const xmlChar *>(name),
+    "%.7f",
+    value);
   if (rc < 0) {
     throw write_error("cannot write double-precision attribute.");
   }
 }
 
-void xml_writer::attribute(const std::string &name, int32_t value) {
-  int rc = xmlTextWriterWriteFormatAttribute(
-      pimpl->writer, reinterpret_cast<const xmlChar *>(name.c_str()), "%" PRId32, value);
-  if (rc < 0) {
-    throw write_error("cannot write int32_t attribute.");
-  }
-}
-
-void xml_writer::attribute(const std::string &name, int64_t value) {
-  int rc = xmlTextWriterWriteFormatAttribute(
-      pimpl->writer, reinterpret_cast<const xmlChar *>(name.c_str()), "%" PRId64, value);
-  if (rc < 0) {
-    throw write_error("cannot write int64_t attribute.");
-  }
-}
-
-void xml_writer::attribute(const std::string &name, uint32_t value) {
-  int rc = xmlTextWriterWriteFormatAttribute(
-      pimpl->writer, reinterpret_cast<const xmlChar *>(name.c_str()), "%" PRIu32, value);
-  if (rc < 0) {
-    throw write_error("cannot write uint32_t attribute.");
-  }
-}
-
-void xml_writer::attribute(const std::string &name, uint64_t value) {
-  int rc = xmlTextWriterWriteFormatAttribute(
-      pimpl->writer, reinterpret_cast<const xmlChar *>(name.c_str()), "%" PRIu64, value);
-  if (rc < 0) {
-    throw write_error("cannot write uint64_t attribute.");
-  }
-}
-
-void xml_writer::attribute(const std::string &name, bool value) {
+void xml_writer::attribute(const char *name, bool value) {
   const char *str = value ? "true" : "false";
-  int rc = xmlTextWriterWriteAttribute(pimpl->writer, reinterpret_cast<const xmlChar *>(name.c_str()),
-				       reinterpret_cast<const xmlChar *>(str));
+  int rc = writeAttribute(name, str);
   if (rc < 0) {
     throw write_error("cannot write boolean attribute.");
   }
 }
 
-void xml_writer::text(const std::string &t) {
-  if (xmlTextWriterWriteString(pimpl->writer, reinterpret_cast<const xmlChar *>(t.c_str())) < 0) {
+void xml_writer::text(const char* t) {
+  if (xmlTextWriterWriteString(pimpl->writer, reinterpret_cast<const xmlChar *>(t)) < 0) {
     throw write_error("cannot write text string.");
   }
 }
@@ -193,6 +161,14 @@ void xml_writer::error(const std::string &s) {
   start("error");
   text(s);
   end();
+}
+
+int xml_writer::writeAttribute(const char* name, const char* value) {
+  int rc = xmlTextWriterWriteAttribute(
+    pimpl->writer,
+    reinterpret_cast<const xmlChar *>(name),
+    reinterpret_cast<const xmlChar *>(value));
+  return rc;
 }
 
 // TODO: move this to its own file


### PR DESCRIPTION
- Use std::to_chars to convert integers to strings for xml serialization instead of xml attribute string formatter 
  - No temporary heap allocations
    - At _least_ 4 temporary heap allocations per element eliminated (element id, element version, changeset number, last user id)
  - std::to_chars is generally the fastest string conversion function available
- Add char* overloads for xml_writer functions to avoid temporary std::string allocations
  - Passing string literals to a const std::string& parameter requires a temporary std::string object. (libxml2 only uses char* anyway.)
- Deduplicate and move common string constants to base formatter class