### PR TITLE
Remove multi-backend support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ endif()
 ###############
 # build options
 ###############
-option(ENABLE_APIDB "Enable APIDB backend, as used by the OSM servers" ON)
 option(ENABLE_YAJL "Enable JSON output with the YAJL library" ON)
 option(ENABLE_BROTLI "Enable Brotli library" ON)
 option(ENABLE_FMT_HEADER "Enable FMT header only mode" ON)
@@ -61,7 +60,6 @@ include(BuildLint)
 add_library(cgimap_common_compiler_options INTERFACE)
 
 target_compile_features(cgimap_common_compiler_options INTERFACE cxx_std_17)
-target_compile_definitions(cgimap_common_compiler_options INTERFACE "ENABLE_APIDB=$<BOOL:${ENABLE_APIDB}>")
 target_compile_definitions(cgimap_common_compiler_options INTERFACE CMAKE=1)
 target_add_autotools_compatibility_definitions(cgimap_common_compiler_options)
 
@@ -141,7 +139,7 @@ target_link_libraries(openstreetmap_cgimap
     cgimap_common_compiler_options
     cgimap_core
     cgimap_fcgi
-    $<$<BOOL:${ENABLE_APIDB}>:cgimap_apidb>
+    cgimap_apidb
     Boost::program_options
     PQXX::PQXX)
 
@@ -181,9 +179,7 @@ if (ENABLE_INSTALL)
   if (BUILD_SHARED_LIBS)
     install(TARGETS cgimap_core DESTINATION lib)
     install(TARGETS cgimap_fcgi DESTINATION lib)
-    if (ENABLE_APIDB)
-      install(TARGETS cgimap_apidb DESTINATION lib)
-    endif()
+    install(TARGETS cgimap_apidb DESTINATION lib)
   endif()
 endif()
 

--- a/openstreetmap-cgimap.1
+++ b/openstreetmap-cgimap.1
@@ -17,7 +17,6 @@ openstreetmap-cgimap \- FCGI version of the OpenStreetMap API
 [\fB\-\-moderator-maxdebt \fIMODERATOR_DEBT\fR]
 [\fB\-\-port \fIPORT\fR]
 [\fB\-\-socket \fISOCKET\fR]
