### PR TITLE
yajl: output json in larger chunks

### DIFF
--- a/include/cgimap/brotli.hpp
+++ b/include/cgimap/brotli.hpp
@@ -32,7 +32,7 @@ public:
   brotli_output_buffer(const brotli_output_buffer &old) = delete;
   ~brotli_output_buffer() override = default;
   int write(const char *buffer, int len) override;
-  int written() override;
+  int written() const override;
   int close() override;
   void flush() override;
 

--- a/include/cgimap/json_writer.hpp
+++ b/include/cgimap/json_writer.hpp
@@ -34,7 +34,8 @@ public:
   ~json_writer() noexcept override;
 
   void start_object();
-  void object_key(const std::string &s);
+  void object_key(const char* s);
+  void object_key(std::string_view sv);
   void end_object();
 
   void start_array();

--- a/include/cgimap/json_writer.hpp
+++ b/include/cgimap/json_writer.hpp
@@ -62,9 +62,13 @@ public:
   void error(const std::string &) override;
 
 private:
+  void output_yajl_buffer(bool ignore_buffer_size);
+
   yajl_gen gen;
   yajl_alloc_funcs alloc_funcs;
   output_buffer& out;
+
+  constexpr static int MAX_BUFFER = 16384;
 };
 
 #endif /* JSON_WRITER_HPP */

--- a/include/cgimap/output_buffer.hpp
+++ b/include/cgimap/output_buffer.hpp
@@ -18,7 +18,7 @@
 struct output_buffer {
   virtual int write(const char *buffer, int len) = 0;
   virtual int write(std::string_view str) { return write(str.data(), str.size()); }
-  virtual int written() = 0;
+  virtual int written() const = 0;
   virtual int close() = 0;
   virtual void flush() = 0;
   virtual ~output_buffer() = default;
@@ -38,7 +38,7 @@ public:
     explicit identity_output_buffer(output_buffer& o) : out(o) {}
 
     int write(const char *buffer, int len) override { return out.write(buffer, len); }
-    int written() override { return out.written(); }
+    int written() const override { return out.written(); }
     int close() override { return out.close(); }
     void flush() override { out.flush(); }
 

--- a/include/cgimap/zlib.hpp
+++ b/include/cgimap/zlib.hpp
@@ -37,7 +37,7 @@ public:
   zlib_output_buffer(const zlib_output_buffer &old);
   ~zlib_output_buffer() override = default;
   int write(const char *buffer, int len) override;
-  int written() override;
+  int written() const override;
   int close() override;
   void flush() override;
 

--- a/src/brotli.cpp
+++ b/src/brotli.cpp
@@ -69,7 +69,7 @@ int brotli_output_buffer::close() {
   return out.close();
 }
 
-int brotli_output_buffer::written() { return bytes_in; }
+int brotli_output_buffer::written() const { return bytes_in; }
 
 
 void brotli_output_buffer::flush() {

--- a/src/fcgi_request.cpp
+++ b/src/fcgi_request.cpp
@@ -41,7 +41,7 @@ struct fcgi_buffer : public output_buffer {
     return bytes;
   }
 
-  int written() override { return m_written; }
+  int written() const override { return m_written; }
 
   int close() override { return FCGX_FClose(m_req.out); }
 

--- a/src/json_writer.cpp
+++ b/src/json_writer.cpp
@@ -55,8 +55,12 @@ json_writer::~json_writer() noexcept {
 
 void json_writer::start_object() { yajl_gen_map_open(gen); }
 
-void json_writer::object_key(const std::string &s) {
+void json_writer::object_key(const char* s) {
   entry(s);
+}
+
+void json_writer::object_key(std::string_view sv) {
+  entry(sv);
 }
 
 void json_writer::end_object() {

--- a/src/request_helpers.cpp
+++ b/src/request_helpers.cpp
@@ -120,7 +120,7 @@ public:
     return 0;
   }
 
-  int written() override { return w; }
+  int written() const override { return w; }
 
   void flush() override {
     // there's a note that says this causes too many writes and decreases

--- a/src/zlib.cpp
+++ b/src/zlib.cpp
@@ -101,7 +101,7 @@ int zlib_output_buffer::close() {
   return out.close();
 }
 
-int zlib_output_buffer::written() { return bytes_in; }
+int zlib_output_buffer::written() const { return bytes_in; }
 
 void zlib_output_buffer::flush_output() {
   out.write(outbuf, sizeof(outbuf) - stream.avail_out);

--- a/test/test_request.cpp
+++ b/test/test_request.cpp
@@ -25,7 +25,7 @@ int test_output_buffer::write(const char *buffer, int len) {
   return len;
 }
 
-int test_output_buffer::written() {
+int test_output_buffer::written() const {
   return m_written;
 }
 

--- a/test/test_request.hpp
+++ b/test/test_request.hpp
@@ -26,7 +26,7 @@ struct test_output_buffer : public output_buffer {
   explicit test_output_buffer(std::ostream &out, std::ostream &body);
   ~test_output_buffer() override = default;
   int write(const char *buffer, int len) override;
-  int written() override;
+  int written() const override;
   int close() override;
   void flush() override;
 


### PR DESCRIPTION
Previously, `wrap_write` function was called frequently for small amounts of data. This resulted in FCGX_PutStr or some compression function showing up at the top of the perf trace. With this change in place, we're leveraging the YAJL internal buffer, and only output data once a certain threshold value is reached.