### PR TITLE
Propagate request context to handlers

### DIFF
--- a/include/cgimap/api06/changeset_close_handler.hpp
+++ b/include/cgimap/api06/changeset_close_handler.hpp
@@ -16,6 +16,8 @@
 #include "cgimap/handler.hpp"
 #include "cgimap/request.hpp"
 
+struct RequestContext;
+
 namespace api06 {
 
 class changeset_close_responder : public text_responder {
@@ -24,7 +26,7 @@ public:
                             data_update &, 
                             osm_changeset_id_t,
                             const std::string &,
-                            std::optional<osm_user_id_t>);
+                            const RequestContext& req_ctx);
 };
 
 class changeset_close_handler : public payload_enabled_handler {
@@ -36,7 +38,7 @@ public:
 
   responder_ptr_t responder(data_update &,
                             const std::string &payload,
-                            std::optional<osm_user_id_t> user_id) const override;
+                            const RequestContext& req_ctx) const override;
   bool requires_selection_after_update() const override;
 
 private:

--- a/include/cgimap/api06/changeset_create_handler.hpp
+++ b/include/cgimap/api06/changeset_create_handler.hpp
@@ -23,7 +23,7 @@ public:
   changeset_create_responder(mime::type, 
                              data_update &,
                              const std::string &,
-                             std::optional<osm_user_id_t>);
+                             const RequestContext& req_ctx);
 };
 
 class changeset_create_handler : public payload_enabled_handler {
@@ -35,7 +35,7 @@ public:
 
   responder_ptr_t responder(data_update &,
                             const std::string &payload,
-                            std::optional<osm_user_id_t> user_id) const override;
+                            const RequestContext& req_ctx) const override;
   bool requires_selection_after_update() const override;
 };
 

--- a/include/cgimap/api06/changeset_update_handler.hpp
+++ b/include/cgimap/api06/changeset_update_handler.hpp
@@ -25,7 +25,7 @@ public:
                              data_update &,
                              osm_changeset_id_t id_,
                              const std::string & payload,
-                             std::optional<osm_user_id_t> user_id);
+                             const RequestContext& req_ctx);
 };
 
 class changeset_update_sel_responder : public osm_current_responder {
@@ -46,7 +46,7 @@ public:
 
   responder_ptr_t responder(data_update &,
                             const std::string &payload,
-                            std::optional<osm_user_id_t> user_id) const override;
+                            const RequestContext& req_ctx) const override;
   bool requires_selection_after_update() const override;
 
 private:

--- a/include/cgimap/api06/changeset_upload_handler.hpp
+++ b/include/cgimap/api06/changeset_upload_handler.hpp
@@ -16,13 +16,15 @@
 #include "cgimap/osm_diffresult_responder.hpp"
 #include "cgimap/request.hpp"
 
+struct RequestContext;
+
 namespace api06 {
 
 class changeset_upload_responder : public osm_diffresult_responder {
 public:
   changeset_upload_responder(mime::type, data_update &, osm_changeset_id_t,
                              const std::string &,
-                             std::optional<osm_user_id_t>);
+                             const RequestContext& req_ctx);
 };
 
 class changeset_upload_handler : public payload_enabled_handler {
@@ -34,7 +36,7 @@ public:
 
   responder_ptr_t responder(data_update &,
                             const std::string &payload,
-                            std::optional<osm_user_id_t> user_id) const override;
+                            const RequestContext& req_ctx) const override;
   bool requires_selection_after_update() const override;
 
 private:

--- a/include/cgimap/backend/apidb/changeset_upload/changeset_updater.hpp
+++ b/include/cgimap/backend/apidb/changeset_upload/changeset_updater.hpp
@@ -17,12 +17,14 @@
 #include "cgimap/api06/changeset_upload/osmchange_tracking.hpp"
 #include "cgimap/backend/apidb/transaction_manager.hpp"
 
+struct RequestContext;
+
 class ApiDB_Changeset_Updater : public api06::Changeset_Updater {
 
 public:
   ApiDB_Changeset_Updater(Transaction_Manager &_m,
-                          osm_changeset_id_t _changeset, 
-                          osm_user_id_t _uid);
+                          const RequestContext& _req_ctx, 
+                          osm_changeset_id_t _changeset);
 
   ~ApiDB_Changeset_Updater() override = default;
 
