### PR TITLE
Allow changeset bounding boxes to be limited in size

### DIFF
--- a/include/cgimap/options.hpp
+++ b/include/cgimap/options.hpp
@@ -35,6 +35,8 @@ public:
   virtual uint32_t get_ratelimiter_ratelimit(bool) const = 0;
   virtual uint32_t get_ratelimiter_maxdebt(bool) const = 0;
   virtual bool get_ratelimiter_upload() const = 0;
+  virtual double get_bbox_max_size_1d() const = 0;
+  virtual double get_bbox_max_size_2d() const = 0;
 };
 
 class global_settings_default : public global_settings_base {
@@ -96,6 +98,14 @@ public:
 
   bool get_ratelimiter_upload() const override {
     return false;
+  }
+
+  double get_bbox_max_size_1d() const override {
+    return 360.0;
+  }
+
+  double get_bbox_max_size_2d() const override {
+    return 180.0 * 360.0;
   }
 };
 
@@ -175,6 +185,14 @@ public:
     return m_ratelimiter_upload;
   }
 
+  double get_bbox_max_size_1d() const override {
+    return m_bbox_max_size_1d;
+  }
+
+  double get_bbox_max_size_2d() const override {
+    return m_bbox_max_size_2d;
+  }
+
 private:
   void init_fallback_values(const global_settings_base &def);
   void set_new_options(const po::variables_map &options);
@@ -191,6 +209,8 @@ private:
   void set_ratelimiter_ratelimit(const po::variables_map &options);
   void set_ratelimiter_maxdebt(const po::variables_map &options);
   void set_ratelimiter_upload(const po::variables_map &options);
+  void set_bbox_max_size_1d(const po::variables_map &options);
+  void set_bbox_max_size_2d(const po::variables_map &options);
   bool validate_timeout(const std::string &timeout) const;
 
   uint32_t m_payload_max_size;
@@ -208,6 +228,8 @@ private:
   uint32_t m_ratelimiter_maxdebt;
   uint32_t m_moderator_ratelimiter_maxdebt;
   bool m_ratelimiter_upload;
