### PR TITLE
Refactor cmake install and package definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ if(ENABLE_INSTALL)
     set(CGIMAP_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 
     if(BUILD_SHARED_LIBS)
-        set(CGIMAP_LIBS cgimap_core cgimap_fcgi cgimap_apidb libxml++)
+        set(CGIMAP_LIBS cgimap_core cgimap_fcgi cgimap_apidb cgimap_libxml++)
     endif()
 
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,8 @@ if(ENABLE_INSTALL)
         set(CGIMAP_HEADER_FILE_SET_INSTALL_ARTIFACTS
             FILE_SET HEADERS
                 COMPONENT Development
-                DESTINATION ${CGIMAP_INSTALL_INCLUDEDIR})
+                DESTINATION ${CGIMAP_INSTALL_INCLUDEDIR}
+                EXCLUDE_FROM_ALL)
     endif()
 
     install(TARGETS openstreetmap_cgimap ${CGIMAP_LIBS}
@@ -196,9 +197,11 @@ if(ENABLE_INSTALL)
         PUBLIC_HEADER
             COMPONENT Development
             DESTINATION ${CGIMAP_INSTALL_INCLUDEDIR}
+            EXCLUDE_FROM_ALL
         PRIVATE_HEADER
             COMPONENT Development
             DESTINATION ${CGIMAP_INSTALL_INCLUDEDIR}
+            EXCLUDE_FROM_ALL
         ${CGIMAP_HEADER_FILE_SET_INSTALL_ARTIFACTS})
 
     install(FILES openstreetmap-cgimap.1 TYPE MAN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,20 +167,36 @@ endif()
 # Install
 #############################################################
 
-if (ENABLE_INSTALL)
-  install(TARGETS openstreetmap_cgimap
-          PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-          DESTINATION "bin")
+if(ENABLE_INSTALL)
+    include(GNUInstallDirs)
 
-  install(FILES openstreetmap-cgimap.1 DESTINATION share/man/man1)
+    set(CMAKE_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE)
 
-  install(FILES README DESTINATION share/doc/openstreetmap-cgimap)
+    set(CGIMAP_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 
-  if (BUILD_SHARED_LIBS)
-    install(TARGETS cgimap_core DESTINATION lib)
-    install(TARGETS cgimap_fcgi DESTINATION lib)
-    install(TARGETS cgimap_apidb DESTINATION lib)
-  endif()
+    if(BUILD_SHARED_LIBS)
+        set(CGIMAP_LIBS cgimap_core cgimap_fcgi cgimap_apidb libxml++)
+    endif()
+
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23.0)
+        set(CGIMAP_HEADER_FILE_SET_INSTALL_ARTIFACTS
+            FILE_SET HEADERS
+                DESTINATION ${CGIMAP_INSTALL_INCLUDEDIR})
+    endif()
+
+    install(TARGETS openstreetmap_cgimap ${CGIMAP_LIBS}
+        PUBLIC_HEADER
+            DESTINATION ${CGIMAP_INSTALL_INCLUDEDIR}
+        PRIVATE_HEADER
+            DESTINATION ${CGIMAP_INSTALL_INCLUDEDIR}
+        ${CGIMAP_HEADER_FILE_SET_INSTALL_ARTIFACTS})
+
+    install(FILES openstreetmap-cgimap.1 TYPE MAN)
+
+    install(FILES README TYPE DOC)
 endif()
 
 
@@ -193,11 +209,6 @@ set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(CPACK_PACKAGE_CONTACT "mmd.osm@gmail.com")
-set(CPACK_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS
-    OWNER_READ OWNER_WRITE OWNER_EXECUTE
-    GROUP_READ GROUP_EXECUTE
-    WORLD_READ WORLD_EXECUTE
-)
 set(CPACK_PACKAGE_DESCRIPTION "A comprehensive list of supported endpoints can be found at https://github.com/zerebubuth/openstreetmap-cgimap")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "OpenStreetMap CGImap - Performance optimized implementation of selected parts of the OSM API")
 set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,19 +184,28 @@ if(ENABLE_INSTALL)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23.0)
         set(CGIMAP_HEADER_FILE_SET_INSTALL_ARTIFACTS
             FILE_SET HEADERS
+                COMPONENT Development
                 DESTINATION ${CGIMAP_INSTALL_INCLUDEDIR})
     endif()
 
     install(TARGETS openstreetmap_cgimap ${CGIMAP_LIBS}
+        RUNTIME
+            COMPONENT Runtime
+        LIBRARY
+            COMPONENT Libraries
         PUBLIC_HEADER
+            COMPONENT Development
             DESTINATION ${CGIMAP_INSTALL_INCLUDEDIR}
         PRIVATE_HEADER
+            COMPONENT Development
             DESTINATION ${CGIMAP_INSTALL_INCLUDEDIR}
         ${CGIMAP_HEADER_FILE_SET_INSTALL_ARTIFACTS})
 
