### PR TITLE
Integrate clang-tidy in cmake build

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+---
+Checks: '-*,cppcoreguidelines-*,bugprone-*,performance*,modernize-*,-modernize-use-trailing-return-type'
+...

--- a/.iwyu_mappings.imp
+++ b/.iwyu_mappings.imp
@@ -1,0 +1,10 @@
+[ 
+  { include: ["@<libmemcached-.*/.*>", "public", "<libmemcached/memcached.h>", "public"] },
+  { include: ["@<boost/algorithm/string/.*>", "public", "<boost/algorithm/string.hpp>", "public"] },
+  { include: ["@<boost/program_options/.*>", "public", "<boost/program_options.hpp>", "public"] },
+  { include: ["@<boost/lexical_cast/.*>", "public", "<boost/lexical_cast.hpp>", "public"] },
+  { include: ["@<pqxx/.*\\.h.*>", "private", "<pqxx/pqxx>", "public"] },
+  { include: ["<cryptopp/config_int.h>", "private", "<cryptopp/config.h>", "public"] },
+  { include: ["<bits/chrono.h>", "private", "<chrono>", "public"] },
+  { include: ["<bits/local_lim.h>", "private", "<limits.h>", "public"] },
+] 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ endif()
 
 include(CTest)
 include(AutotoolsCompatibilityDefinitions)
+include(BuildLint)
 
 #########################
 # common compiler options
@@ -145,17 +146,12 @@ target_link_libraries(openstreetmap_cgimap
     PQXX::PQXX)
 
 
-
 #############################################################
 # Optional "clang-tidy" target
 #############################################################
 