-[\fB\-\-backend \fIBACKEND\fR]
 ] [
 [\fB\-\-dbname \fIDBNAME\fR]
 [\fB\-\-host \fIHOST\fR]

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -10,8 +10,7 @@
 #include "cgimap/backend.hpp"
 
 #include <fmt/core.h>
-#include <stdexcept>
-#include <mutex>
+#include <memory>
 
 namespace po = boost::program_options;
 
@@ -43,166 +42,74 @@ po::variables_map first_pass_argments(int argc, char *argv[],
 struct registry {
   registry() = default;
 
-  bool add(std::unique_ptr<backend> ptr);
+  bool set_backend(std::unique_ptr<backend> ptr);
   void setup_options(int argc, char *argv[], po::options_description &desc);
   void output_options(std::ostream &out);
   std::unique_ptr<data_selection::factory> create(const po::variables_map &options);
   std::unique_ptr<data_update::factory> create_data_update(const po::variables_map &options);
 
 private:
-  using backend_map_t = std::map<std::string, std::unique_ptr<backend> >;
-  backend_map_t backends;
-  std::optional<std::string> default_backend;
+  std::unique_ptr<backend> backend_ptr;
 };
 
-bool registry::add(std::unique_ptr<backend> ptr) {
-  if (default_backend) {
-    if (ptr->name() <= *default_backend) {
-      default_backend = ptr->name();
-    }
-  } else {
-    default_backend = ptr->name();
-  }
-
-  std::string name = ptr->name();
-  backends.emplace(name, std::move(ptr));
-
+bool registry::set_backend(std::unique_ptr<backend> ptr) {
+  backend_ptr = std::move(ptr);
   return true;
 }
 
 void registry::setup_options(int argc, char *argv[],
                              po::options_description &desc) {
-  if (backends.empty() || !default_backend) {
-    throw std::runtime_error("No backends available - this is most likely a "
-                             "compile-time configuration error.");
-  }
-
-  std::string all_backends;
-
-  for (const backend_map_t::value_type &val : backends) {
-    if (!all_backends.empty()) {
-      all_backends += ", ";
-    }
-    all_backends += val.second->name();
-  }
-
-  std::string description = fmt::format("backend to use, available options are: {}", all_backends);
-
-  desc.add_options()("backend", po::value<std::string>()->default_value(*default_backend),
-                     description.c_str());
 
   po::variables_map vm = first_pass_argments(argc, argv, desc);
 
-  std::string bcknd = *default_backend;
-
-  // little hack - we want to print *all* the backends when --help is passed, so
-  // we don't add one here when it's present. it's a nasty way to do it, but i
-  // can't think of a better one right now...
   if (!vm.count("help")) {
-
-    if (vm.count("backend")) {
-      auto itr =
-          backends.find(vm["backend"].as<std::string>());
-      if (itr != backends.end()) {
-        bcknd = itr->first;
-      }
-      else {
-        throw std::runtime_error(fmt::format("unknown backend provided, available options are: {}", all_backends));
-      }
-    }
-
-    desc.add(backends[bcknd]->options());
+    desc.add(backend_ptr->options());
   }
 }
 
 void registry::output_options(std::ostream &out) {
-  for (const backend_map_t::value_type &val : backends) {
-    out << val.second->options() << std::endl;
-  }
+    out << backend_ptr->options() << std::endl;
 }
 
 std::unique_ptr<data_selection::factory>
 registry::create(const po::variables_map &options) {
-  std::string bcknd = *default_backend;
-
-  if (options.count("backend")) {
-    auto itr =
-        backends.find(options["backend"].as<std::string>());
-    if (itr != backends.end()) {
-      bcknd = itr->first;
-    }
-  }
-
-  return backends[bcknd]->create(options);
+  return backend_ptr->create(options);
 }
 
 std::unique_ptr<data_update::factory>
 registry::create_data_update(const po::variables_map &options) {
-  std::string bcknd = *default_backend;
-
-  if (options.count("backend")) {
-    auto itr =
-        backends.find(options["backend"].as<std::string>());
-    if (itr != backends.end()) {
-      bcknd = itr->first;
-    }
-  }
-
-  return backends[bcknd]->create_data_update(options);
+  return backend_ptr->create_data_update(options);
 }
 
-registry *registry_ptr = NULL;
-std::mutex registry_mut;
+std::unique_ptr<registry> registry_ptr = std::make_unique<registry>();
+
 
 } // anonymous namespace
 
 backend::~backend() = default;
 
+// Registers a single backend, replacing an existing backend
 bool register_backend(std::unique_ptr<backend> ptr) {
-  std::unique_lock<std::mutex> lock(registry_mut);
-  if (registry_ptr == NULL) {
-    registry_ptr = new registry;
-  }
-
-  return registry_ptr->add(std::move(ptr));
+  return registry_ptr->set_backend(std::move(ptr));
 }
 
 void setup_backend_options(int argc, char *argv[],
                            po::options_description &desc) {
-  std::unique_lock<std::mutex> lock(registry_mut);
-  if (registry_ptr == NULL) {
-    registry_ptr = new registry;
-  }
 
   registry_ptr->setup_options(argc, argv, desc);
 }
 
 void output_backend_options(std::ostream &out) {
-  std::unique_lock<std::mutex> lock(registry_mut);
-  if (registry_ptr == NULL) {
-    registry_ptr = new registry;
-  }
-
   registry_ptr->output_options(out);
 }
 
 std::unique_ptr<data_selection::factory>
 create_backend(const po::variables_map &options) {
-  std::unique_lock<std::mutex> lock(registry_mut);
-  if (registry_ptr == NULL) {
-    registry_ptr = new registry;
-  }
-
   return registry_ptr->create(options);
 }
 
 std::unique_ptr<data_update::factory>
 create_update_backend(const po::variables_map &options) {
-  std::unique_lock<std::mutex> lock(registry_mut);
-  if (registry_ptr == NULL) {
-    registry_ptr = new registry;
-  }
-
   return registry_ptr->create_data_update(options);
 }
 

--- a/src/backend/apidb/CMakeLists.txt
+++ b/src/backend/apidb/CMakeLists.txt
@@ -1,7 +1,7 @@
 ##############
 # cgimap_apidb
 ##############
-if(ENABLE_APIDB)
+
     add_library(cgimap_apidb)
 
     target_include_directories(cgimap_apidb PUBLIC
@@ -26,4 +26,4 @@ if(ENABLE_APIDB)
         cgimap_common_compiler_options
         cgimap_core
         PQXX::PQXX)
-endif()
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,9 +7,7 @@
  * For a full list of authors see the git log.
  */
 
-#if ENABLE_APIDB
 #include <pqxx/pqxx>
-#endif
 #include <iostream>
 #include <sstream>
 
@@ -48,10 +46,8 @@ using namespace std::chrono_literals;
 #include "cgimap/fcgi_request.hpp"
 #include "cgimap/options.hpp"
 #include "cgimap/process_request.hpp"
-
-#ifdef ENABLE_APIDB
 #include "cgimap/backend/apidb/apidb.hpp"
-#endif
+
 
 namespace po = boost::program_options;
 
@@ -287,12 +283,6 @@ void daemonise() {
   close(2);
 }
 
-void setup_backends() {
-#if ENABLE_APIDB
-  register_backend(make_apidb_backend());
-#endif
-}
-
 
 void daemon_mode(const po::variables_map &options, int socket)
 {
@@ -423,8 +413,8 @@ int main(int argc, char **argv) {
   try {
     po::variables_map options;
 
-    // set up all the backends
-    setup_backends();
+    // set up the apidb backend
+    register_backend(make_apidb_backend());
 
     // get options
     get_options(argc, argv, options);
@@ -445,7 +435,6 @@ int main(int argc, char **argv) {
     std::cerr << "Error: " << e.what() << "\n(\"openstreetmap-cgimap --help\" for help)" << std::endl;
     return 1;
 
-#if ENABLE_APIDB
   } catch (const pqxx::sql_error &er) {
     logger::message(er.what());
     // Catch-all for query related postgres exceptions
@@ -461,7 +450,6 @@ int main(int argc, char **argv) {
     std::cerr << "Error: " << e.base().what() << std::endl;
     return 1;
 
-#endif
 #endif
 
   } catch (const std::exception &e) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -159,7 +159,6 @@ if(BUILD_TESTING)
         COMMAND test_parse_changeset_input)
 
 
-    if(ENABLE_APIDB)
         ##########################
         # test_apidb_backend_nodes
         ##########################
@@ -283,7 +282,6 @@ if(BUILD_TESTING)
 
         add_test(NAME test_apidb_backend_changeset_uploads
             COMMAND pg_virtualenv "$<TARGET_FILE:test_apidb_backend_changeset_uploads>" --db-schema "${CMAKE_CURRENT_SOURCE_DIR}/structure.sql")
-    endif()
 
     # define check alias target for autotools compatibility
     add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
@@ -297,13 +295,11 @@ if(BUILD_TESTING)
                            test_parse_osmchange_input
                            test_parse_changeset_input)
 
-    if(ENABLE_APIDB)
       add_dependencies(check test_apidb_backend_nodes
                              test_apidb_backend_oauth2
                              test_apidb_backend_historic
                              test_apidb_backend_changesets
                              test_apidb_backend_changeset_downloads
                              test_apidb_backend_changeset_uploads)
-    endif()
 
 endif()


### PR DESCRIPTION
This PR addresses the two remaining topics from #368, namely removing multi-backend support, and removing the ENABLE_APIDB compile time flag. With the staticxml backend removal in 0.9.1, there's not much point in keeping this code around for a single remaining APIDB backend.

*/CMakeLists.txt need a bit of reformatting which will be done later.

Closes #368