### PR TITLE
Use raw string literal for bearer token regex

### DIFF
--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -73,7 +73,7 @@ bool registry::add(std::unique_ptr<backend> ptr) {
 
 void registry::setup_options(int argc, char *argv[],
                              po::options_description &desc) {
-  if (backends.empty() || (!(default_backend))) {
+  if (backends.empty() || !default_backend) {
     throw std::runtime_error("No backends available - this is most likely a "
                              "compile-time configuration error.");
   }

--- a/src/mime_types.cpp
+++ b/src/mime_types.cpp
@@ -41,7 +41,7 @@ type parse_from(const std::string &name) {
   } else if (name == "text/plain") {
     return mime::type::text_plain;
   } else if (name == "text/xml") {     // alias according to RFC 7303, section 9.2
-    return mime::type:: application_xml;
+    return mime::type::application_xml;
   } else if (name == "application/xml") {
     return mime::type::application_xml;
 #if HAVE_YAJL

--- a/src/oauth2.cpp
+++ b/src/oauth2.cpp
@@ -36,7 +36,7 @@ namespace oauth2 {
   [[nodiscard]] std::optional<osm_user_id_t> validate_bearer_token(const request &req, data_selection& selection, bool& allow_api_write)
   {
 
-    static const std::regex r("Bearer ([A-Za-z0-9~_\\-\\.\\+\\/]+=*)");   // according to RFC 6750, section 2.1
+    static const std::regex r(R"(Bearer ([A-Za-z0-9~_\-\.\+\/]+=*))");   // according to RFC 6750, section 2.1
 
     const char * auth_hdr = req.get_param ("HTTP_AUTHORIZATION");
     if (auth_hdr == nullptr)


### PR DESCRIPTION
\+ some whitespace / parentheses cleanup