@@ -48,9 +50,9 @@ private:
   void changeset_insert_cs ();
 
   Transaction_Manager &m;
+  const RequestContext& req_ctx;
   uint32_t cs_num_changes{0};
   osm_changeset_id_t changeset;
-  osm_user_id_t uid;
   bbox_t cs_bbox{};
 };
 

--- a/include/cgimap/backend/apidb/changeset_upload/node_updater.hpp
+++ b/include/cgimap/backend/apidb/changeset_upload/node_updater.hpp
@@ -20,11 +20,14 @@
 #include <memory>
 #include <set>
 
+struct RequestContext;
+
 
 class ApiDB_Node_Updater : public api06::Node_Updater {
 
 public:
   ApiDB_Node_Updater(Transaction_Manager &_m,
+                     const RequestContext& req_ctx,
                      api06::OSMChange_Tracking &ct);
 
   ~ApiDB_Node_Updater() override = default;
@@ -108,6 +111,7 @@ private:
   void delete_current_node_tags(const std::vector<osm_nwr_id_t> &ids);
 
   Transaction_Manager &m;
+  const RequestContext& req_ctx;
   api06::OSMChange_Tracking &ct;
 
   std::vector<node_t> create_nodes;

--- a/include/cgimap/backend/apidb/changeset_upload/relation_updater.hpp
+++ b/include/cgimap/backend/apidb/changeset_upload/relation_updater.hpp
@@ -21,6 +21,8 @@
 #include <memory>
 #include <set>
 
+struct RequestContext;
+
 using RelationMemberList = std::vector<api06::RelationMember>;
 using TagList = std::map<std::string, std::string>;
 
@@ -28,6 +30,7 @@ class ApiDB_Relation_Updater : public api06::Relation_Updater {
 
 public:
   ApiDB_Relation_Updater(Transaction_Manager &_m,
+                         const RequestContext& _req_ctx,
                          api06::OSMChange_Tracking &ct);
 
   ~ApiDB_Relation_Updater() override = default;
@@ -175,6 +178,7 @@ private:
       const std::set<osm_nwr_id_t> &direct_relation_ids);
 
   Transaction_Manager &m;
+  const RequestContext& req_ctx;
   api06::OSMChange_Tracking &ct;
 
   std::vector<relation_t> create_relations;

--- a/include/cgimap/backend/apidb/changeset_upload/way_updater.hpp
+++ b/include/cgimap/backend/apidb/changeset_upload/way_updater.hpp
@@ -21,6 +21,8 @@
 #include <memory>
 #include <set>
 
+struct RequestContext;
+
 /*  Way operations
  *
  */
@@ -29,6 +31,7 @@ class ApiDB_Way_Updater : public api06::Way_Updater {
 
 public:
   ApiDB_Way_Updater(Transaction_Manager &_m,
+                    const RequestContext& _req_ctx,
                     api06::OSMChange_Tracking &ct);
 
   ~ApiDB_Way_Updater() override = default;
@@ -130,6 +133,7 @@ private:
   void delete_current_way_nodes(std::vector<osm_nwr_id_t> ids);
 
   Transaction_Manager &m;
+  const RequestContext& req_ctx;
   api06::OSMChange_Tracking &ct;
 
   std::vector<way_t> create_ways;

--- a/include/cgimap/backend/apidb/pgsql_update.hpp
+++ b/include/cgimap/backend/apidb/pgsql_update.hpp
@@ -18,6 +18,8 @@
 #include <pqxx/pqxx>
 #include <boost/program_options.hpp>
 
+struct RequestContext;
+
 class pgsql_update : public data_update {
 
 public:
@@ -26,16 +28,16 @@ public:
   ~pgsql_update() override = default;
 
   std::unique_ptr<api06::Changeset_Updater>
-  get_changeset_updater(osm_changeset_id_t _changeset, osm_user_id_t _uid) override;
+  get_changeset_updater(const RequestContext& ctx, osm_changeset_id_t _changeset) override;
 
   std::unique_ptr<api06::Node_Updater>
-  get_node_updater(api06::OSMChange_Tracking &ct) override;
+  get_node_updater(const RequestContext& ctx, api06::OSMChange_Tracking &ct) override;
 
   std::unique_ptr<api06::Way_Updater>
-  get_way_updater(api06::OSMChange_Tracking &ct) override;
+  get_way_updater(const RequestContext& ctx, api06::OSMChange_Tracking &ct) override;
 
   std::unique_ptr<api06::Relation_Updater>
-  get_relation_updater(api06::OSMChange_Tracking &ct) override;
+  get_relation_updater(const RequestContext& ctx, api06::OSMChange_Tracking &ct) override;
 
   void commit() override;
 

--- a/include/cgimap/data_update.hpp
+++ b/include/cgimap/data_update.hpp
@@ -24,6 +24,8 @@
 #include <memory>
 #include <vector>
 
+struct RequestContext;
+
 class data_update {
 public:
   data_update() = default;
@@ -37,16 +39,16 @@ public:
   data_update& operator=(data_update&&) = delete;
 
   virtual std::unique_ptr<api06::Changeset_Updater>
-  get_changeset_updater(osm_changeset_id_t _changeset, osm_user_id_t _uid) = 0;
+  get_changeset_updater(const RequestContext& ctx, osm_changeset_id_t _changeset) = 0;
 
   virtual std::unique_ptr<api06::Node_Updater>
-  get_node_updater(api06::OSMChange_Tracking &ct) = 0;
+  get_node_updater(const RequestContext& ctx, api06::OSMChange_Tracking &ct) = 0;
 
   virtual std::unique_ptr<api06::Way_Updater>
-  get_way_updater(api06::OSMChange_Tracking &ct) = 0;
+  get_way_updater(const RequestContext& ctx, api06::OSMChange_Tracking &ct) = 0;
 
   virtual std::unique_ptr<api06::Relation_Updater>
-  get_relation_updater(api06::OSMChange_Tracking &ct) = 0;
+  get_relation_updater(const RequestContext& ctx, api06::OSMChange_Tracking &ct) = 0;
 
   virtual void
   commit() = 0;

--- a/include/cgimap/handler.hpp
+++ b/include/cgimap/handler.hpp
@@ -96,7 +96,7 @@ public:
   // Responder used to update the database
   virtual responder_ptr_t responder(data_update &, 
                                     const std::string & payload, 
-                                    std::optional<osm_user_id_t> user_id) const = 0;
+                                    const RequestContext& req_ctx) const = 0;
 
   // Optional responder to return XML response back to caller of the API method
   responder_ptr_t responder(data_selection &) const override = 0;

--- a/include/cgimap/request_context.hpp
+++ b/include/cgimap/request_context.hpp
@@ -1,0 +1,37 @@
+/**
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * This file is part of openstreetmap-cgimap (https://github.com/zerebubuth/openstreetmap-cgimap/).
+ *
+ * Copyright (C) 2009-2024 by the CGImap developer community.
+ * For a full list of authors see the git log.
+ */
+
+#ifndef REQUEST_CONTEXT_HPP
+#define REQUEST_CONTEXT_HPP
+
+#include "cgimap/types.hpp"
+
+#include <optional>
+#include <set>
+#include <chrono>
+
+struct request;
+
+struct UserInfo
+{
+    osm_user_id_t id = {};
+    std::set<osm_user_role_t> user_roles = {};
+    bool allow_api_write = false;
+
+    bool has_role(osm_user_role_t role) const { return user_roles.count(role) > 0; }
+};
+
+struct RequestContext
+{
+    request& req;
+    std::chrono::system_clock::time_point start_time = {};
+    std::optional<UserInfo> user = {};
+};
+
+#endif /* REQUEST_CONTEXT_HPP */

--- a/include/cgimap/request_helpers.hpp
+++ b/include/cgimap/request_helpers.hpp
@@ -10,9 +10,10 @@
 #ifndef REQUEST_HELPERS_HPP
 #define REQUEST_HELPERS_HPP
 
-#include <string>
 #include "cgimap/request.hpp"
 #include "cgimap/http.hpp"
+
+#include <string>
 #include <memory>
 
 /**

--- a/src/api06/changeset_close_handler.cpp
+++ b/src/api06/changeset_close_handler.cpp
@@ -29,10 +29,10 @@ changeset_close_responder::changeset_close_responder(mime::type mt,
                                                      data_update & upd, 
                                                      osm_changeset_id_t changeset, 
                                                      const std::string &, 
-                                                     std::optional<osm_user_id_t> user_id)
+                                                     const RequestContext& req_ctx)
     : text_responder(mt) {
 
-  auto changeset_updater = upd.get_changeset_updater(changeset, *user_id);
+  auto changeset_updater = upd.get_changeset_updater(req_ctx, changeset);
   changeset_updater->api_close_changeset();
   upd.commit();
 }
@@ -55,8 +55,8 @@ responder_ptr_t changeset_close_handler::responder(data_selection &) const {
 
 responder_ptr_t changeset_close_handler::responder(data_update & upd, 
                                                    const std::string &payload, 
-                                                   std::optional<osm_user_id_t> user_id) const {
-  return std::make_unique<changeset_close_responder>(mime_type, upd, id, payload, user_id);
+                                                   const RequestContext& req_ctx) const {
+  return std::make_unique<changeset_close_responder>(mime_type, upd, id, payload, req_ctx);
 }
 
 bool changeset_close_handler::requires_selection_after_update() const {

--- a/src/api06/changeset_create_handler.cpp
+++ b/src/api06/changeset_create_handler.cpp
@@ -28,12 +28,12 @@ namespace api06 {
 changeset_create_responder::changeset_create_responder(mime::type mt, 
                                                        data_update & upd, 
                                                        const std::string &payload,
-                                                       std::optional<osm_user_id_t> user_id)
+                                                       const RequestContext& req_ctx)
     : text_responder(mt) {
 
   osm_changeset_id_t changeset = 0;
 
-  auto changeset_updater = upd.get_changeset_updater(changeset, *user_id);
+  auto changeset_updater = upd.get_changeset_updater(req_ctx, changeset);
   auto tags = ChangesetXMLParser().process_message(payload);
   changeset = changeset_updater->api_create_changeset(tags);
 
@@ -56,8 +56,8 @@ changeset_create_handler::responder(data_selection &) const {
 
 responder_ptr_t changeset_create_handler::responder(data_update & upd, 
                                                     const std::string &payload, 
-                                                    std::optional<osm_user_id_t> user_id) const {
-  return std::make_unique<changeset_create_responder>(mime_type, upd, payload, user_id);
+                                                    const RequestContext& req_ctx) const {
+  return std::make_unique<changeset_create_responder>(mime_type, upd, payload, req_ctx);
 }
 
 bool changeset_create_handler::requires_selection_after_update() const {

--- a/src/api06/changeset_update_handler.cpp
+++ b/src/api06/changeset_update_handler.cpp
@@ -30,10 +30,10 @@ changeset_update_responder::changeset_update_responder(
     data_update &upd,
     osm_changeset_id_t changeset_id,
     const std::string &payload,
-    std::optional<osm_user_id_t> user_id)
+    const RequestContext& req_ctx)
     : text_responder(mt){
 
-  auto changeset_updater = upd.get_changeset_updater(changeset_id, *user_id);
+  auto changeset_updater = upd.get_changeset_updater(req_ctx, changeset_id);
 
   auto tags = ChangesetXMLParser().process_message(payload);
 
@@ -69,8 +69,8 @@ changeset_update_handler::responder(data_selection &sel) const {
 
 responder_ptr_t changeset_update_handler::responder(data_update & upd, 
                                                     const std::string &payload, 
-                                                    std::optional<osm_user_id_t> user_id) const {
-  return std::make_unique<changeset_update_responder>(mime_type, upd, id, payload, user_id);
+                                                    const RequestContext& req_ctx) const {
+  return std::make_unique<changeset_update_responder>(mime_type, upd, id, payload, req_ctx);
 }
 
 bool changeset_update_handler::requires_selection_after_update() const {

--- a/src/backend/apidb/changeset_upload/node_updater.cpp
+++ b/src/backend/apidb/changeset_upload/node_updater.cpp
@@ -16,6 +16,7 @@
 #include "cgimap/logger.hpp"
 #include "cgimap/options.hpp"
 #include "cgimap/util.hpp"
+#include "cgimap/request_helpers.hpp"
 
 
 #include <algorithm>
@@ -32,8 +33,10 @@
 
 
 ApiDB_Node_Updater::ApiDB_Node_Updater(Transaction_Manager &_m,
+                                       const RequestContext& _req_ctx,
                                        api06::OSMChange_Tracking &ct)
     : m(_m), 
+      req_ctx(_req_ctx),
       ct(ct)
 {}
 

--- a/src/backend/apidb/changeset_upload/relation_updater.cpp
+++ b/src/backend/apidb/changeset_upload/relation_updater.cpp
@@ -28,8 +28,10 @@
 
 
 ApiDB_Relation_Updater::ApiDB_Relation_Updater(Transaction_Manager &_m, 
+                                               const RequestContext& _req_ctx,
                                                api06::OSMChange_Tracking &ct)
   : m(_m),
+    req_ctx(_req_ctx),
     ct(ct) 
 {}
 

--- a/src/backend/apidb/changeset_upload/way_updater.cpp
+++ b/src/backend/apidb/changeset_upload/way_updater.cpp
@@ -15,6 +15,7 @@
 #include "cgimap/logger.hpp"
 #include "cgimap/options.hpp"
 #include "cgimap/util.hpp"
+#include "cgimap/request_helpers.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -30,8 +31,10 @@
 
 
 ApiDB_Way_Updater::ApiDB_Way_Updater(Transaction_Manager &_m,
+                                     const RequestContext& _req_ctx,
                                      api06::OSMChange_Tracking &ct)
   : m(_m), 
+    req_ctx(_req_ctx),
     ct(ct) 
 {}
 

--- a/src/backend/apidb/pgsql_update.cpp
+++ b/src/backend/apidb/pgsql_update.cpp
@@ -24,6 +24,8 @@
 
 namespace po = boost::program_options;
 
+struct RequestContext;
+
 namespace {
 std::string connect_db_str(const po::variables_map &options) {
   // build the connection string.
@@ -107,27 +109,27 @@ bool pgsql_update::is_api_write_disabled() const {
 }
 
 std::unique_ptr<api06::Changeset_Updater>
-pgsql_update::get_changeset_updater(osm_changeset_id_t changeset, osm_user_id_t uid)
+pgsql_update::get_changeset_updater(const RequestContext& req_ctx, osm_changeset_id_t changeset)
 {
-  return std::make_unique<ApiDB_Changeset_Updater>(m, changeset, uid);
+  return std::make_unique<ApiDB_Changeset_Updater>(m, req_ctx, changeset);
 }
 
 std::unique_ptr<api06::Node_Updater>
-pgsql_update::get_node_updater(api06::OSMChange_Tracking &ct)
+pgsql_update::get_node_updater(const RequestContext& req_ctx, api06::OSMChange_Tracking &ct)
 {
-  return std::make_unique<ApiDB_Node_Updater>(m, ct);
+  return std::make_unique<ApiDB_Node_Updater>(m, req_ctx, ct);
 }
 
 std::unique_ptr<api06::Way_Updater>
-pgsql_update::get_way_updater(api06::OSMChange_Tracking &ct)
+pgsql_update::get_way_updater(const RequestContext& req_ctx, api06::OSMChange_Tracking &ct)
 {
-  return std::make_unique<ApiDB_Way_Updater>(m, ct);
+  return std::make_unique<ApiDB_Way_Updater>(m, req_ctx, ct);
 }
 
 std::unique_ptr<api06::Relation_Updater>
-pgsql_update::get_relation_updater(api06::OSMChange_Tracking &ct)
+pgsql_update::get_relation_updater(const RequestContext& req_ctx, api06::OSMChange_Tracking &ct)
 {
-  return std::make_unique<ApiDB_Relation_Updater>(m, ct);
+  return std::make_unique<ApiDB_Relation_Updater>(m, req_ctx, ct);
 }
 
 void pgsql_update::commit() {


### PR DESCRIPTION
Make context information about the request (user id, roles, ...) available in change handlers.
Unblocks future features like https://github.com/zerebubuth/openstreetmap-cgimap/pull/409#issuecomment-2171787640