### PR TITLE
Diff upload: CTE instead of temporary tables

### DIFF
--- a/include/cgimap/backend/apidb/changeset_upload/node_updater.hpp
+++ b/include/cgimap/backend/apidb/changeset_upload/node_updater.hpp
@@ -66,8 +66,6 @@ private:
     bool if_unused;
   };
 
-  void truncate_temporary_tables();
-
   void replace_old_ids_in_nodes(
       std::vector<node_t> &create_nodes,
       const std::vector<api06::OSMChange_Tracking::object_id_mapping_t>
@@ -75,11 +73,7 @@ private:
 
   void check_unique_placeholder_ids(const std::vector<node_t> &create_nodes);
 
-  void insert_new_nodes_to_tmp_table(const std::vector<node_t> &create_nodes);
-
-  void copy_tmp_create_nodes_to_current_nodes();
-
-  void delete_tmp_create_nodes();
+  void insert_new_nodes_to_current_table(const std::vector<node_t> &create_nodes);
 
   void lock_current_nodes(const std::vector<osm_nwr_id_t> &ids);
 

--- a/include/cgimap/backend/apidb/changeset_upload/relation_updater.hpp
+++ b/include/cgimap/backend/apidb/changeset_upload/relation_updater.hpp
@@ -82,8 +82,6 @@ private:
     bool new_member;
   };
 
-  void truncate_temporary_tables();
-
   /*
    * Set id field based on old_id -> id mapping
    *
@@ -101,12 +99,8 @@ private:
 
   void check_forward_relation_placeholders(const std::vector<relation_t> &create_relations);
 
-  void insert_new_relations_to_tmp_table(
+  void insert_new_relations_to_current_table(
       const std::vector<relation_t> &create_relations);
-
-  void copy_tmp_create_relations_to_current_relations();
-
-  void delete_tmp_create_relations();
 
   void lock_current_relations(const std::vector<osm_nwr_id_t> &ids);
 

--- a/include/cgimap/backend/apidb/changeset_upload/way_updater.hpp
+++ b/include/cgimap/backend/apidb/changeset_upload/way_updater.hpp
@@ -75,8 +75,6 @@ private:
     bool if_unused;
   };
 
-  void truncate_temporary_tables();
-
   /*
    * Set id field based on old_id -> id mapping
    *
@@ -91,11 +89,7 @@ private:
 
   void check_unique_placeholder_ids(const std::vector<way_t> &create_ways);
 
-  void insert_new_ways_to_tmp_table(const std::vector<way_t> &create_ways);
-
-  void copy_tmp_create_ways_to_current_ways();
-
-  void delete_tmp_create_ways();
+  void insert_new_ways_to_current_table(const std::vector<way_t> &create_ways);
 
   bbox_t calc_way_bbox(const std::vector<osm_nwr_id_t> &ids);
 

--- a/src/backend/apidb/pgsql_update.cpp
+++ b/src/backend/apidb/pgsql_update.cpp
@@ -69,47 +69,6 @@ pgsql_update::pgsql_update(Transaction_Owner_Base& to, bool readonly)
     : m{ to }, 
       m_readonly{ readonly } {
 
-  if (is_api_write_disabled())
-    return;
-
-  m.exec(R"(CREATE TEMPORARY TABLE tmp_create_nodes 
-      (
-        id bigint NOT NULL DEFAULT nextval('current_nodes_id_seq'::regclass),
-        latitude integer NOT NULL,
-        longitude integer NOT NULL,
-        changeset_id bigint NOT NULL,
-        visible boolean NOT NULL DEFAULT true,
-        "timestamp" timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc'),
-        tile bigint NOT NULL,
-        version bigint NOT NULL DEFAULT 1,
-        old_id bigint NOT NULL UNIQUE,
-        PRIMARY KEY (id))
-        ON COMMIT DROP
-      )");
-
-  m.exec(R"(CREATE TEMPORARY TABLE tmp_create_ways 
-      (
-        id bigint NOT NULL DEFAULT nextval('current_ways_id_seq'::regclass),
-        changeset_id bigint NOT NULL,
-        visible boolean NOT NULL DEFAULT true,
-        "timestamp" timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc'),
-        version bigint NOT NULL DEFAULT 1,
-        old_id bigint NOT NULL UNIQUE,
-        PRIMARY KEY (id))
-        ON COMMIT DROP
-     )");
-
-  m.exec(R"(CREATE TEMPORARY TABLE tmp_create_relations 
-     (
-        id bigint NOT NULL DEFAULT nextval('current_relations_id_seq'::regclass),
-        changeset_id bigint NOT NULL,
-        visible boolean NOT NULL DEFAULT true,
-        "timestamp" timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc'),
-        version bigint NOT NULL DEFAULT 1,
-        old_id bigint NOT NULL UNIQUE,
-        PRIMARY KEY (id))
-        ON COMMIT DROP
-     )");
 }
 
 bool pgsql_update::is_api_write_disabled() const {


### PR DESCRIPTION
This PR removes the need for temporary tables during diff upload by leveraging CTE. As a result, copying new objects from temporary to current tables, and cleaning up temporary tables afterwards is no longer required.