### PR TITLE
Create separate cmake files for contrib libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ target_link_libraries(cgimap_common_compiler_options INTERFACE
 ###########################
 # source subdirectories
 ###########################
+add_subdirectory(contrib)
 add_subdirectory(src)
 add_subdirectory(test)
 

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_subdirectory(catch2)
+add_subdirectory(libxml++)
+
+target_link_libraries(catch2 INTERFACE cgimap_common_compiler_options)
+target_link_libraries(libxml++ INTERFACE cgimap_common_compiler_options)

--- a/contrib/catch2/CMakeLists.txt
+++ b/contrib/catch2/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(catch2
+    LANGUAGES CXX)
+
+add_library(catch2 INTERFACE)
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23.0)
+    target_sources(catch2
+        INTERFACE
+            FILE_SET HEADERS
+            BASE_DIRS single_include/
+            FILES
+                single_include/catch.hpp)
+else()
+    target_include_directories(catch2 INTERFACE
+        single_include/)
+endif()
+

--- a/contrib/libxml++/CMakeLists.txt
+++ b/contrib/libxml++/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(libxml++
+    LANGUAGES CXX
+    DESCRIPTION "This library provides a C++ interface to XML files. It uses libxml2 to access the XML files."
+    HOMEPAGE_URL "https://libxmlplusplus.github.io/libxmlplusplus/")
+
+add_library(libxml++)
+
+target_sources(libxml++
+    PRIVATE
+        parsers/exception.cpp
+        parsers/internal_error.cpp
+        parsers/parse_error.cpp
+        parsers/parser.cpp
+        parsers/saxparser.cpp
+        parsers/wrapped_exception.cpp)
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23.0)
+    target_sources(libxml++
+        PRIVATE
+            FILE_SET libxmlpp_private_headers
+            TYPE HEADERS
+            BASE_DIRS ./
+            FILES
+                parsers/exception.hpp
+                parsers/internal_error.hpp
+                parsers/parse_error.hpp
+                parsers/parser.hpp
+                parsers/wrapped_exception.hpp)
+
+    target_sources(libxml++
+        PUBLIC
+            FILE_SET libxmlpp_public_headers
+            TYPE HEADERS
+            BASE_DIRS ./
+            FILES
+                parsers/saxparser.hpp)
+else()
+    target_include_directories(libxml++ PUBLIC
+        ./)
+endif()
+
+target_link_libraries(libxml++ PUBLIC
+    LibXml2::LibXml2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,7 @@
 add_library(cgimap_core)
 
 target_include_directories(cgimap_core PUBLIC
-    ../include
-    ../contrib/libxml++)
+    ../include)
 
 target_sources(cgimap_core PRIVATE
     backend.cpp
@@ -38,13 +37,6 @@ target_sources(cgimap_core PRIVATE
     xml_formatter.cpp
     xml_writer.cpp
     zlib.cpp
-
-    ../contrib/libxml++/parsers/exception.cpp
-    ../contrib/libxml++/parsers/internal_error.cpp
-    ../contrib/libxml++/parsers/parse_error.cpp
-    ../contrib/libxml++/parsers/parser.cpp
-    ../contrib/libxml++/parsers/saxparser.cpp
-    ../contrib/libxml++/parsers/wrapped_exception.cpp
 
     api06/changeset_close_handler.cpp
     api06/changeset_create_handler.cpp
@@ -81,7 +73,7 @@ target_sources(cgimap_core PRIVATE
 
 target_link_libraries(cgimap_core
     cgimap_common_compiler_options
-    LibXml2::LibXml2
+    libxml++
     ZLIB::ZLIB
     CryptoPP::CryptoPP
     Libmemcached::Libmemcached

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,3 @@
-########
-# catch2
-########
-add_library(catch2 INTERFACE)
-target_include_directories(catch2 INTERFACE
-    ../contrib/catch2/single_include)
-
-
 ############
 # unit tests
 ############


### PR DESCRIPTION
Move contrib libs cmake definitions out of main cgimap cmake files into separate CMakeLists.txt files per library