### PR TITLE
Some refactorings for "JSON support for changeset upload"

### DIFF
--- a/include/cgimap/api06/changeset_upload/changeset_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/changeset_input_format.hpp
@@ -60,7 +60,7 @@ namespace api06 {
 	  if (element == "osm")
 	    m_context = context::top;
 	  else
-	    throw xml_error{ "Unknown top-level element, expecting osm"  };
+	    throw payload_error{ "Unknown top-level element, expecting osm"  };
 
 	  break;
 
@@ -70,7 +70,7 @@ namespace api06 {
 	    changeset_element_found = true;
 	  }
 	  else
-	    throw xml_error{ "Unknown element, expecting changeset" };
+	    throw payload_error{ "Unknown element, expecting changeset" };
 	  break;
 
 	case context::in_changeset:
@@ -79,7 +79,7 @@ namespace api06 {
 	    add_tag(attrs);
 	  }
 	  else
-	    throw xml_error{ "Unknown element, expecting tag" };
+	    throw payload_error{ "Unknown element, expecting tag" };
 	  break;
 
 	case context::in_tag:
@@ -100,7 +100,7 @@ namespace api06 {
 	  assert(element == "osm");
 	  m_context = context::root;
 	  if (!changeset_element_found)
-	    throw xml_error{ "Cannot parse valid changeset from xml string. XML doesn't contain an osm/changeset element" };
+	    throw payload_error{ "Cannot parse valid changeset from xml string. XML doesn't contain an osm/changeset element" };
 	  break;
 	case context::in_changeset:
 	  assert(element == "changeset");
@@ -116,7 +116,7 @@ namespace api06 {
 
       try {
           throw;
-      } catch (const xml_error& e) {
+      } catch (const payload_error& e) {
         throw_with_context(e, location);
       }
     }
@@ -128,13 +128,13 @@ namespace api06 {
     void add_tag(const std::string &key, const std::string &value) {
 
       if (key.empty())
-	throw xml_error("Key may not be empty");
+	throw payload_error("Key may not be empty");
 
       if (unicode_strlen(key) > 255)
-	throw xml_error("Key has more than 255 unicode characters");
+	throw payload_error("Key has more than 255 unicode characters");
 
       if (unicode_strlen(value) > 255)
-	throw xml_error("Value has more than 255 unicode characters");
+	throw payload_error("Value has more than 255 unicode characters");
 
       m_tags[key] = value;
 
@@ -166,10 +166,10 @@ namespace api06 {
       });
 
       if (!k)
-	throw xml_error{"Mandatory field k missing in tag element"};
+	throw payload_error{"Mandatory field k missing in tag element"};
 
       if (!v)
-	throw xml_error{"Mandatory field v missing in tag element"};
+	throw payload_error{"Mandatory field v missing in tag element"};
 
       add_tag(*k, *v);
     }

--- a/include/cgimap/api06/changeset_upload/node.hpp
+++ b/include/cgimap/api06/changeset_upload/node.hpp
@@ -37,11 +37,11 @@ public:
     if (ec == std::errc())
       set_lat(_lat);
     else if (ec == std::errc::invalid_argument)
-      throw xml_error("Latitude is not numeric");
+      throw payload_error("Latitude is not numeric");
     else if (ec == std::errc::result_out_of_range)
-      throw xml_error("Latitude value is too large");
+      throw payload_error("Latitude value is too large");
     else
-      throw xml_error("Unexpected parsing error");
+      throw payload_error("Unexpected parsing error");
   }
 
   void set_lon(const std::string &lon) {
@@ -53,26 +53,26 @@ public:
     if (ec == std::errc())
       set_lon(_lon);
     else if (ec == std::errc::invalid_argument)
-      throw xml_error("Longitude is not numeric");
+      throw payload_error("Longitude is not numeric");
     else if (ec == std::errc::result_out_of_range)
-      throw xml_error("Longitude value is too large");
+      throw payload_error("Longitude value is too large");
     else
-      throw xml_error("Unexpected parsing error");
+      throw payload_error("Unexpected parsing error");
   }
 
   void set_lat(double lat) {
     if (lat < -90 || lat > 90)
-      throw xml_error("Latitude outside of valid range");
+      throw payload_error("Latitude outside of valid range");
     else if (!std::isfinite(lat))
-      throw xml_error("Latitude not a valid finite number");
+      throw payload_error("Latitude not a valid finite number");
     m_lat = lat;
   }
 
   void set_lon(double lon) {
     if (lon < -180 || lon > 180)
-      throw xml_error("Longitude outside of valid range");
+      throw payload_error("Longitude outside of valid range");
     else if (!std::isfinite(lon))
-      throw xml_error("Longitude not a valid finite number");
+      throw payload_error("Longitude not a valid finite number");
     m_lon = lon;
   }
 
@@ -87,7 +87,13 @@ public:
     }
   }
 