+  double m_bbox_max_size_1d;
+  double m_bbox_max_size_2d;
 };
 
 class global_settings final {
@@ -255,6 +277,12 @@ public:
 
   // Use ratelimiter for changeset uploads
   static bool get_ratelimiter_upload() { return settings->get_ratelimiter_upload(); }
+
+  // Maximum size of a bounding box in either dimension (lat or lon)
+  static double get_bbox_max_size_1d() { return settings->get_bbox_max_size_1d(); }
+
+  // Maximum size of a bounding box in both dimensions (lat * lon)
+  static double get_bbox_max_size_2d() { return settings->get_bbox_max_size_2d(); }
 
 private:
   static std::unique_ptr<global_settings_base> settings;  // gets initialized with global_settings_default instance

--- a/src/backend/apidb/changeset_upload/changeset_updater.cpp
+++ b/src/backend/apidb/changeset_upload/changeset_updater.cpp
@@ -119,6 +119,13 @@ void ApiDB_Changeset_Updater::update_changeset(const uint32_t num_new_changes,
        )");
 
   if (valid_bbox) {
+      double dx = 1.0 * (cs_bbox.maxlon - cs_bbox.minlon) / global_settings::get_scale();
+      double dy = 1.0 * (cs_bbox.maxlat - cs_bbox.minlat) / global_settings::get_scale();
+      if (dy > global_settings::get_bbox_max_size_1d() ||
+          dx > global_settings::get_bbox_max_size_1d() ||
+          (dy * dx) > global_settings::get_bbox_max_size_2d()) {
+        throw http::bad_request("The changeset area is greater than the maximum allowed by this server.");
+      }
       auto r = m.exec_prepared("changeset_update_w_bbox", cs_num_changes, cs_bbox.minlat, cs_bbox.minlon,
 			  cs_bbox.maxlat, cs_bbox.maxlon,
 			  global_settings::get_changeset_timeout_open_max(),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -135,6 +135,8 @@ void get_options(int argc, char **argv, po::variables_map &options) {
     ("max-relation-members", po::value<int>(), "max number of relation members per relation")
     ("max-element-tags", po::value<int>(), "max number of tags per OSM element")
     ("ratelimit-upload", po::value<bool>(), "enable rate limiting for changeset upload")
+    ("max-bbox-1d", po::value<double>(), "max size in degrees of a changeset in either dimension")
+    ("max-bbox-2d", po::value<double>(), "max size in square degrees of a changeset in both dimensions")
     ;
   // clang-format on
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -33,6 +33,8 @@ void global_settings_via_options::init_fallback_values(const global_settings_bas
   m_ratelimiter_maxdebt = def.get_ratelimiter_maxdebt(false);
   m_moderator_ratelimiter_maxdebt = def.get_ratelimiter_maxdebt(true);
   m_ratelimiter_upload = def.get_ratelimiter_upload();
+  m_bbox_max_size_1d = def.get_bbox_max_size_1d();
+  m_bbox_max_size_2d = def.get_bbox_max_size_2d();
 }
 
 void global_settings_via_options::set_new_options(const po::variables_map &options) {
@@ -50,6 +52,8 @@ void global_settings_via_options::set_new_options(const po::variables_map &optio
   set_ratelimiter_ratelimit(options);
   set_ratelimiter_maxdebt(options);
   set_ratelimiter_upload(options);
+  set_bbox_max_size_1d(options);
+  set_bbox_max_size_2d(options);
 }
 
 void global_settings_via_options::set_payload_max_size(const po::variables_map &options)  {
@@ -185,6 +189,23 @@ void global_settings_via_options::set_ratelimiter_upload(const po::variables_map
   }
 }
 
+void global_settings_via_options::set_bbox_max_size_1d(const po::variables_map &options) {
+  if (options.count("max-bbox-1d")) {
+      m_bbox_max_size_1d = options["max-bbox-1d"].as<double>();
+      if (m_bbox_max_size_1d < 0 || m_bbox_max_size_1d > 360.0) {
+        throw std::invalid_argument("max-bbox-1d (in degrees) must be between 0 and 360");
+      }
+  }
+}
+
+void global_settings_via_options::set_bbox_max_size_2d(const po::variables_map &options) {
+  if (options.count("max-bbox-2d")) {
+      m_bbox_max_size_1d = options["max-bbox-2d"].as<double>();
+      if (m_bbox_max_size_1d < 0 || m_bbox_max_size_1d > 360.0*180.0) {
+        throw std::invalid_argument("max-bbox-2d (in degrees) must be between 0 and 360*180");
+      }
+  }
+}
 
 bool global_settings_via_options::validate_timeout(const std::string &timeout) const {
   std::smatch sm;

--- a/test/test_parse_options.cpp
+++ b/test/test_parse_options.cpp
@@ -54,6 +54,8 @@ TEST_CASE("Set all supported options" "[options]") {
   vm.emplace("maxdebt", po::variable_value((long) 500, false));
   vm.emplace("moderator-maxdebt", po::variable_value((long) 1000, false));
   vm.emplace("ratelimit-upload", po::variable_value(true, false));
+  vm.emplace("max-bbox-1d", po::variable_value((double) 3.5, false));
+  vm.emplace("max-bbox-2d", po::variable_value((double) 16.0, false));
   REQUIRE_NOTHROW(check_options(vm));
 
   REQUIRE( global_settings::get_payload_max_size() == 40000 );
@@ -71,4 +73,6 @@ TEST_CASE("Set all supported options" "[options]") {
   REQUIRE( global_settings::get_ratelimiter_ratelimit(true) == 10000000 );
   REQUIRE( global_settings::get_ratelimiter_maxdebt(true) == 1000l * 1024 * 1024 );
   REQUIRE( global_settings::get_ratelimiter_upload() == true );
+  REQUIRE( global_settings::get_bbox_max_size_1d() == 3.5 );
+  REQUIRE( global_settings::get_bbox_max_size_2d() == 16.0 );
 }


### PR DESCRIPTION
This PR adds the ability for a maximum changeset bounding box to be enforced.

The maximum can be set with `--max-bbox-1d` and `--max-bbox-2d`. The former sets the maximum, in degrees, in any one dimension: for example, if it's set to 2, then a changeset with a node at lon 35.0 and another at lon 38.0 will fail. The latter sets the maximum, in square degrees, in both dimensions (i.e. dx * dy).

I'm not under any illusions that this will prove more than a speedbump in the road for our long-wayed friend, but it's another tool for the box.

The PR passes existing tests and new ones have been added but more testing is always good!