### PR TITLE
rate_limiter-update: consumed bytes may be larger than maxdebt

### DIFF
--- a/include/cgimap/rate_limiter.hpp
+++ b/include/cgimap/rate_limiter.hpp
@@ -22,13 +22,13 @@ struct rate_limiter {
   virtual std::tuple<bool, int> check(const std::string &key, bool moderator) = 0;
 
   // update the limit for the key to say it has consumed this number of bytes.
-  virtual void update(const std::string &key, int bytes, bool moderator) = 0;
+  virtual void update(const std::string &key, uint32_t bytes, bool moderator) = 0;
 };
 
 struct null_rate_limiter : public rate_limiter {
   ~null_rate_limiter() override = default;
   std::tuple<bool, int> check(const std::string &key, bool moderator) override;
-  void update(const std::string &key, int bytes, bool moderator) override;
+  void update(const std::string &key, uint32_t bytes, bool moderator) override;
 };
 
 class memcached_rate_limiter : public rate_limiter {
@@ -39,7 +39,7 @@ public:
   explicit memcached_rate_limiter(const boost::program_options::variables_map &options);
   ~memcached_rate_limiter() override;
   std::tuple<bool, int> check(const std::string &key, bool moderator) override;
-  void update(const std::string &key, int bytes, bool moderator) override;
+  void update(const std::string &key, uint32_t bytes, bool moderator) override;
 
 private:
   memcached_st *ptr = nullptr;

--- a/src/rate_limiter.cpp
+++ b/src/rate_limiter.cpp
@@ -20,7 +20,7 @@ std::tuple<bool, int> null_rate_limiter::check(const std::string &, bool) {
   return {false, 0};
 }
 
-void null_rate_limiter::update(const std::string &, int, bool) {
+void null_rate_limiter::update(const std::string &, uint32_t, bool) {
 }
 
 struct memcached_rate_limiter::state {
@@ -89,7 +89,7 @@ std::tuple<bool, int> memcached_rate_limiter::check(const std::string &key, bool
   }
 }
 
-void memcached_rate_limiter::update(const std::string &key, int bytes, bool moderator) {
+void memcached_rate_limiter::update(const std::string &key, uint32_t bytes, bool moderator) {
 
   if (!ptr)
     return;
@@ -110,8 +110,8 @@ void memcached_rate_limiter::update(const std::string &key, int bytes, bool mode
 
   // calculate number of seconds after which the memcached entry is guaranteed
   // to be irrelevant (adding a bit of headroom).
-  const auto memcached_expiration = std::min(REALTIME_MAXDELTA,
-      2L * global_settings::get_ratelimiter_maxdebt(moderator) / bytes_per_sec);
+  const auto relevant_bytes = std::max(global_settings::get_ratelimiter_maxdebt(moderator), bytes);
+  const auto memcached_expiration = std::min(REALTIME_MAXDELTA, 2L * relevant_bytes / bytes_per_sec);
 
 retry:
 

--- a/test/test_apidb_backend_oauth2.cpp
+++ b/test/test_apidb_backend_oauth2.cpp
@@ -36,7 +36,7 @@ struct recording_rate_limiter : public rate_limiter {
     return std::make_tuple(false, 0);
   }
 
-  void update(const std::string &key, int bytes, bool moderator) override {
+  void update(const std::string &key, uint32_t bytes, bool moderator) override {
     m_keys_seen.insert(key);
   }
 


### PR DESCRIPTION
In extreme cases, the memcached entry was dropped too early (first download larger than maxdebt limit).