-    install(FILES openstreetmap-cgimap.1 TYPE MAN)
+    install(FILES openstreetmap-cgimap.1 TYPE MAN
+        COMPONENT Runtime)
 
-    install(FILES README TYPE DOC)
+    install(FILES README TYPE DOC
+        COMPONENT Runtime)
 endif()
 
 
@@ -219,7 +228,30 @@ set(CPACK_VERBATIM_VARIABLES YES)
 
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "mmd <${CPACK_PACKAGE_CONTACT}>")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+set(CPACK_DEBIAN_ENABLE_COMPONENT_DEPENDS YES)
 set(CPACK_DEBIAN_PACKAGE_CONTROL_STRICT_PERMISSION TRUE)
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+# Set to YES to create individual packages for components instead of everything in one package
+set(CPACK_DEB_COMPONENT_INSTALL NO)
+
+set(CPACK_DEBIAN_RUNTIME_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_DEBIAN_LIBRARIES_PACKAGE_NAME "${PROJECT_NAME}-libs")
+set(CPACK_DEBIAN_DEVELOPMENT_PACKAGE_NAME "${PROJECT_NAME}-dev")
 
 include(CPack)
+
+cpack_add_component(Libraries
+                    DISPLAY_NAME "openstreetmap-cgimap libraries"
+                    DESCRIPTION "Libraries required to run openstreetmap-cgimap")
+
+if(BUILD_SHARED_LIBS)
+    set(CGIMAP_RUNTIME_COMPONENT_DEPENDENCIES Libraries)
+endif()
+cpack_add_component(Runtime
+                    DISPLAY_NAME "openstreetmap-cgimap runtime binary"
+                    DEPENDS ${CGIMAP_RUNTIME_COMPONENT_DEPENDENCIES})
+
+cpack_add_component(Development
+                    DISPLAY_NAME "openstreetmap-cgimap development headers"
+                    DESCRIPTION "Header files required for development using openstreetmap-cgimap libraries"
+                    DEPENDS Libraries)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,15 @@ set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
 ################
-# CGImap project
+# openstreetmap-cgimap project
 ################
 string(TIMESTAMP CURRENT_TIMESTAMP %y%m%d%H%M UTC)
 
-project(CGImap LANGUAGES CXX
-               VERSION "0.10.0.${CURRENT_TIMESTAMP}"
-               DESCRIPTION "CGImap is a C++ implementation of some parts of the OpenStreetMap API as a FastCGI process."
-               HOMEPAGE_URL "https://github.com/zerebubuth/openstreetmap-cgimap")
+project(openstreetmap-cgimap
+        LANGUAGES CXX
+        VERSION "0.10.0.${CURRENT_TIMESTAMP}"
+        DESCRIPTION "CGImap is a C++ implementation of some parts of the OpenStreetMap API as a FastCGI process."
+        HOMEPAGE_URL "https://github.com/zerebubuth/openstreetmap-cgimap")
 set(CMAKE_PROJECT_BUGREPORT_URL "https://github.com/zerebubuth/openstreetmap-cgimap/issues")
 
 
@@ -191,9 +192,7 @@ set(CPACK_GENERATOR "DEB")
 set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(CPACK_DEBIAN_PACKAGE_NAME "openstreetmap-cgimap")
 set(CPACK_PACKAGE_CONTACT "mmd.osm@gmail.com")
