### PR TITLE
Revert "Skip changeset discussions unless requested"

### DIFF
--- a/src/backend/apidb/common_pgsql_selection.cpp
+++ b/src/backend/apidb/common_pgsql_selection.cpp
@@ -458,7 +458,7 @@ void extract_changesets(
   for (const auto &row : rows) {
     auto elem = extract_changeset(row, cc, changeset_cols);
     auto tags = extract_tags(row, tag_cols);
-    auto comments = (include_changeset_discussions ? extract_comments(row, comments_cols) : comments_t{});
+    auto comments = extract_comments(row, comments_cols);
     elem.comments_count = comments.size();
     formatter.write_changeset(
       elem, tags, include_changeset_discussions, comments, now);

--- a/src/backend/apidb/readonly_pgsql_selection.cpp
+++ b/src/backend/apidb/readonly_pgsql_selection.cpp
@@ -362,10 +362,10 @@ void readonly_pgsql_selection::write_changesets(output_formatter &formatter,
            "to_char(cc.created_at,'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS created_at "
            "FROM changeset_comments cc JOIN users u ON cc.author_id = u.id "
            "where cc.changeset_id=c.id AND cc.visible ORDER BY cc.created_at) x "
-         ")cc ON $2 "
+         ")cc ON true "
       "WHERE c.id = ANY($1)");
 
-  pqxx::result changesets = m.exec_prepared("extract_changesets", sel_changesets, include_changeset_discussions);
+  pqxx::result changesets = m.exec_prepared("extract_changesets", sel_changesets);
 
   fetch_changesets(sel_changesets, cc);
 

--- a/test/test_apidb_backend_changesets.cpp
+++ b/test/test_apidb_backend_changesets.cpp
@@ -290,8 +290,7 @@ void check_changeset_with_comments_impl(
   REQUIRE(f.m_changesets.size() == 1);
 
   comments_t comments;
-
-  if (include_discussion) {
+  {
     changeset_comment_info comment;
     comment.id = 1;
     comment.author_id = 3;
@@ -312,7 +311,7 @@ void check_changeset_with_comments_impl(
         std::string("user_1"), // display_name
         {}, // bounding box
         0, // num_changes
-        include_discussion ? 1 : 0 // comments_count
+        1 // comments_count
         ),
       tags_t(),
       include_discussion,


### PR DESCRIPTION
See discussion in #401. This PR was causing regressions, since the "comments_count" header attribute did not show the acutal number of changeset comments.

```
<?xml version="1.0" encoding="UTF-8"?>
<osm version="0.6" generator="CGImap 0.9.1 (2193678 spike-06.openstreetmap.org)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
 <changeset id="79214306" created_at="2020-01-05T14:39:30Z" closed_at="2020-01-05T14:40:09Z" open="false" user="Chenshi" uid="114430" min_lat="52.3942212" min_lon="8.1937004" max_lat="52.9121770" max_lon="9.2001523" comments_count="0" changes_count="5343">
  <tag k="comment" v="maxspeed"/>
  <tag k="created_by" v="JOSM/1.5 (15553 de)"/>
  <tag k="source" v="datenbestandbearbeitung"/>
 </changeset>
</osm>
```

Reverts zerebubuth/openstreetmap-cgimap#388