### PR TITLE
Fix json output incorrectly truncating coordinates 

### DIFF
--- a/test/json.testcore/data.osm
+++ b/test/json.testcore/data.osm
@@ -7,6 +7,10 @@
     <tag k='foo' v='bar1' />
   </node>
   <node visible="true" id='3' timestamp='2012-09-25T00:01:00Z' uid='1' user='foo' version='2' changeset='3' lat='0.0' lon='0.0' />
+
+  <!-- Regression test for double values mistakenly being truncated to 11 characters https://github.com/zerebubuth/openstreetmap-cgimap/issues/363 -->
+  <node visible="true" id='4' timestamp='2013-10-20T00:00:00Z' uid='1' user='foo' version='1' changeset='4' lat='48.1730392' lon='-117.0671669' /> 
+
   <node visible="true" id='40050' timestamp='2012-09-25T00:00:01Z' uid='1' user='foo' version='1' changeset='1' lat='0.99587530072' lon='1.15459870878' />
   <node visible="true" id='40051' timestamp='2012-09-25T00:00:02Z' uid='1' user='foo' version='1' changeset='1' lat='0.99684898006' lon='1.15459552634' />
   <node visible="true" id='40053' timestamp='2012-09-25T00:00:03Z' uid='1' user='foo' version='1' changeset='1' lat='0.99657533165' lon='1.15587486714'>

--- a/test/json.testcore/regression_double_truncated.case
+++ b/test/json.testcore/regression_double_truncated.case
@@ -1,0 +1,27 @@
+# Regression test for double values mistakenly being truncated to 11 characters in json output https://github.com/zerebubuth/openstreetmap-cgimap/issues/363
+Request-Method: GET
+Request-URI: /api/0.6/node/4.json
+HTTP-Accept: */*
+---
+Content-Type: application/json; charset=utf-8
+!Content-Disposition: 
+Status: 200 OK
+---
+{ "version": "0.6",
+  "generator": "***",
+  "copyright": "***",
+  "attribution": "***",
+  "license": "***",
+  "elements": [
+      { "type": "node",
+        "id": 4,
+	"lat": 48.1730392,
+	"lon": -117.0671669,
+	"timestamp": "2013-10-20T00:00:00Z",
+	"version": 1,
+	"changeset": 4,
+	"user": "foo",
+	"uid": 1
+      }
+  ]
+}


### PR DESCRIPTION
Fixes https://github.com/zerebubuth/openstreetmap-cgimap/issues/363

The json formatter used a 12 byte buffer to format floating point values. This is not enough to hold the full string including the final null terminator byte for negative values with three digits before the decimal point and seven digits precision. The output of `snprintf()` was not checked, so if there is a digit which does not fit into the buffer it will be silently dropped.

E.g.  `-117.0671669` has 12 digits/bytes including the minus sign character. However, the terminating null character also requires 1 byte so the output string gets silently truncated to `-117.067166`.

This means that all coordinates with longitudes from -100 to -180, which is mostly the western USA and Canada, will be shifted by up to ~11cm at the equator (~8 cm in San Francisco) if downloaded via the json format. 
https://wiki.openstreetmap.org/wiki/Precision_of_coordinates#Precision_of_longitudes
![longitude_-180_to_-100](https://github.com/zerebubuth/openstreetmap-cgimap/assets/8714382/dd8f3218-f2dd-47ad-a49e-dabe60b4a9c6)
