### PR TITLE
Adjustments for libpqxx-7.x, clang, macOS

### DIFF
--- a/include/cgimap/backend/apidb/pqxx_string_traits.hpp
+++ b/include/cgimap/backend/apidb/pqxx_string_traits.hpp
@@ -127,7 +127,6 @@ PQXX_ARRAY_STRING_TRAITS(std::vector<tile_id_t>);
 PQXX_ARRAY_STRING_TRAITS(std::vector<osm_changeset_id_t>);
 PQXX_ARRAY_STRING_TRAITS(std::set<osm_changeset_id_t>);
 PQXX_ARRAY_STRING_TRAITS(std::vector<std::string>);
-PQXX_ARRAY_STRING_TRAITS(std::vector<bool>);
 
 } // namespace pqxx
 

--- a/include/cgimap/backend/apidb/pqxx_string_traits.hpp
+++ b/include/cgimap/backend/apidb/pqxx_string_traits.hpp
@@ -116,7 +116,7 @@ public:
   template<>                                                            \
   struct string_traits<type> : cgimap::array_string_traits<type> {};    \
                                                                         \
-  template<> std::string const type_name<type>{#type};                  \
+  template<> inline std::string const type_name<type>{#type};           \
 
 
 #endif


### PR DESCRIPTION
Without "inline", clang 17 was rightfully complaining about multiple definitions of `pqxx::type_name<... >'