### PR TITLE
Small refactorings

### DIFF
--- a/include/cgimap/backend/apidb/changeset_upload/relation_updater.hpp
+++ b/include/cgimap/backend/apidb/changeset_upload/relation_updater.hpp
@@ -121,6 +121,15 @@ private:
   std::set<osm_nwr_id_t>
   determine_already_deleted_relations(const std::vector<relation_t> &relations);
 
+  void lock_future_members_nodes(std::vector< osm_nwr_id_t >& node_ids,
+    const std::vector< relation_t > &relations);
+
+  void lock_future_members_ways(std::vector< osm_nwr_id_t >& way_ids,
+    const std::vector< relation_t > &relations);
+
+  void lock_future_members_relations(std::vector< osm_nwr_id_t >& relation_ids,
+    const std::vector< relation_t > &relations);
+
   void lock_future_members(const std::vector<relation_t> &relations,
 			   const std::vector<osm_nwr_id_t>& already_locked_relations);
 

--- a/include/cgimap/handler.hpp
+++ b/include/cgimap/handler.hpp
@@ -30,7 +30,7 @@
  */
 class responder {
 public:
-  responder(mime::type);
+  explicit responder(mime::type);
   virtual ~responder() = default;
   virtual void write(output_formatter& f,
                      const std::string &generator,

--- a/include/cgimap/mime_types.hpp
+++ b/include/cgimap/mime_types.hpp
@@ -11,6 +11,7 @@
 #define MIME_TYPES_HPP
 
 #include <string>
+#include <string_view>
 
 /**
  * simple set of supported mime types.
@@ -27,7 +28,7 @@ enum class type {
 };
 
 std::string to_string(type);
-type parse_from(const std::string &);
+type parse_from(std::string_view);
 }
 
 #endif /* MIME_TYPES_HPP */

--- a/include/cgimap/request_context.hpp
+++ b/include/cgimap/request_context.hpp
@@ -23,15 +23,15 @@ struct UserInfo
     osm_user_id_t id = {};
     std::set<osm_user_role_t> user_roles = {};
     bool allow_api_write = false;
-
     bool has_role(osm_user_role_t role) const { return user_roles.count(role) > 0; }
 };
 
 struct RequestContext
 {
     request& req;
-    std::chrono::system_clock::time_point start_time = {};
     std::optional<UserInfo> user = {};
+
+    bool is_moderator() const { return user && user->has_role(osm_user_role_t::moderator); }
 };
 
 #endif /* REQUEST_CONTEXT_HPP */

--- a/src/api06/changeset_upload_handler.cpp
+++ b/src/api06/changeset_upload_handler.cpp
@@ -65,13 +65,13 @@ changeset_upload_responder::changeset_upload_responder(mime::type mt,
 
   if (global_settings::get_ratelimiter_upload()) {
 
-    auto max_changes = upd.get_rate_limit((*req_ctx.user).id);
+    auto max_changes = upd.get_rate_limit(req_ctx.user->id);
     if (new_changes > max_changes)
     {
       logger::message(
           fmt::format(
               "Upload of {} changes by user {} in changeset {} blocked due to rate limiting, max. {} changes allowed",
-              new_changes, (*req_ctx.user).id, changeset, max_changes));
+              new_changes, req_ctx.user->id, changeset, max_changes));
       throw http::too_many_requests("Upload has been blocked due to rate limiting. Please try again later.");
     }
   }
@@ -84,14 +84,14 @@ changeset_upload_responder::changeset_upload_responder(mime::type mt,
 
     if (!(cs_bbox == bbox_t()))   // valid bbox?
     {
-      auto const max_bbox_size = upd.get_bbox_size_limit((*req_ctx.user).id);
+      auto const max_bbox_size = upd.get_bbox_size_limit(req_ctx.user->id);
 
       if (cs_bbox.linear_size() > max_bbox_size) {
 
         logger::message(
             fmt::format(
                 "Upload of {} changes by user {} in changeset {} blocked due to bbox size limit exceeded, max bbox size {}",
-                new_changes, (*req_ctx.user).id, changeset, max_bbox_size));
+                new_changes, req_ctx.user->id, changeset, max_bbox_size));
 
         throw http::payload_too_large("Changeset bounding box size limit exceeded.");
       }

