### PR TITLE
Relocate two methods to data_selection class

### DIFF
--- a/include/cgimap/backend/apidb/oauth_store.hpp
+++ b/include/cgimap/backend/apidb/oauth_store.hpp
@@ -25,8 +25,6 @@ public:
   bool allow_read_api(const std::string &token_id) override;
   bool allow_write_api(const std::string &token_id) override;
   std::optional<osm_user_id_t> get_user_id_for_token(const std::string &token_id) override;
-  std::set<osm_user_role_t> get_roles_for_user(osm_user_id_t id) override;
-  std::optional<osm_user_id_t> get_user_id_for_oauth2_token(const std::string &token_id, bool& expired, bool& revoked, bool& allow_api_write) override;
 
 private:
   pqxx::connection m_connection;

--- a/include/cgimap/backend/apidb/readonly_pgsql_selection.hpp
+++ b/include/cgimap/backend/apidb/readonly_pgsql_selection.hpp
@@ -75,6 +75,10 @@ public:
   bool supports_user_details() const override;
   bool is_user_blocked(const osm_user_id_t) override;
   bool get_user_id_pass(const std::string&, osm_user_id_t &, std::string &, std::string &) override;
+  std::set< osm_user_role_t > get_roles_for_user(osm_user_id_t id) override;
+  std::optional< osm_user_id_t > get_user_id_for_oauth2_token(
+      const std::string &token_id, bool &expired, bool &revoked,
+      bool &allow_api_write) override;
   bool is_user_active(const osm_user_id_t id) override;
 
 

--- a/include/cgimap/backend/staticxml/staticxml.hpp
+++ b/include/cgimap/backend/staticxml/staticxml.hpp
@@ -14,6 +14,8 @@
 
 #include <memory>
 
-std::unique_ptr<backend> make_staticxml_backend();
+using user_roles_t = std::map<osm_user_id_t, std::set<osm_user_role_t> >;
+
+std::unique_ptr<backend> make_staticxml_backend(user_roles_t = {});
 
 #endif /* STATICXML_BACKEND_HPP */

--- a/include/cgimap/data_selection.hpp
+++ b/include/cgimap/data_selection.hpp
@@ -15,6 +15,7 @@
 
 #include <chrono>
 #include <memory>
+#include <set>
 #include <vector>
 #include <string>
 
@@ -175,6 +176,12 @@ public:
                                 osm_user_id_t &,
                                 std::string & pass_crypt, 
                                 std::string & pass_salt) = 0;
+
+  virtual std::set<osm_user_role_t> get_roles_for_user(osm_user_id_t id) = 0;
+
+  virtual std::optional< osm_user_id_t > get_user_id_for_oauth2_token(
+      const std::string &token_id, bool &expired, bool &revoked,
+      bool &allow_api_write) = 0;
 
   // is user status confirmed or active?
   virtual bool is_user_active(const osm_user_id_t) = 0;

--- a/include/cgimap/oauth.hpp
+++ b/include/cgimap/oauth.hpp
@@ -56,8 +56,6 @@ struct token_store {
   virtual bool allow_read_api(const std::string &token_id) = 0;
   virtual bool allow_write_api(const std::string &token_id) = 0;
   virtual std::optional<osm_user_id_t> get_user_id_for_token(const std::string &token_id) = 0;
-  virtual std::set<osm_user_role_t> get_roles_for_user(osm_user_id_t) = 0;
-  virtual std::optional<osm_user_id_t> get_user_id_for_oauth2_token(const std::string &token_id, bool& expired, bool& revoked, bool& allow_api_write) = 0;
   virtual ~token_store() = default;
 };
 

--- a/include/cgimap/oauth2.hpp
+++ b/include/cgimap/oauth2.hpp
@@ -19,7 +19,7 @@
 #include "cgimap/request_helpers.hpp"
 
 namespace oauth2 {
-  std::optional<osm_user_id_t> validate_bearer_token(const request &req, oauth::store* store, bool& allow_api_write);
+  std::optional<osm_user_id_t> validate_bearer_token(const request &req, data_selection& selection, bool& allow_api_write);
 }
 
 #endif

