### PR TITLE
Skip changeset discussions unless requested

### DIFF
--- a/src/backend/apidb/common_pgsql_selection.cpp
+++ b/src/backend/apidb/common_pgsql_selection.cpp
@@ -458,7 +458,7 @@ void extract_changesets(
   for (const auto &row : rows) {
     auto elem = extract_changeset(row, cc, changeset_cols);
     auto tags = extract_tags(row, tag_cols);
-    auto comments = extract_comments(row, comments_cols);
+    auto comments = (include_changeset_discussions ? extract_comments(row, comments_cols) : comments_t{});
     elem.comments_count = comments.size();
     formatter.write_changeset(
       elem, tags, include_changeset_discussions, comments, now);

--- a/src/backend/apidb/readonly_pgsql_selection.cpp
+++ b/src/backend/apidb/readonly_pgsql_selection.cpp
@@ -362,10 +362,10 @@ void readonly_pgsql_selection::write_changesets(output_formatter &formatter,
            "to_char(cc.created_at,'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS created_at "
            "FROM changeset_comments cc JOIN users u ON cc.author_id = u.id "
            "where cc.changeset_id=c.id AND cc.visible ORDER BY cc.created_at) x "
-         ")cc ON true "
+         ")cc ON $2 "
       "WHERE c.id = ANY($1)");
 
-  pqxx::result changesets = m.exec_prepared("extract_changesets", sel_changesets);
+  pqxx::result changesets = m.exec_prepared("extract_changesets", sel_changesets, include_changeset_discussions);
 
   fetch_changesets(sel_changesets, cc);
 

--- a/test/test_apidb_backend_changesets.cpp
+++ b/test/test_apidb_backend_changesets.cpp
@@ -290,7 +290,8 @@ void check_changeset_with_comments_impl(
   REQUIRE(f.m_changesets.size() == 1);
 
   comments_t comments;
-  {
+
+  if (include_discussion) {
     changeset_comment_info comment;
     comment.id = 1;
     comment.author_id = 3;
@@ -311,7 +312,7 @@ void check_changeset_with_comments_impl(
         std::string("user_1"), // display_name
         {}, // bounding box
         0, // num_changes
-        1 // comments_count
+        include_discussion ? 1 : 0 // comments_count
         ),
       tags_t(),
       include_discussion,


### PR DESCRIPTION
As of today, changeset comments were discarded only at the time of generating the XML/JSON output. That's slightly wasteful. Instead, we now pass the `include_changeset_discussions` flag to the changeset extraction SQL statement to stop extra effort as early as possible.