--- a/src/backend/apidb/changeset_upload/changeset_updater.cpp
+++ b/src/backend/apidb/changeset_upload/changeset_updater.cpp
@@ -279,7 +279,6 @@ void ApiDB_Changeset_Updater::changeset_insert_tags (
   if (tags.empty())
     return;
 
-
   m.prepare (
       "changeset_insert_tags",
       R"(
@@ -299,13 +298,13 @@ void ApiDB_Changeset_Updater::changeset_insert_tags (
   std::vector<std::string> vs;
   unsigned total_tags = 0;
 
-  for (const auto& tag : tags)
-    {
-      cs.emplace_back (changeset);
-      ks.emplace_back (escape (tag.first));
-      vs.emplace_back (escape (tag.second));
+  for (const auto& [key, value] : tags)
+  {
+      cs.emplace_back(changeset);
+      ks.emplace_back(escape(key));
+      vs.emplace_back(escape(value));
       ++total_tags;
-    }
+  }
 
   pqxx::result r = m.exec_prepared ("changeset_insert_tags", cs, ks, vs);
 

--- a/src/backend/apidb/changeset_upload/changeset_updater.cpp
+++ b/src/backend/apidb/changeset_upload/changeset_updater.cpp
@@ -152,7 +152,7 @@ ApiDB_Changeset_Updater::changeset_update_users_cs_count ()
            SET "changesets_count" = COALESCE("changesets_count", 0) + 1 
 	   WHERE "id" = $1
      )");
-    pqxx::result r = m.exec_prepared ("update_users", (*req_ctx.user).id);
+    pqxx::result r = m.exec_prepared ("update_users", req_ctx.user->id);
     if (r.affected_rows () != 1)
       throw http::server_error (
 	  "Cannot create changeset - update changesets_count");
@@ -192,7 +192,7 @@ void ApiDB_Changeset_Updater::api_close_changeset()
        SET closed_at = now() at time zone 'utc'
            WHERE id = $1 AND user_id = $2 )");
 
-  auto r = m.exec_prepared("changeset_close", changeset, (*req_ctx.user).id);
+  auto r = m.exec_prepared("changeset_close", changeset, req_ctx.user->id);
 
   if (r.affected_rows() != 1)
     throw http::server_error("Cannot close changeset");
@@ -219,7 +219,7 @@ void ApiDB_Changeset_Updater::lock_cs(bool& is_closed, std::string& closed_at, s
 	  FOR UPDATE 
      )");
 
-  auto r = m.exec_prepared("changeset_current_lock", changeset, (*req_ctx.user).id);
+  auto r = m.exec_prepared("changeset_current_lock", changeset, req_ctx.user->id);
   if (r.affected_rows () != 1)
     throw http::conflict ("The user doesn't own that changeset");
 
@@ -250,7 +250,7 @@ void ApiDB_Changeset_Updater::check_user_owns_changeset()
   if (r.affected_rows () != 1)
     throw http::not_found ("");
 
-  if (r[0]["user_id"].as<osm_user_id_t> () != (*req_ctx.user).id)
+  if (r[0]["user_id"].as<osm_user_id_t> () != req_ctx.user->id)
     throw http::conflict ("The user doesn't own that changeset");
 
 }
@@ -265,7 +265,7 @@ void ApiDB_Changeset_Updater::changeset_insert_subscriber ()
         INSERT INTO "changesets_subscribers" ("subscriber_id", "changeset_id") VALUES ($1, $2)
      )");
 