-  std::string get_type_name() override { return "Node"; }
+  std::string get_type_name() const override { return "Node"; }
+
+  bool operator==(const Node &o) const {
+    return (OSMObject::operator==(o) &&
+            o.m_lat == m_lat &&
+            o.m_lon == m_lon);
+  }
 
 private:
   std::optional<double> m_lat;

--- a/include/cgimap/api06/changeset_upload/osmchange_xml_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/osmchange_xml_input_format.hpp
@@ -7,8 +7,8 @@
  * For a full list of authors see the git log.
  */
 
-#ifndef OSMCHANGE_INPUT_FORMAT_HPP
-#define OSMCHANGE_INPUT_FORMAT_HPP
+#ifndef OSMCHANGE_XML_INPUT_FORMAT_HPP
+#define OSMCHANGE_XML_INPUT_FORMAT_HPP
 
 #include "cgimap/api06/changeset_upload/node.hpp"
 #include "cgimap/api06/changeset_upload/osmobject.hpp"
@@ -67,7 +67,7 @@ protected:
       if (element == "osmChange") {
         m_callback.start_document();
       } else {
-        throw xml_error{
+        throw payload_error{
           fmt::format("Unknown top-level element {}, expecting osmChange",
            element)
         };
@@ -94,7 +94,7 @@ protected:
         m_context.push_back(context::in_delete);
         m_operation = operation::op_delete;
       } else {
-        throw xml_error{
+        throw payload_error{
            fmt::format(
                "Unknown action {}, choices are create, modify, delete",
            element)
@@ -120,7 +120,7 @@ protected:
         init_object(*m_relation, attrs);
         m_context.push_back(context::relation);
       } else {
-        throw xml_error{
+        throw payload_error{
           fmt::format(
                "Unknown element {}, expecting node, way or relation",
            element)
@@ -145,7 +145,7 @@ protected:
           }
         });
         if (!ref_found)
-          throw xml_error{fmt::format(
+          throw payload_error{fmt::format(
                                 "Missing mandatory ref field on way node {}",
                             m_way->to_string()) };
       } else if (element == "tag") {
@@ -166,7 +166,7 @@ protected:
           }
         });
         if (!member.is_valid()) {
-          throw xml_error{ fmt::format(
+          throw payload_error{ fmt::format(
                                 "Missing mandatory field on relation member in {}",
                             m_relation->to_string()) };
         }
@@ -176,7 +176,7 @@ protected:
       }
       break;
     case context::in_object:
-      throw xml_error{ "xml file nested too deep" };
+      throw payload_error{ "xml file nested too deep" };
       break;
     }
   }
@@ -216,7 +216,7 @@ protected:
     case context::node:
       assert(element == "node");
       if (!m_node->is_valid(m_operation)) {
-        throw xml_error{
+        throw payload_error{
           fmt::format("{} does not include all mandatory fields",
            m_node->to_string())
         };
@@ -228,7 +228,7 @@ protected:
     case context::way:
       assert(element == "way");
       if (!m_way->is_valid(m_operation)) {
-        throw xml_error{
+        throw payload_error{
           fmt::format("{} does not include all mandatory fields",
            m_way->to_string())
         };
@@ -241,7 +241,7 @@ protected:
     case context::relation:
       assert(element == "relation");
       if (!m_relation->is_valid(m_operation)) {
-        throw xml_error{
+        throw payload_error{
           fmt::format("{} does not include all mandatory fields",
            m_relation->to_string())
         };
@@ -260,7 +260,7 @@ protected:
 
     try {
         throw;
-    } catch (const xml_error& e) {
+    } catch (const payload_error& e) {
       throw_with_context(e, location);
     }
   }
@@ -304,11 +304,11 @@ private:
     });
 
     if (!object.has_id()) {
-	throw xml_error{ "Mandatory field id missing in object" };
+	throw payload_error{ "Mandatory field id missing in object" };
     }
 
     if (!object.has_changeset()) {
-      throw xml_error{ fmt::format("Changeset id is missing for {}",
+      throw payload_error{ fmt::format("Changeset id is missing for {}",
                         object.to_string()) };
     }
 
@@ -320,12 +320,12 @@ private:
                m_operation == operation::op_modify) {
       // objects for other operations must have a positive version number
       if (!object.has_version()) {
-        throw xml_error{ fmt::format(
+        throw payload_error{ fmt::format(
                               "Version is required when updating {}",
                           object.to_string()) };
       }
       if (object.version() < 1) {
-        throw xml_error{ fmt::format("Invalid version number {} in {}",
+        throw payload_error{ fmt::format("Invalid version number {} in {}",
                           object.version(), object.to_string()) };
       }
     }
@@ -357,13 +357,13 @@ private:
     });
 
     if (!k)
-      throw xml_error{
+      throw payload_error{
         fmt::format("Mandatory field k missing in tag element for {}",
          o.to_string())
       };
 
     if (!v)
-      throw xml_error{
+      throw payload_error{
         fmt::format("Mandatory field v missing in tag element for {}",
          o.to_string())
       };
@@ -400,4 +400,4 @@ private:
 
 } // namespace api06
 
-#endif // OSMCHANGE_INPUT_FORMAT_HPP
+#endif // OSMCHANGE_INPUT_XML_FORMAT_HPP

--- a/include/cgimap/api06/changeset_upload/way.hpp
+++ b/include/cgimap/api06/changeset_upload/way.hpp
@@ -27,9 +27,14 @@ public:
 
   ~Way() override = default;
 
+  void add_way_nodes(const std::vector<osm_nwr_signed_id_t>& way_nodes) {
+    for (auto const wn : way_nodes)
+      m_way_nodes.emplace_back(wn);
+  }
+
   void add_way_node(osm_nwr_signed_id_t waynode) {
     if (waynode == 0) {
-      throw xml_error("Way node value may not be 0");
+      throw payload_error("Way node value may not be 0");
     }
 
     m_way_nodes.emplace_back(waynode);
@@ -44,11 +49,11 @@ public:
     if (ec == std::errc())
       add_way_node(_waynode);
     else if (ec == std::errc::invalid_argument)
-      throw xml_error("Way node is not numeric");
+      throw payload_error("Way node is not numeric");
     else if (ec == std::errc::result_out_of_range)
-      throw xml_error("Way node value is too large");
+      throw payload_error("Way node value is too large");
     else
-      throw xml_error("Unexpected parsing error");
+      throw payload_error("Unexpected parsing error");
   }
 
   const std::vector<osm_nwr_signed_id_t> &nodes() const { return m_way_nodes; }
@@ -78,7 +83,12 @@ public:
     }
   }
 
-  std::string get_type_name() override { return "Way"; }
+  std::string get_type_name() const override { return "Way"; }
+
+  bool operator==(const Way &o) const {
+    return (OSMObject::operator==(o) &&
+            o.m_way_nodes == m_way_nodes);
+  }
 
 private:
   std::vector<osm_nwr_signed_id_t> m_way_nodes;

--- a/src/api06/changeset_upload_handler.cpp
+++ b/src/api06/changeset_upload_handler.cpp
@@ -13,7 +13,7 @@
 #include "cgimap/request_context.hpp"
 
 #include "cgimap/api06/changeset_upload/osmchange_handler.hpp"
-#include "cgimap/api06/changeset_upload/osmchange_input_format.hpp"
+#include "cgimap/api06/changeset_upload/osmchange_xml_input_format.hpp"
 #include "cgimap/api06/changeset_upload/osmchange_tracking.hpp"
 #include "cgimap/api06/changeset_upload_handler.hpp"
 #include "cgimap/backend/apidb/changeset_upload/changeset_updater.hpp"
@@ -31,9 +31,9 @@
 
 namespace api06 {
 
-changeset_upload_responder::changeset_upload_responder(mime::type mt, 
-                                                       data_update& upd, 
-                                                       osm_changeset_id_t changeset, 
+changeset_upload_responder::changeset_upload_responder(mime::type mt,
+                                                       data_update& upd,
+                                                       osm_changeset_id_t changeset,
                                                        const std::string &payload,
                                                        const RequestContext& req_ctx)
     : osm_diffresult_responder(mt) {
@@ -54,9 +54,10 @@ changeset_upload_responder::changeset_upload_responder(mime::type mt,
 
   OSMChange_Handler handler(*node_updater, *way_updater, *relation_updater, changeset);
 
-  OSMChangeXMLParser parser(handler);
-
-  parser.process_message(payload);
+  // TODO: check HTTP Accept header
+  if (mt != mime::type::application_json) {
+    OSMChangeXMLParser(handler).process_message(payload);
+  }
 
   // store diffresult for output handling in class osm_diffresult_responder
   m_diffresult = change_tracking.assemble_diffresult();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,20 +109,21 @@ if(BUILD_TESTING)
         COMMAND test_parse_time)
 
 
-    ############################
-    # test_parse_osmchange_input
-    ############################
-    add_executable(test_parse_osmchange_input
-        test_parse_osmchange_input.cpp)
+    ################################
+    # test_parse_osmchange_xml_input
+    ################################
+    add_executable(test_parse_osmchange_xml_input
+        test_parse_osmchange_xml_input.cpp)
 
-    target_link_libraries(test_parse_osmchange_input
+    target_link_libraries(test_parse_osmchange_xml_input
         cgimap_common_compiler_options
         cgimap_core
         Boost::program_options
         catch2)
 
-    add_test(NAME test_parse_osmchange_input
-        COMMAND test_parse_osmchange_input)
+    add_test(NAME test_parse_osmchange_xml_input
+        COMMAND test_parse_osmchange_xml_input)
+
 
 
     ############################
@@ -273,7 +274,7 @@ if(BUILD_TESTING)
                            test_oauth2
                            test_http
                            test_parse_time
-                           test_parse_osmchange_input
+                           test_parse_osmchange_xml_input
                            test_parse_changeset_input)
 
       add_dependencies(check test_apidb_backend_nodes

--- a/test/test_parse_osmchange_xml_input.cpp
+++ b/test/test_parse_osmchange_xml_input.cpp
@@ -9,7 +9,7 @@
 
 
 #include "cgimap/options.hpp"
-#include "cgimap/api06/changeset_upload/osmchange_input_format.hpp"
+#include "cgimap/api06/changeset_upload/osmchange_xml_input_format.hpp"
 #include "cgimap/api06/changeset_upload/parser_callback.hpp"
 #include "cgimap/util.hpp"
 #include "cgimap/http.hpp"
@@ -92,7 +92,7 @@ TEST_CASE("Misspelled osmchange xml", "[osmchange][xml]") {
 }
 
 TEST_CASE("osmchange: Unknown action", "[osmchange][xml]") {
-  REQUIRE_THROWS_MATCHES(process_testmsg(R"(<osmChange><dummy/></osmChange>)"), http::bad_request, 
+  REQUIRE_THROWS_MATCHES(process_testmsg(R"(<osmChange><dummy/></osmChange>)"), http::bad_request,
     Catch::Message("Unknown action dummy, choices are create, modify, delete at line 1, column 18"));
 }
 
@@ -109,7 +109,7 @@ TEST_CASE("osmchange: Empty delete action", "[osmchange][xml]") {
 }
 
 TEST_CASE("osmchange: create invalid object", "[osmchange][xml]") {
-  REQUIRE_THROWS_MATCHES(process_testmsg(R"(<osmChange><create><bla/></create></osmChange>)"), http::bad_request, 
+  REQUIRE_THROWS_MATCHES(process_testmsg(R"(<osmChange><create><bla/></create></osmChange>)"), http::bad_request,
     Catch::Message("Unknown element bla, expecting node, way or relation at line 1, column 24"));
 }
 
@@ -168,7 +168,7 @@ TEST_CASE("Create node, lon non-finite float", "[osmchange][node][xml]") {
 }
 
 TEST_CASE("Create node, changeset missing", "[osmchange][node][xml]") {
-  REQUIRE_THROWS_MATCHES(process_testmsg(R"(<osmChange><create><node id="-1" lat="-90.00" lon="-180.00"/></create></osmChange>)"), http::bad_request, 
+  REQUIRE_THROWS_MATCHES(process_testmsg(R"(<osmChange><create><node id="-1" lat="-90.00" lon="-180.00"/></create></osmChange>)"), http::bad_request,
     Catch::Message("Changeset id is missing for Node -1 at line 1, column 60"));
 }
 
@@ -177,7 +177,7 @@ TEST_CASE("Create node, redefined lat attribute", "[osmchange][node][xml]") {
 }
 
 TEST_CASE("Create valid node", "[osmchange][node][xml]") {
-  auto i = GENERATE(R"(<osmChange><create><node changeset="858" id="-1" lat="90.00" lon="180.00"/></create></osmChange>)", 
+  auto i = GENERATE(R"(<osmChange><create><node changeset="858" id="-1" lat="90.00" lon="180.00"/></create></osmChange>)",
                     R"(<osmChange><create><node changeset="858" id="-1" lat="-90.00" lon="-180.00"/></create></osmChange>)");
   REQUIRE_NOTHROW(process_testmsg(i));
 }
@@ -235,7 +235,7 @@ TEST_CASE("Create node, duplicate key dup1", "[osmchange][node][xml]") {
                        <tag k="dup1" v="value2"/>
                        <tag k="dup1" v="value3"/>
                        <tag k="key3" v="value4"/>
-                       </node></create></osmChange>)"), 
+                       </node></create></osmChange>)"),
     http::bad_request, Catch::Message("Node -1 has duplicate tags with key dup1 at line 4, column 48"));
 }
 
@@ -263,7 +263,7 @@ TEST_CASE("Create node, tag value with <= 255 unicode characters", "[osmchange][
 TEST_CASE("Create node, tag value with > 255 unicode characters", "[osmchange][node][xml]") {
   REQUIRE_THROWS_MATCHES(process_testmsg(
     fmt::format(R"(<osmChange><create><node changeset="858" id="-1" lat="-1" lon="2">
-                           <tag k="key" v="{}"/></node></create></osmChange>)", repeat("😎", 256))), 
+                           <tag k="key" v="{}"/></node></create></osmChange>)", repeat("😎", 256))),
     http::bad_request, Catch::Message("Value has more than 255 unicode characters in Node -1 at line 2, column 301"));
 }
 
@@ -279,7 +279,7 @@ TEST_CASE("Create node, tag key with <= 255 unicode characters", "[osmchange][no
 TEST_CASE("Create node, tag key with > 255 unicode characters", "[osmchange][node][xml]") {
   REQUIRE_THROWS_MATCHES(process_testmsg(
     fmt::format(R"(<osmChange><create><node changeset="858" id="-1" lat="-1" lon="2">
-                           <tag k="{}" v="value"/></node></create></osmChange>)", repeat("😎", 256))), 
+                           <tag k="{}" v="value"/></node></create></osmChange>)", repeat("😎", 256))),
     http::bad_request, Catch::Message("Key has more than 255 unicode characters in Node -1 at line 2, column 303"));
 }
 
@@ -378,13 +378,13 @@ TEST_CASE("Create way, only changeset", "[osmchange][way][xml]") {
 
 TEST_CASE("Create way, missing changeset", "[osmchange][way][xml]") {
   REQUIRE_THROWS_MATCHES(process_testmsg(
-    R"(<osmChange><create><way id="-1"/></create></osmChange>)"), 
+    R"(<osmChange><create><way id="-1"/></create></osmChange>)"),
     http::bad_request, Catch::Message("Changeset id is missing for Way -1 at line 1, column 32"));
 }
 
 TEST_CASE("Create way, missing node ref", "[osmchange][way][xml]") {
   REQUIRE_THROWS_MATCHES(process_testmsg(
-    R"(<osmChange><create><way changeset="858" id="-1"/></create></osmChange>)"), 
+    R"(<osmChange><create><way changeset="858" id="-1"/></create></osmChange>)"),
     http::precondition_failed, Catch::Message("Precondition failed: Way -1 must have at least one node"));
 }
 
@@ -519,7 +519,7 @@ TEST_CASE("Create relation, role with > 255 unicode characters", "[osmchange][re
                R"(<osmChange><create><relation changeset="858" id="-1">
                            <member type="node" role="{}" ref="123"/>
                   </relation></create></osmChange>)",
-           repeat("😎", 256))), 
+           repeat("😎", 256))),
     http::bad_request, Catch::Message("Relation Role has more than 255 unicode characters at line 2, column 321"));
 }
 
@@ -531,7 +531,7 @@ TEST_CASE("Delete relation, no version", "[osmchange][relation][xml]") {
 
 TEST_CASE("Delete relation, no id", "[osmchange][relation][xml]") {
   REQUIRE_THROWS_MATCHES(process_testmsg(
-    R"(<osmChange><delete><relation changeset="972" version="1"/></delete></osmChange>)"), 
+    R"(<osmChange><delete><relation changeset="972" version="1"/></delete></osmChange>)"),
     http::bad_request, Catch::Message(fmt::format("Mandatory field id missing in object at line 1, column 57")));
 }
 


### PR DESCRIPTION
This PR includes some upfront refactoring, which was originally part of #407, but really unrelated to JSON format.

Note: the second commit has a typo, it should read "Rename osmchange_input_format → osmchange_xml_input_format"