--- a/include/cgimap/process_request.hpp
+++ b/include/cgimap/process_request.hpp
@@ -27,6 +27,6 @@ void process_request(request &req, rate_limiter &limiter,
                      const std::string &generator, const routes &route,
                      data_selection::factory& factory,
                      data_update::factory* update_factory,
-                     oauth::store* store);
+                     oauth::store* store = nullptr);
 
 #endif /* PROCESS_REQUEST_HPP */

--- a/src/backend/apidb/readonly_pgsql_selection.cpp
+++ b/src/backend/apidb/readonly_pgsql_selection.cpp
@@ -18,6 +18,7 @@
 #include "cgimap/infix_ostream_iterator.hpp"
 
 #include <functional>
+#include <set>
 #include <sstream>
 #include <list>
 #include <vector>
@@ -823,6 +824,60 @@ bool readonly_pgsql_selection::get_user_id_pass(const std::string& user_name, os
   pass_salt = row["pass_salt"].as<std::string>();
 
   return true;
+}
+
+std::set< osm_user_role_t > readonly_pgsql_selection::get_roles_for_user(osm_user_id_t id)
+{
+  std::set<osm_user_role_t> roles;
+
+  // return all the roles to which the user belongs.
+  m.prepare("roles_for_user",
+    "SELECT role FROM user_roles WHERE user_id = $1");
+
+  auto res = m.exec_prepared("roles_for_user", id);
+
+  for (const auto &tuple : res) {
+    auto role = tuple[0].as<std::string>();
+    if (role == "moderator") {
+      roles.insert(osm_user_role_t::moderator);
+    } else if (role == "administrator") {
+      roles.insert(osm_user_role_t::administrator);
+    }
+  }
+
+  return roles;
+}
+
+std::optional< osm_user_id_t > readonly_pgsql_selection::get_user_id_for_oauth2_token(
+    const std::string &token_id, bool &expired, bool &revoked,
+    bool &allow_api_write)
+{
+  // return details for OAuth 2.0 access token
+  m.prepare("oauth2_access_token",
+    R"(SELECT resource_owner_id as user_id,
+         CASE WHEN expires_in IS NULL THEN false
+              ELSE (created_at + expires_in * interval '1' second)  < now() at time zone 'utc'
+         END as expired,
+         COALESCE(revoked_at < now() at time zone 'utc', false) as revoked,
+         'write_api' = any(string_to_array(scopes, ' ')) as allow_api_write
+       FROM oauth_access_tokens
+       WHERE token = $1)");
+
+  auto res = m.exec_prepared("oauth2_access_token", token_id);
+
+  if (!res.empty()) {
+    auto uid = res[0]["user_id"].as<osm_user_id_t>();
+    expired = res[0]["expired"].as<bool>();
+    revoked = res[0]["revoked"].as<bool>();
+    allow_api_write = res[0]["allow_api_write"].as<bool>();
+    return uid;
+
+  } else {
+    expired = true;
+    revoked = true;
+    allow_api_write = false;
+    return {};
+  }
 }
 
 bool readonly_pgsql_selection::is_user_active(const osm_user_id_t id)

