### PR TITLE
Fix libxml++ contrib library compiler options

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -5,4 +5,4 @@ add_subdirectory(catch2)
 add_subdirectory(libxml++)
 
 target_link_libraries(catch2 INTERFACE cgimap_common_compiler_options)
-target_link_libraries(libxml++ INTERFACE cgimap_common_compiler_options)
+target_link_libraries(libxml++ PUBLIC cgimap_common_compiler_options)


### PR DESCRIPTION
Linking the libxml++ contrib library with cgimap_common_compiler_options with INTERFACE scope is a bug as that only applies to targets using the library but not the library itself.
(Copy paste error from catch2 which is a header only interface library and can therefore only link to other libraries with INTERFACE scope)

https://github.com/zerebubuth/openstreetmap-cgimap/commit/0901120a963542b457ceb1f45890e18de4b4be88#diff-f3c6529ba39f2f8fe71ba721bdb3eccec46bd4ba024980398b12c7e7cd3f2672R5