-find_program(CLANG_TIDY
-             NAMES clang-tidy clang-tidy-16 clang-tidy-15 clang-tidy-14 clang-tidy-13 clang-tidy-12 clang-tidy-11)
-
-if (CLANG_TIDY)
-    message(STATUS "Looking for clang-tidy - found ${CLANG_TIDY}")
-
+# BuildLint module already checks for clang-tidy
+if(CLANG_TIDY)
     file(GLOB CT_CHECK_FILES src/*.cpp src/api06/*.cpp src/api06/changeset_upload/*.cpp src/api07/*.cpp
                              src/backend/apidb/*.cpp src/backend/apidb/changeset_upload/*.cpp
                              test/*.cpp test/*.hpp)
@@ -166,8 +162,6 @@ if (CLANG_TIDY)
         -p ${CMAKE_BINARY_DIR}
         ${CT_CHECK_FILES}
     )
-else()
-    message(STATUS "Looking for clang-tidy - not found")
 endif()
 
 

--- a/cmake/BuildLint.cmake
+++ b/cmake/BuildLint.cmake
@@ -68,3 +68,42 @@ if(ENABLE_BUILD_LINT_IWYU)
         message(STATUS "Looking for include-what-you-use - not found")
     endif()
 endif()
+
+
+########################################################
+# Disable / save / restore lint config utility functions
+########################################################
+
+set(BUILD_LINT_CONFIGS CMAKE_CXX_CLANG_TIDY CMAKE_CXX_CPPCHECK CMAKE_CXX_CPPLINT CMAKE_CXX_INCLUDE_WHAT_YOU_USE)
+
+function(save_build_lint_config LINT_CONFIG_VAR)
+    foreach(LINT_CONFIG IN LISTS BUILD_LINT_CONFIGS)
+        string(REPLACE ";" "@SEMICOLON@" ${LINT_CONFIG} "${${LINT_CONFIG}}")
+        list(APPEND LINT_CONFIGS_LIST "${${LINT_CONFIG}}")
+    endforeach()
+
+    set(${LINT_CONFIG_VAR} ${LINT_CONFIGS_LIST} PARENT_SCOPE)
+endfunction()
+
+
+function(restore_build_lint_config LINT_CONFIG_VAR)
+    foreach(LINT_CONFIG IN LISTS BUILD_LINT_CONFIGS)
+        list(POP_FRONT ${LINT_CONFIG_VAR} ${LINT_CONFIG})
+        string(REPLACE "@SEMICOLON@" ";" ${LINT_CONFIG} "${${LINT_CONFIG}}")
+        set(${LINT_CONFIG} ${${LINT_CONFIG}} PARENT_SCOPE)
+    endforeach()
+endfunction()
+
+
+macro(disable_build_lint)
+    foreach(LINT_CONFIG IN LISTS BUILD_LINT_CONFIGS)
+        unset(${LINT_CONFIG})
+    endforeach()
+endmacro()
+
+
+function(print_build_lint_config)
+    foreach(LINT_CONFIG IN LISTS BUILD_LINT_CONFIGS)
+        message("lint config ${LINT_CONFIG}: ${${LINT_CONFIG}}")
+    endforeach()
+endfunction()

--- a/cmake/BuildLint.cmake
+++ b/cmake/BuildLint.cmake
@@ -12,7 +12,7 @@ if(CLANG_TIDY)
     message(STATUS "Looking for clang-tidy - found ${CLANG_TIDY}")
 
     if(ENABLE_BUILD_LINT_CLANG_TIDY)
-        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY}")
+        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY}" -extra-arg=-std=c++17)
     endif()
 else()
     message(STATUS "Looking for clang-tidy - not found")

--- a/cmake/BuildLint.cmake
+++ b/cmake/BuildLint.cmake
@@ -1,0 +1,70 @@
+# CMAKE_CXX_<LINTER> variables need to be set before targets are created
+
+############
+# clang-tidy
+############
+option(ENABLE_BUILD_LINT_CLANG_TIDY "Automatically check code with clang-tidy during compilation" OFF)
+
+find_program(CLANG_TIDY
+        NAMES clang-tidy clang-tidy-16 clang-tidy-15 clang-tidy-14 clang-tidy-13 clang-tidy-12 clang-tidy-11)
+
+if(CLANG_TIDY)
+    message(STATUS "Looking for clang-tidy - found ${CLANG_TIDY}")
+
+    if(ENABLE_BUILD_LINT_CLANG_TIDY)
+        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY}")
+    endif()
+else()
+    message(STATUS "Looking for clang-tidy - not found")
+endif()
+
+##########
+# cppcheck
+##########
+option(ENABLE_BUILD_LINT_CPPCHECK "Automatically check code with cppcheck during compilation" OFF)
+
+if(ENABLE_BUILD_LINT_CPPCHECK)
+    find_program(CPPCHECK NAMES cppcheck)
+
+    if(CPPCHECK)
+        message(STATUS "Looking for cppcheck - found ${CPPCHECK}")
+
+        set(CMAKE_CXX_CPPCHECK "${CPPCHECK}")
+    else()
+        message(STATUS "Looking for cppcheck - not found")
+    endif()
+endif()
+
+#########
+# cpplint
+#########
+option(ENABLE_BUILD_LINT_CPPLINT "Automatically check code with cpplint during compilation" OFF)
+
+if(ENABLE_BUILD_LINT_CPPLINT)
+    find_program(CPPLINT NAMES cpplint)
+
+    if(CPPLINT)
+        message(STATUS "Looking for cpplint - found ${CPPLINT}")
+
+        set(CMAKE_CXX_CPPLINT "${CPPLINT}")
+    else()
+        message(STATUS "Looking for cpplint - not found")
+    endif()
+endif()
+
+######################
+# include-what-you-use
+######################
+option(ENABLE_BUILD_LINT_IWYU "Automatically check code with include-what-you-use during compilation" OFF)
+
+if(ENABLE_BUILD_LINT_IWYU)
+    find_program(IWYU NAMES iwyu)
+
+    if(IWYU)
+        message(STATUS "Looking for include-what-you-use - found ${IWYU}")
+
+        set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE "${IWYU}")
+    else()
+        message(STATUS "Looking for include-what-you-use - not found")
+    endif()
+endif()

--- a/cmake/BuildLint.cmake
+++ b/cmake/BuildLint.cmake
@@ -46,7 +46,7 @@ if(ENABLE_BUILD_LINT_CPPLINT)
     if(CPPLINT)
         message(STATUS "Looking for cpplint - found ${CPPLINT}")
 
-        set(CMAKE_CXX_CPPLINT "${CPPLINT}")
+        set(CMAKE_CXX_CPPLINT "${CPPLINT}" --filter=-whitespace,-whitespace/braces,-whitespace/indent,-whitespace/line_length,-whitespace/comments,-readability/todo,-runtime/references,-build/c++11,-build/include_order)
     else()
         message(STATUS "Looking for cpplint - not found")
     endif()

--- a/cmake/BuildLint.cmake
+++ b/cmake/BuildLint.cmake
@@ -63,7 +63,7 @@ if(ENABLE_BUILD_LINT_IWYU)
     if(IWYU)
         message(STATUS "Looking for include-what-you-use - found ${IWYU}")
 
-        set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE "${IWYU}")
+        set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE "${IWYU}" -std=c++17 -Xiwyu --cxx17ns -Xiwyu --no_fwd_decls -Xiwyu "--mapping_file=${CMAKE_SOURCE_DIR}/.iwyu_mappings.imp")
     else()
         message(STATUS "Looking for include-what-you-use - not found")
     endif()

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Disable linters during build of contrib libraries
+disable_build_lint()
+
 add_subdirectory(catch2)
 add_subdirectory(libxml++)
 


### PR DESCRIPTION
Add option to automatically run clang-tidy during compilation. Currently disabled by default due to the number of warnings it produces. The enabled checks can be configured in `.clang-tidy`.

Also adds some more options for other linters that are directly supported by cmake.