--- a/src/oauth2.cpp
+++ b/src/oauth2.cpp
@@ -33,7 +33,7 @@ inline std::string sha256_hash(const std::string& s) {
 
 namespace oauth2 {
 
-  [[nodiscard]] std::optional<osm_user_id_t> validate_bearer_token(const request &req, oauth::store* store, bool& allow_api_write)
+  [[nodiscard]] std::optional<osm_user_id_t> validate_bearer_token(const request &req, data_selection& selection, bool& allow_api_write)
   {
     const char * auth_hdr = req.get_param ("HTTP_AUTHORIZATION");
     if (auth_hdr == nullptr)
@@ -61,16 +61,13 @@ namespace oauth2 {
     bool expired;
     bool revoked;
 
-    if (!store)
-      return std::nullopt;
-
     // Check token as plain text first
-    auto user_id = store->get_user_id_for_oauth2_token(bearer_token, expired, revoked, allow_api_write);
+    auto user_id = selection.get_user_id_for_oauth2_token(bearer_token, expired, revoked, allow_api_write);
 
     // Fallback to sha256-hashed token
     if (!(user_id)) {
       const auto bearer_token_hashed = sha256_hash(bearer_token);
-      user_id = store->get_user_id_for_oauth2_token(bearer_token_hashed, expired, revoked, allow_api_write);
+      user_id = selection.get_user_id_for_oauth2_token(bearer_token_hashed, expired, revoked, allow_api_write);
     }
 
     if (!(user_id)) {

--- a/test/redactions.testcore/oauth.json
+++ b/test/redactions.testcore/oauth.json
@@ -7,12 +7,5 @@
             "secret": "xvvffpkvrk",
             "user_id": 2
         }
-    },
-    "users": {
-        "2": {
-            "roles": [
-                "moderator"
-            ]
-        }
     }
 }

--- a/test/redactions.testcore/roles.json
+++ b/test/redactions.testcore/roles.json
@@ -1,0 +1,9 @@
+{
+    "users": {
+        "2": {
+            "roles": [
+                "moderator"
+            ]
+        }
+    }
+}

--- a/test/test_apidb_backend_changeset_uploads.cpp
+++ b/test/test_apidb_backend_changeset_uploads.cpp
@@ -1757,7 +1757,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
            </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     REQUIRE(req.response_status() == 401);
   }
@@ -1773,7 +1773,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
            </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     REQUIRE(req.response_status() == 200);
   }
@@ -1789,7 +1789,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
            </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     REQUIRE(req.response_status() == 200);
   }
@@ -1805,7 +1805,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
            </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     REQUIRE(req.response_status() == 200);
   }
@@ -1822,7 +1822,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
            </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     // Basic Auth in status "pending" should return status HTTP 401
     REQUIRE(req.response_status() == 401);
@@ -1841,7 +1841,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
            </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     REQUIRE(req.response_status() == 403);
 
@@ -1862,7 +1862,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
            </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     REQUIRE(req.response_status() == 403);
 
@@ -1881,7 +1881,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
            </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     REQUIRE(req.response_status() == 409);
   }
@@ -1897,7 +1897,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
            </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     REQUIRE(req.response_status() == 409);
   }
@@ -1913,7 +1913,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
                 </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     REQUIRE(req.response_status() == 409);
   }
@@ -1929,7 +1929,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
                 </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     REQUIRE(req.response_status() == 409);
   }
@@ -1981,7 +1981,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
                </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     CAPTURE(req.body().str());
 
@@ -2030,7 +2030,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
                </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     CAPTURE(req.body().str());
 
@@ -2059,7 +2059,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
                </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     // std::cout << "Response was:\n----------------------\n" << req.buffer().str() << "\n";
 
@@ -2083,7 +2083,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
     req.set_payload(get_compressed_payload(payload));
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     CAPTURE(req.body().str());
 
@@ -2176,7 +2176,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_rate_limiter", "[changes
                </osmChange>)" );
 
     // execute the request
-    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+    process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
     CAPTURE(req.body().str());
     REQUIRE(req.response_status() == 200);
@@ -2211,7 +2211,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_rate_limiter", "[changes
                  </osmChange>)" , nodes));
 
       // execute the request
-      process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+      process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
       if (nds > 98)
       {

--- a/test/test_apidb_backend_changesets.cpp
+++ b/test/test_apidb_backend_changesets.cpp
@@ -424,7 +424,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_create", "[changeset][db
                           )" );
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 401);
     }
@@ -448,7 +448,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_create", "[changeset][db
                           )" );
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 401);
     }
@@ -474,7 +474,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_create", "[changeset][db
                           )" );
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 403);
 