-    pqxx::result r = m.exec_prepared ("insert_changeset_subscribers", (*req_ctx.user).id,
+    pqxx::result r = m.exec_prepared ("insert_changeset_subscribers", req_ctx.user->id,
 				      changeset);
     if (r.affected_rows () != 1)
       throw http::server_error (
@@ -343,7 +343,7 @@ void ApiDB_Changeset_Updater::changeset_insert_cs ()
               RETURNING id 
    )");
 
-    pqxx::result r = m.exec_prepared ("create_changeset", (*req_ctx.user).id, global_settings::get_changeset_timeout_idle());
+    pqxx::result r = m.exec_prepared ("create_changeset", req_ctx.user->id, global_settings::get_changeset_timeout_idle());
     if (r.affected_rows () != 1)
       throw http::server_error ("Cannot create changeset");
 

--- a/src/backend/apidb/changeset_upload/node_updater.cpp
+++ b/src/backend/apidb/changeset_upload/node_updater.cpp
@@ -52,8 +52,8 @@ void ApiDB_Node_Updater::add_node(double lat, double lon,
   new_node.tile = xy2tile(lon2x(lon), lat2y(lat));
   new_node.changeset_id = changeset_id;
   new_node.old_id = old_id;
-  for (const auto &tag : tags)
-    new_node.tags.emplace_back(tag.first, tag.second);
+  for (const auto &[key, value] : tags)
+    new_node.tags.emplace_back(key, value);
   create_nodes.push_back(new_node);
 
   ct.osmchange_orig_sequence.push_back({ operation::op_create,
@@ -74,8 +74,8 @@ void ApiDB_Node_Updater::modify_node(double lat, double lon,
   modify_node.lon = round(lon * global_settings::get_scale());
   modify_node.tile = xy2tile(lon2x(lon), lat2y(lat));
   modify_node.changeset_id = changeset_id;
-  for (const auto &tag : tags)
-    modify_node.tags.emplace_back(std::make_pair(tag.first, tag.second));
+  for (const auto &[key, value] : tags)
+    modify_node.tags.emplace_back(key, value);
   modify_nodes.push_back(modify_node);
 
   ct.osmchange_orig_sequence.push_back({ operation::op_modify,

--- a/src/backend/apidb/changeset_upload/relation_updater.cpp
+++ b/src/backend/apidb/changeset_upload/relation_updater.cpp
@@ -676,6 +676,142 @@ ApiDB_Relation_Updater::determine_already_deleted_relations(
   return result;
 }
 
+void ApiDB_Relation_Updater::lock_future_members_nodes(
+    std::vector< osm_nwr_id_t >& node_ids,
+    const std::vector< relation_t > &relations)
+{
+  if (node_ids.empty())
+    return;
+
+  std::sort(node_ids.begin(), node_ids.end());
+  node_ids.erase(std::unique(node_ids.begin(), node_ids.end()), node_ids.end());
+
+  m.prepare("lock_future_nodes_in_relations",
+            R"( 
+                SELECT id
+                FROM current_nodes
+                WHERE visible = true 
+                AND id = ANY($1) FOR SHARE 
+            )");
+
+  pqxx::result r =
+      m.exec_prepared("lock_future_nodes_in_relations", node_ids);
+
+  if (r.size() != node_ids.size()) {
+    std::set<osm_nwr_id_t> locked_nodes;
+
+    for (const auto &row : r)
+      locked_nodes.insert(row["id"].as<osm_nwr_id_t>());
+
+    std::map<osm_nwr_signed_id_t, std::set<osm_nwr_id_t>> absent_rel_node_ids;
+
+    for (const auto &rel : relations)
+      for (const auto &rm : rel.members)
+        if (rm.member_type == "Node" &&
+            locked_nodes.find(rm.member_id) == locked_nodes.end())
+          absent_rel_node_ids[rel.old_id].insert(
+              rm.member_id); // return rel id in osmChange for error msg
+
+    auto it = absent_rel_node_ids.begin();
+
+    throw http::precondition_failed(
+        fmt::format("Relation {:d} requires the nodes with id in {}, "
+                       "which either do not exist, or are not visible.",
+         it->first, to_string(it->second)));
+  }
+}
+
+void ApiDB_Relation_Updater::lock_future_members_ways(
+    std::vector< osm_nwr_id_t >& way_ids,
+    const std::vector< relation_t > &relations)
+{
+  if (way_ids.empty())
+    return;
+
+  std::sort(way_ids.begin(), way_ids.end());
+  way_ids.erase(std::unique(way_ids.begin(), way_ids.end()), way_ids.end());
+
+  m.prepare("lock_future_ways_in_relations",
+            R"( 
+              SELECT id
+              FROM current_ways
+              WHERE visible = true 
+              AND id = ANY($1) FOR SHARE 
+           )");
+
+  pqxx::result r =
+      m.exec_prepared("lock_future_ways_in_relations", way_ids);
+
+  if (r.size() != way_ids.size()) {
+    std::set<osm_nwr_id_t> locked_ways;
+
+    for (const auto &row : r)
+      locked_ways.insert(row["id"].as<osm_nwr_id_t>());
+
+    std::map<osm_nwr_signed_id_t, std::set<osm_nwr_id_t>> absent_rel_way_ids;
+
+    for (const auto &rel : relations)
+      for (const auto &rm : rel.members)
+        if (rm.member_type == "Way" &&
+            locked_ways.find(rm.member_id) == locked_ways.end())
+          absent_rel_way_ids[rel.old_id].insert(
+              rm.member_id); // return rel id in osmChange for error msg
+
+    auto it = absent_rel_way_ids.begin();
+
+    throw http::precondition_failed(
+        fmt::format("Relation {:d} requires the ways with id in {}, which "
+                       "either do not exist, or are not visible.",
+         it->first, to_string(it->second)));
+  }
+}
+
+
+void ApiDB_Relation_Updater::lock_future_members_relations(
+    std::vector< osm_nwr_id_t >& relation_ids,
+    const std::vector< relation_t > &relations)
+{
+  if (relation_ids.empty())
+    return;
+
+  std::sort(relation_ids.begin(), relation_ids.end());
+  relation_ids.erase(std::unique(relation_ids.begin(), relation_ids.end()),
+                     relation_ids.end());
+
+  m.prepare("lock_future_relations_in_relations",
+            R"( 
+              SELECT id
+              FROM current_relations
+              WHERE visible = true 
+              AND id = ANY($1) FOR SHARE )");
+
+  pqxx::result r =
+      m.exec_prepared("lock_future_relations_in_relations", relation_ids);
+
+  if (r.size() != relation_ids.size()) {
+    std::set<osm_nwr_id_t> locked_relations;
+
+    for (const auto &row : r)
+      locked_relations.insert(row["id"].as<osm_nwr_id_t>());
+
+    std::map<osm_nwr_signed_id_t, std::set<osm_nwr_id_t>> absent_rel_rel_ids;
+
+    for (const auto &rel : relations)
+      for (const auto &rm : rel.members)
+        if (rm.member_type == "Relation" &&
+            locked_relations.find(rm.member_id) == locked_relations.end())
+          absent_rel_rel_ids[rel.old_id].insert(
+              rm.member_id); // return rel id in osmChange for error msg
+
+    auto it = absent_rel_rel_ids.begin();
+
+    throw http::precondition_failed(
+        fmt::format("Relation {:d} requires the relations with id in {}, "
+                       "which either do not exist, or are not visible.",
+         it->first, to_string(it->second)));
+  }
+}
+
 void ApiDB_Relation_Updater::lock_future_members(
     const std::vector<relation_t> &relations,
     const std::vector<osm_nwr_id_t>& already_locked_relations) {
@@ -712,125 +848,9 @@ void ApiDB_Relation_Updater::lock_future_members(
   if (node_ids.empty() && way_ids.empty() && relation_ids.empty())
     return; // nothing to do
 
-  // remove duplicates
-  std::sort(node_ids.begin(), node_ids.end());
-  node_ids.erase(std::unique(node_ids.begin(), node_ids.end()), node_ids.end());
-
-  std::sort(way_ids.begin(), way_ids.end());
-  way_ids.erase(std::unique(way_ids.begin(), way_ids.end()), way_ids.end());
-
-  std::sort(relation_ids.begin(), relation_ids.end());
-  relation_ids.erase(std::unique(relation_ids.begin(), relation_ids.end()),
-                     relation_ids.end());
-
-  // sequence nodes/way/relations??
-
-  if (!node_ids.empty()) {
-    m.prepare("lock_future_nodes_in_relations",
-              R"( 
-                  SELECT id
-                  FROM current_nodes
-                  WHERE visible = true 
-                  AND id = ANY($1) FOR SHARE 
-              )");
-
-    pqxx::result r =
-        m.exec_prepared("lock_future_nodes_in_relations", node_ids);
-
-    if (r.size() != node_ids.size()) {
-      std::set<osm_nwr_id_t> locked_nodes;
-
-      for (const auto &row : r)
-        locked_nodes.insert(row["id"].as<osm_nwr_id_t>());
-
-      std::map<osm_nwr_signed_id_t, std::set<osm_nwr_id_t>> absent_rel_node_ids;
-
-      for (const auto &rel : relations)
-        for (const auto &rm : rel.members)
-          if (rm.member_type == "Node" &&
-              locked_nodes.find(rm.member_id) == locked_nodes.end())
-            absent_rel_node_ids[rel.old_id].insert(
-                rm.member_id); // return rel id in osmChange for error msg
-
-      auto it = absent_rel_node_ids.begin();
-
-      throw http::precondition_failed(
-          fmt::format("Relation {:d} requires the nodes with id in {}, "
-                         "which either do not exist, or are not visible.",
-           it->first, to_string(it->second)));
-    }
-  }
-
-  if (!way_ids.empty()) {
-    m.prepare("lock_future_ways_in_relations",
-              R"( 
-                SELECT id
-                FROM current_ways
-                WHERE visible = true 
-                AND id = ANY($1) FOR SHARE 
-             )");
-
-    pqxx::result r =
-        m.exec_prepared("lock_future_ways_in_relations", way_ids);
-
-    if (r.size() != way_ids.size()) {
-      std::set<osm_nwr_id_t> locked_ways;
-
-      for (const auto &row : r)
-        locked_ways.insert(row["id"].as<osm_nwr_id_t>());
-
-      std::map<osm_nwr_signed_id_t, std::set<osm_nwr_id_t>> absent_rel_way_ids;
-
-      for (const auto &rel : relations)
-        for (const auto &rm : rel.members)
-          if (rm.member_type == "Way" &&
-              locked_ways.find(rm.member_id) == locked_ways.end())
-            absent_rel_way_ids[rel.old_id].insert(
-                rm.member_id); // return rel id in osmChange for error msg
-
-      auto it = absent_rel_way_ids.begin();
-
-      throw http::precondition_failed(
-          fmt::format("Relation {:d} requires the ways with id in {}, which "
-                         "either do not exist, or are not visible.",
-           it->first, to_string(it->second)));
-    }
-  }
-
-  if (!relation_ids.empty()) {
-    m.prepare("lock_future_relations_in_relations",
-              R"( 
-                SELECT id
-                FROM current_relations
-                WHERE visible = true 
-                AND id = ANY($1) FOR SHARE )");
-
-    pqxx::result r =
-        m.exec_prepared("lock_future_relations_in_relations", relation_ids);
-
-    if (r.size() != relation_ids.size()) {
-      std::set<osm_nwr_id_t> locked_relations;
-
-      for (const auto &row : r)
-        locked_relations.insert(row["id"].as<osm_nwr_id_t>());
-
-      std::map<osm_nwr_signed_id_t, std::set<osm_nwr_id_t>> absent_rel_rel_ids;
-
-      for (const auto &rel : relations)
-        for (const auto &rm : rel.members)
-          if (rm.member_type == "Relation" &&
-              locked_relations.find(rm.member_id) == locked_relations.end())
-            absent_rel_rel_ids[rel.old_id].insert(
-                rm.member_id); // return rel id in osmChange for error msg
-
-      auto it = absent_rel_rel_ids.begin();
-
-      throw http::precondition_failed(
-          fmt::format("Relation {:d} requires the relations with id in {}, "
-                         "which either do not exist, or are not visible.",
-           it->first, to_string(it->second)));
-    }
-  }
+  lock_future_members_nodes(node_ids, relations);
+  lock_future_members_ways(way_ids, relations);
+  lock_future_members_relations(relation_ids, relations);
 }
 
 // Helper for bbox calculation: Adding a relation member causes all node and

--- a/src/backend/apidb/changeset_upload/relation_updater.cpp
+++ b/src/backend/apidb/changeset_upload/relation_updater.cpp
@@ -46,8 +46,8 @@ void ApiDB_Relation_Updater::add_relation(osm_changeset_id_t changeset_id,
   new_relation.changeset_id = changeset_id;
   new_relation.old_id = old_id;
 
-  for (const auto &tag : tags)
-    new_relation.tags.emplace_back(tag.first, tag.second);
+  for (const auto &[key, value] : tags)
+    new_relation.tags.emplace_back(key, value);
 
   osm_sequence_id_t member_seq = 0;
   for (const auto &member : members) {
@@ -80,8 +80,8 @@ void ApiDB_Relation_Updater::modify_relation(osm_changeset_id_t changeset_id,
   modify_relation.version = version;
   modify_relation.changeset_id = changeset_id;
 
-  for (const auto &tag : tags)
-    modify_relation.tags.emplace_back(tag.first, tag.second);
+  for (const auto &[key, value] : tags)
+    modify_relation.tags.emplace_back(key, value);
 
   osm_sequence_id_t member_seq = 0;
   for (const auto &member : members) {

--- a/src/backend/apidb/changeset_upload/way_updater.cpp
+++ b/src/backend/apidb/changeset_upload/way_updater.cpp
@@ -48,8 +48,8 @@ void ApiDB_Way_Updater::add_way(osm_changeset_id_t changeset_id,
   new_way.changeset_id = changeset_id;
   new_way.old_id = old_id;
 
-  for (const auto &tag : tags)
-    new_way.tags.emplace_back(tag.first, tag.second);
+  for (const auto &[key, value] : tags)
+    new_way.tags.emplace_back(key, value);
 
   // If the following conditions are still not met, although our XML parser
   // raised an exception for it, it's clearly a programming error.
@@ -79,8 +79,8 @@ void ApiDB_Way_Updater::modify_way(osm_changeset_id_t changeset_id,
   modify_way.version = version;
   modify_way.changeset_id = changeset_id;
 
-  for (const auto &tag : tags)
-    modify_way.tags.emplace_back(tag.first, tag.second);
+  for (const auto &[key, value] : tags)
+    modify_way.tags.emplace_back(key, value);
 
   // If the following conditions are still not met, although our XML parser
   // raised an exception for it, it's clearly a programming error.

--- a/src/backend/apidb/common_pgsql_selection.cpp
+++ b/src/backend/apidb/common_pgsql_selection.cpp
@@ -410,7 +410,7 @@ void extract(
   const tag_columns tag_cols(rows);
 
   for (const auto &row : rows) {
-    typename T::extra_info extra;
+    typename T::extra_info extra{};
     auto elem = extract_elem(row, cc, elem_cols);
     extra.extract(row, extra_cols);
     auto tags = extract_tags(row, tag_cols);

--- a/src/backend/apidb/quad_tile.cpp
+++ b/src/backend/apidb/quad_tile.cpp
@@ -32,5 +32,5 @@ std::vector<tile_id_t> tiles_for_area(double minlat, double minlon, double maxla
     }
   }
 
-  return std::vector<tile_id_t>(tiles.begin(), tiles.end());
+  return {tiles.begin(), tiles.end()};
 }

--- a/src/choose_formatter.cpp
+++ b/src/choose_formatter.cpp
@@ -53,9 +53,9 @@ namespace {
 class acceptable_types {
 public:
   explicit acceptable_types(const std::string &accept_header);
-  bool is_acceptable(mime::type) const;
+  [[nodiscard]] bool is_acceptable(mime::type) const;
   // note: returns mime::type::unspecified_type if none were acceptable
-  mime::type most_acceptable_of(const std::vector<mime::type> &available) const;
+  [[nodiscard]] mime::type most_acceptable_of(const std::vector<mime::type> &available) const;
 
 private:
   map<mime::type, float> mapping;

--- a/src/fcgi_request.cpp
+++ b/src/fcgi_request.cpp
@@ -168,7 +168,7 @@ int fcgi_request::accept_r() {
 
   // swap out the output buffer for a new one referencing the new
   // request.
-  m_buffer.reset(new fcgi_buffer(m_impl->req));
+  m_buffer = std::make_unique<fcgi_buffer>(m_impl->req);
 
   return status;
 }

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -215,10 +215,10 @@ vector<pair<string, string> > parse_params(const string &p) {
       al::split(kvTemp, kvPair, al::is_any_of("="));
 
       if (kvTemp.size() == 2) {
-        queryKVPairs.push_back(std::make_pair(kvTemp[0], kvTemp[1]));
+        queryKVPairs.emplace_back(kvTemp[0], kvTemp[1]);
 
       } else if (kvTemp.size() == 1) {
-        queryKVPairs.push_back(std::make_pair(kvTemp[0], std::string()));
+        queryKVPairs.emplace_back(kvTemp[0], std::string());
       }
     }
   }

--- a/src/json_writer.cpp
+++ b/src/json_writer.cpp
@@ -124,9 +124,7 @@ void json_writer::output_yajl_buffer(bool ignore_buffer_size)
   const unsigned char *yajl_buf;
   size_t yajl_buf_len;
 
-  auto status = yajl_gen_get_buf(gen, &yajl_buf, &yajl_buf_len);
-
-  if (status != yajl_gen_status_ok)
+  if (yajl_gen_get_buf(gen, &yajl_buf, &yajl_buf_len) != yajl_gen_status_ok)
     throw output_writer::write_error("Expected yajl_gen_status_ok");
 
   // Keep adding more JSON elements, if the yajl buffer size hasn't

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -29,7 +29,7 @@ void initialise(const std::string &filename) {
 
 void message(const std::string &m) {
   if (stream) {
-    time_t now = time(0);
+    time_t now = time(nullptr);
     *stream << "[" << std::put_time( std::gmtime( &now ), "%FT%T") << " #" << pid << "] " << m
             << std::endl;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -244,7 +244,7 @@ void install_signal_handlers() {
   sa.sa_handler = terminate;
   sigemptyset(&sa.sa_mask);
   sa.sa_flags = 0;
-  if (sigaction(SIGTERM, &sa, NULL) < 0) {
+  if (sigaction(SIGTERM, &sa, nullptr) < 0) {
     throw std::runtime_error("sigaction failed");
   }
 
@@ -252,7 +252,7 @@ void install_signal_handlers() {
   sa.sa_handler = reload;
   sigemptyset(&sa.sa_mask);
   sa.sa_flags = 0;
-  if (sigaction(SIGHUP, &sa, NULL) < 0) {
+  if (sigaction(SIGHUP, &sa, nullptr) < 0) {
     throw std::runtime_error("sigaction failed");
   }
 }
@@ -311,7 +311,7 @@ void daemon_mode(const po::variables_map &options, int socket)
   }
 
   // loop until we have been asked to stop and have no more children
-  while (!terminate_requested || children.size() > 0) {
+  while (!terminate_requested || !children.empty()) {
     pid_t pid;
 
     // start more children if we don't have enough
@@ -337,7 +337,7 @@ void daemon_mode(const po::variables_map &options, int socket)
     }
 
     // wait for a child to exit
-    if ((pid = wait(NULL)) >= 0) {
+    if ((pid = wait(nullptr)) >= 0) {
       children.erase(pid);
     } else if (errno != EINTR) {
       throw std::runtime_error("wait failed.");

--- a/src/mime_types.cpp
+++ b/src/mime_types.cpp
@@ -10,11 +10,9 @@
 #include "cgimap/mime_types.hpp"
 #include <stdexcept>
 
-using std::string;
-using std::runtime_error;
 
 namespace mime {
-string to_string(type t) {
+std::string to_string(type t) {
   if (mime::type::any_type == t) {
     return "*/*";
   } else if (mime::type::text_plain == t) {
@@ -26,11 +24,11 @@ string to_string(type t) {
     return "application/json";
 #endif
   } else {
-    throw runtime_error("No string conversion for unspecified MIME type.");
+    throw std::runtime_error("No string conversion for unspecified MIME type.");
   }
 }
 
-type parse_from(const std::string &name) {
+type parse_from(std::string_view name) {
 
   if (name == "*") {
     return mime::type::any_type;

--- a/src/osmchange_responder.cpp
+++ b/src/osmchange_responder.cpp
@@ -63,7 +63,7 @@ bool operator<(const element &a, const element &b) {
 
 struct sorting_formatter : public output_formatter {
 
-  virtual ~sorting_formatter() override = default;
+  ~sorting_formatter() override = default;
 
   mime::type mime_type() const override {
     throw std::runtime_error("sorting_formatter::mime_type unimplemented");
@@ -221,7 +221,7 @@ private:
 } // anonymous namespace
 
 osmchange_responder::osmchange_responder(mime::type mt, data_selection &s)
-  : osm_responder(mt, {}), 
+  : osm_responder(mt, {}),
     sel(s) {
 }
 
@@ -232,7 +232,7 @@ std::vector<mime::type> osmchange_responder::types_available() const {
 }
 
 void osmchange_responder::write(output_formatter& fmt,
-                                const std::string &generator, 
+                                const std::string &generator,
                                 const std::chrono::system_clock::time_point &now) {
 
   fmt.start_document(generator, "osmChange");

--- a/src/request_helpers.cpp
+++ b/src/request_helpers.cpp
@@ -24,7 +24,7 @@ string fcgi_get_env(const request &req, const char *name, const char *default_va
 
   // since the map script is so simple i'm just going to assume that
   // any time we fail to get an environment variable is a fatal error.
-  if (v == NULL) {
+  if (v == nullptr) {
     if (default_value) {
       v = default_value;
     } else {
@@ -37,14 +37,14 @@ string fcgi_get_env(const request &req, const char *name, const char *default_va
 
 string get_query_string(const request &req) {
   // try the query string that's supposed to be present first
-  const char *query_string = req.get_param("QUERY_STRING");
+  auto *query_string = req.get_param("QUERY_STRING");
 
   // if that isn't present, then this may be being invoked as part of a
   // 404 handler, so look at the request uri instead.
-  if (query_string == NULL || strlen(query_string) == 0) {
+  if (query_string == nullptr || strlen(query_string) == 0) {
     const char *request_uri = req.get_param("REQUEST_URI");
 
-    if ((request_uri == NULL) || (strlen(request_uri) == 0)) {
+    if ((request_uri == nullptr) || (strlen(request_uri) == 0)) {
       // fail. something has obviously gone massively wrong.
       throw http::server_error("request didn't set the $QUERY_STRING or $REQUEST_URI environment variables.");
     }
@@ -52,7 +52,7 @@ string get_query_string(const request &req) {
     const char *request_uri_end = request_uri + strlen(request_uri);
     // i think the only valid position for the '?' char is at the beginning
     // of the query string.
-    const char *question_mark = std::find(request_uri, request_uri_end, '?');
+    auto *question_mark = std::find(request_uri, request_uri_end, '?');
     if (question_mark == request_uri_end) {
       return string();
     } else {
@@ -67,20 +67,20 @@ string get_query_string(const request &req) {
 std::string get_request_path(const request &req) {
   const char *request_uri = req.get_param("REQUEST_URI");
 
-  if ((request_uri == NULL) || (strlen(request_uri) == 0)) {
+  if ((request_uri == nullptr) || (strlen(request_uri) == 0)) {
     // fall back to PATH_INFO if REQUEST_URI isn't available.
     // the former is set by fcgi, the latter by Rack.
     request_uri = req.get_param("PATH_INFO");
   }
 
-  if ((request_uri == NULL) || (strlen(request_uri) == 0)) {
+  if ((request_uri == nullptr) || (strlen(request_uri) == 0)) {
     throw http::server_error("request didn't set the $QUERY_STRING or $REQUEST_URI environment variables.");
   }
 
   const char *request_uri_end = request_uri + strlen(request_uri);
   // i think the only valid position for the '?' char is at the beginning
   // of the query string.
-  const char *question_mark = std::find(request_uri, request_uri_end, '?');
+  auto *question_mark = std::find(request_uri, request_uri_end, '?');
   if (question_mark == request_uri_end) {
     return string(request_uri);
   } else {

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -36,7 +36,7 @@ std::pair<match_osm_id::match_type, bool> match_osm_id::match(part_iterator &beg
     auto& bit = *begin;
 
     if (bit.end() != std::find_if(bit.begin(), bit.end(),
-        [](unsigned char c)->bool { return !isdigit(c); })) {
+        [](unsigned char c) { return !isdigit(c); })) {
       return {match_type(), true};
     }
 

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -304,19 +304,19 @@ std::vector<std::string_view> split(std::string_view str, char delim)
   {
     if (*it == delim)
     {
-      result.emplace_back(&*left, it - left);
+      result.emplace_back(left, it - left);
       left = it + 1;
       if (left == str.end())
-        result.emplace_back(&*it, 0);
+        result.emplace_back(it, 0);
     }
   }
   if (left != str.end())
-    result.emplace_back(&*left, str.end() - left);
+    result.emplace_back(left, str.end() - left);
   return result;
 }
 
 handler_ptr_t route_resource(request &req, const std::string &path,
-                             const std::unique_ptr<router> &r) {
+                             router* r) {
 
   // strip off the format-spec, if there is one
   auto [resource, mime_type] = resource_mime_type(path);
@@ -344,13 +344,13 @@ handler_ptr_t routes::operator()(request &req) const {
   handler_ptr_t hptr;
   // check the prefix
   if (path.compare(0, common_prefix.size(), common_prefix) == 0) {
-    hptr = route_resource(req, std::string(path, common_prefix.size()), r);
+    hptr = route_resource(req, std::string(path, common_prefix.size()), r.get());
 
 #ifdef ENABLE_API07
   } else if (path.compare(0, experimental_prefix.size(), experimental_prefix) ==
              0) {
     hptr = route_resource(req, std::string(path, experimental_prefix.size()),
-                          r_experimental);
+                          r_experimental.get());
 #endif /* ENABLE_API07 */
   }
 


### PR DESCRIPTION
* Split ApiDB_Relation_Updater::lock_future_members into smaller methods
* RequestContext: removed start_time again, this info is also available as req.get_current_time()
* Changed `(*req_ctx.user).id`  to `req_ctx.user->id` for better readability
* validate_user_db_update_permission: use RequestContext instead of request
* Switch back to request instead of RequestContext for non POST/PUT methods
* Some linter fixes