### PR TITLE
Introduce psql_array_ids_to_vector

### DIFF
--- a/include/cgimap/backend/apidb/common_pgsql_selection.hpp
+++ b/include/cgimap/backend/apidb/common_pgsql_selection.hpp
@@ -51,9 +51,5 @@ void extract_changesets(
   const std::chrono::system_clock::time_point &now,
   bool include_changeset_discussions);
 
-// parses psql array based on specs given
-// https://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
-std::vector<std::string> psql_array_to_vector(std::string_view str);
-std::vector<std::string> psql_array_to_vector(const pqxx::field& field);
 
 #endif /* CGIMAP_BACKEND_APIDB_COMMON_PGSQL_SELECTION_HPP */

--- a/include/cgimap/backend/apidb/utils.hpp
+++ b/include/cgimap/backend/apidb/utils.hpp
@@ -19,4 +19,15 @@
  */
 void check_postgres_version(pqxx::connection_base &conn);
 
+// parses psql array based on specs given
+// https://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
+std::vector<std::string> psql_array_to_vector(std::string_view str, int size_hint = 0);
+std::vector<std::string> psql_array_to_vector(const pqxx::field& field, int size_hint = 0);
+
+template <typename T>
+std::vector<T> psql_array_ids_to_vector(const pqxx::field& field);
+
+template <typename T>
+std::vector<T> psql_array_ids_to_vector(std::string_view str);
+
 #endif /* CGIMAP_BACKEND_APIDB_UTILS_HPP */

--- a/src/backend/apidb/utils.cpp
+++ b/src/backend/apidb/utils.cpp
@@ -7,6 +7,13 @@
  * For a full list of authors see the git log.
  */
 
+#include <charconv>
+#include <functional>
+#include <pqxx/pqxx>
+#include <string_view>
+#include <string>
+#include <vector>
+
 #include "cgimap/backend/apidb/utils.hpp"
 
 void check_postgres_version(pqxx::connection_base &conn) {
@@ -16,3 +23,109 @@ void check_postgres_version(pqxx::connection_base &conn) {
       + std::to_string(version));
   }
 }
+
+std::vector<std::string> psql_array_to_vector(const pqxx::field& field, int size_hint) {
+  return psql_array_to_vector(std::string_view(field.c_str(), field.size()), size_hint);
+}
+
+std::vector<std::string> psql_array_to_vector(std::string_view str, int size_hint) {
+  std::vector<std::string> strs;
+  std::string value;
+  bool quotedValue = false;
+  bool escaped = false;
+  bool write = false;
+
+  if (size_hint > 0)
+    strs.reserve(size_hint);
+
+  if (str == "{NULL}" || str.empty())
+    return strs;
+
+  const auto str_size = str.size();
+  for (unsigned int i = 1; i < str_size; i++) {
+    if (str[i] == ',') {
+      if (quotedValue) {
+        value += ',';
+      } else {
+        write = true;
+      }
+    } else if (str[i] == '"') {
+      if (escaped) {
+        value += '"';
+        escaped = false;
+      } else if (quotedValue) {
+        quotedValue = false;
+      } else {
+        quotedValue = true;
+      }
+    } else if (str[i] == '\\') {
+      if (escaped) {
+        value += '\\';
+        escaped = false;
+      } else {
+        escaped = true;
+      }
+    } else if (str[i] == '}') {
+      if (quotedValue) {
+        value += '}';
+      } else {
+        write = true;
+      }
+    } else {
+      value += str[i];
+    }
+
+    if (write) {
+      strs.emplace_back(std::move(value));
+      value.clear();
+      write = false;
+    }
+  }
+  return strs;
+}
+
+template <typename T>
+std::vector<T> psql_array_ids_to_vector(const pqxx::field& field) {
+  return psql_array_ids_to_vector<T>(std::string_view(field.c_str(), field.size()));
+}
+
+template <typename T>
+std::vector<T> psql_array_ids_to_vector(std::string_view str) {
+  std::vector<T> ids;
+  int start_offset = 1;
+
+  if (str == "{NULL}" || str.empty())
+    return ids;
+
+  const auto str_size = str.size();
+
+  for (unsigned int i = 1; i < str_size; i++) {
+    if (str[i] == ',' || str[i] == '}') {
+      T id;
+
+      auto [_, ec] = std::from_chars(str.data() + start_offset, str.data() + i, id);
+
+      if (ec != std::errc()) {
+       throw std::runtime_error("Conversion to integer failed");
+      }
+      ids.emplace_back(id);
+      start_offset = i + 1;
+    }
+  }
+  return ids;
+}
+
+
+template std::vector<int32_t> psql_array_ids_to_vector(const pqxx::field& field);
+template std::vector<int64_t> psql_array_ids_to_vector(const pqxx::field& field);
+
+template std::vector<uint32_t> psql_array_ids_to_vector(const pqxx::field& field);
+template std::vector<uint64_t> psql_array_ids_to_vector(const pqxx::field& field);
+
+template std::vector<int32_t> psql_array_ids_to_vector(std::string_view str);
+template std::vector<int64_t> psql_array_ids_to_vector(std::string_view str);
+
+template std::vector<uint32_t> psql_array_ids_to_vector(std::string_view str);
+template std::vector<uint64_t> psql_array_ids_to_vector(std::string_view str);
+
+

--- a/test/test_apidb_backend_nodes.cpp
+++ b/test/test_apidb_backend_nodes.cpp
@@ -239,6 +239,44 @@ TEST_CASE("test_psql_array_to_vector", "[nodb]") {
   }
 }
 
+TEST_CASE("psql_array_ids_to_vector", "[nodb]") {
+
+  std::string test;
+  std::vector<int64_t> actual_values;
+  std::vector<int64_t> values;
+
+  SECTION("NULL") {
+    test = "{NULL}";
+    values = psql_array_ids_to_vector<int64_t>(test);
+    REQUIRE (values == actual_values);
+  }
+
+  SECTION("Empty string") {
+    test = "";
+    values = psql_array_ids_to_vector<int64_t>(test);
+    REQUIRE (values == actual_values);
+  }
+
+  SECTION("One value") {
+    test = "{1}";
+    values = psql_array_ids_to_vector<int64_t>(test);
+    actual_values = {1};
+    REQUIRE (values == actual_values);
+  }
+
+  SECTION("Two values") {
+    test = "{1,-2}";
+    values = psql_array_ids_to_vector<int64_t>(test);
+    actual_values = {1, -2};
+    REQUIRE (values == actual_values);
+  }
+
+  SECTION("Invalid string") {
+    test = "{1,}";
+    REQUIRE_THROWS_AS(psql_array_ids_to_vector<int64_t>(test), std::runtime_error);
+  }
+}
+
 int main(int argc, char *argv[]) {
   Catch::Session session;
 


### PR DESCRIPTION
* `psql_array_ids_to_vector` consolidates multiple calls of `std::from_chars` in a single place
  - Similar to psql_array_to_vector
  - No escaping & creating temp strings needed
  - A bit of a follow up for #344

Some further smaller changes  in this PR:
* `extra_info` instances are initialized in constructor instead of a separate extract method
* `psql_array_to_vector` has a new size hint parameter to avoid reallocations
*  `emplace_back` for in place vector creation
* Move helper functions to util.[ch]pp 