@@ -506,7 +506,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_create", "[changeset][db
                           )" );
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 
 	REQUIRE(req.response_status() == 403);
@@ -538,7 +538,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_create", "[changeset][db
 			    </osm>  )" );
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 200);
 	REQUIRE(req.body().str() == "500");   // should have received changeset id 500
@@ -617,7 +617,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_update", "[changeset][db
 			    </osm>  )" );
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 401); // should have received HTTP status 401 Unauthenticated
 
@@ -642,7 +642,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_update", "[changeset][db
                           )" );
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 401);
     }
@@ -666,7 +666,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_update", "[changeset][db
 			    </osm>  )" );
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 409);
     }
@@ -690,7 +690,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_update", "[changeset][db
 			    </osm>  )" );
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 404);
     }
@@ -713,7 +713,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_update", "[changeset][db
 			    </osm>  )" );
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 409);
     }
@@ -739,7 +739,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_update", "[changeset][db
 			    </osm>  )" );
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 200);
 
@@ -769,7 +769,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_update", "[changeset][db
 			    </osm>  )" );
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 200);
 
@@ -833,7 +833,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_close", "[changeset][db]
 	req.set_header("REMOTE_ADDR", "127.0.0.1");
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 401);
     }
@@ -848,7 +848,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_close", "[changeset][db]
 	req.set_header("REMOTE_ADDR", "127.0.0.1");
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 200);
 
@@ -864,7 +864,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_close", "[changeset][db]
 	req.set_header("REMOTE_ADDR", "127.0.0.1");
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 409);
     }
@@ -879,7 +879,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_close", "[changeset][db]
 	req.set_header("REMOTE_ADDR", "127.0.0.1");
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 404);
     }
@@ -894,7 +894,7 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_changeset_close", "[changeset][db]
 	req.set_header("REMOTE_ADDR", "127.0.0.1");
 
 	// execute the request
-	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get(), nullptr);
+	process_request(req, limiter, generator, route, *sel_factory, upd_factory.get());
 
 	REQUIRE(req.response_status() == 409);
     }

--- a/test/test_basicauth.cpp
+++ b/test/test_basicauth.cpp
@@ -59,6 +59,10 @@ public:
 
   bool supports_user_details() const override { return false; }
   bool is_user_blocked(const osm_user_id_t) override { return true; }
+  std::set<osm_user_role_t> get_roles_for_user(osm_user_id_t id) override { return {}; }
+  std::optional< osm_user_id_t > get_user_id_for_oauth2_token(
+      const std::string &token_id, bool &expired, bool &revoked,
+      bool &allow_api_write) override { return {}; }
   bool is_user_active(const osm_user_id_t) override { return false; }
   bool get_user_id_pass(const std::string& user_name, osm_user_id_t & user_id,
 				std::string & pass_crypt, std::string & pass_salt) override {

--- a/test/test_oauth.cpp
+++ b/test/test_oauth.cpp
@@ -312,17 +312,6 @@ struct test_secret_store
     return {};
   }
 
-  std::optional<osm_user_id_t> get_user_id_for_oauth2_token(const std::string &token_id, bool& expired, bool& revoked, bool& allow_api_write) override {
-    expired = false;
-    revoked = false;
-    allow_api_write = false;
-    return {};
-  }
-
-  std::set<osm_user_role_t> get_roles_for_user(osm_user_id_t) override {
-    return std::set<osm_user_role_t>();
-  }
-
 private:
   std::string m_consumer_key, m_consumer_secret, m_token_id, m_token_secret;
   std::set<std::tuple<std::string, uint64_t> > m_nonces;


### PR DESCRIPTION
As a preparation step for OAuth 1.0a removal, the following two methods were moved to the data_selection class. The oauth::store class (and related OAuth 1.0a classes) will be removed in a later commit.

* get_roles_for_user
* get_user_id_for_oauth2_token

Also, oauth.json in redactions.testcore was split up in two files, with roles.json listing all user roles.