-set(CPACK_DEBIAN_PACKAGE_MAINTAINER "mmd")
 set(CPACK_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS
     OWNER_READ OWNER_WRITE OWNER_EXECUTE
     GROUP_READ GROUP_EXECUTE
@@ -201,9 +200,15 @@ set(CPACK_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS
 )
 set(CPACK_PACKAGE_DESCRIPTION "A comprehensive list of supported endpoints can be found at https://github.com/zerebubuth/openstreetmap-cgimap")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "OpenStreetMap CGImap - Performance optimized implementation of selected parts of the OSM API")
-set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
-set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
-set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/zerebubuth/openstreetmap-cgimap")
+set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/COPYING")
+set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 set(CPACK_STRIP_FILES "TRUE")
-INCLUDE(CPack)
+set(CPACK_VERBATIM_VARIABLES YES)
 
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "mmd <${CPACK_PACKAGE_CONTACT}>")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+set(CPACK_DEBIAN_PACKAGE_CONTROL_STRICT_PERMISSION TRUE)
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+
+include(CPack)

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -5,4 +5,4 @@ add_subdirectory(catch2)
 add_subdirectory(libxml++)
 
 target_link_libraries(catch2 INTERFACE cgimap_common_compiler_options)
-target_link_libraries(libxml++ PUBLIC cgimap_common_compiler_options)
+target_link_libraries(cgimap_libxml++ PUBLIC cgimap_common_compiler_options)

--- a/contrib/libxml++/CMakeLists.txt
+++ b/contrib/libxml++/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(libxml++
+project(cgimap_libxml++
     LANGUAGES CXX
     DESCRIPTION "This library provides a C++ interface to XML files. It uses libxml2 to access the XML files."
     HOMEPAGE_URL "https://libxmlplusplus.github.io/libxmlplusplus/")
 
-add_library(libxml++)
+add_library(cgimap_libxml++)
 
-target_sources(libxml++
+target_sources(cgimap_libxml++
     PRIVATE
         parsers/exception.cpp
         parsers/internal_error.cpp
@@ -17,7 +17,7 @@ target_sources(libxml++
         parsers/wrapped_exception.cpp)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23.0)
-    target_sources(libxml++
+    target_sources(cgimap_libxml++
         PUBLIC
             FILE_SET HEADERS
             FILES
@@ -28,9 +28,9 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23.0)
                 parsers/saxparser.hpp
                 parsers/wrapped_exception.hpp)
 else()
-    target_include_directories(libxml++ PUBLIC
+    target_include_directories(cgimap_libxml++ PUBLIC
         ./)
 endif()
 
-target_link_libraries(libxml++ PUBLIC
+target_link_libraries(cgimap_libxml++ PUBLIC
     LibXml2::LibXml2)

--- a/contrib/libxml++/CMakeLists.txt
+++ b/contrib/libxml++/CMakeLists.txt
@@ -18,24 +18,15 @@ target_sources(libxml++
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23.0)
     target_sources(libxml++
-        PRIVATE
-            FILE_SET libxmlpp_private_headers
-            TYPE HEADERS
-            BASE_DIRS ./
+        PUBLIC
+            FILE_SET HEADERS
             FILES
                 parsers/exception.hpp
                 parsers/internal_error.hpp
                 parsers/parse_error.hpp
                 parsers/parser.hpp
+                parsers/saxparser.hpp
                 parsers/wrapped_exception.hpp)
-
-    target_sources(libxml++
-        PUBLIC
-            FILE_SET libxmlpp_public_headers
-            TYPE HEADERS
-            BASE_DIRS ./
-            FILES
-                parsers/saxparser.hpp)
 else()
     target_include_directories(libxml++ PUBLIC
         ./)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,7 +72,7 @@ target_sources(cgimap_core PRIVATE
 
 target_link_libraries(cgimap_core
     cgimap_common_compiler_options
-    libxml++
+    cgimap_libxml++
     ZLIB::ZLIB
     CryptoPP::CryptoPP
     Libmemcached::Libmemcached


### PR DESCRIPTION
* Use implicit default values where possible
* Simplify cmake install targets via GNUInstallDirs module
  * Installation directories for binaries, libaries, etc... are set automatically according to their target type
* Define components for install/package targets
  * Allows building separate packages for binaries and development headers (`*-dev` package)
* Rename included modified libxml++ to differentiate it from original libxml++