### PR TITLE
SQL statements as raw string, store as unindented string

### DIFF
--- a/include/cgimap/backend/apidb/utils.hpp
+++ b/include/cgimap/backend/apidb/utils.hpp
@@ -10,7 +10,178 @@
 #ifndef CGIMAP_BACKEND_APIDB_UTILS_HPP
 #define CGIMAP_BACKEND_APIDB_UTILS_HPP
 
+#include <algorithm>
+#include <string_view>
+#include <vector>
+#include <ranges>
+
 #include <pqxx/pqxx>
+
+/* Unindent SQL statements in raw strings */
+
+#if __GNUC__ < 12
+// fallback implementation for older compilers
+consteval const char* operator"" _M(const char* str, size_t len) {
+    return str;
+}
+
+#else
+
+// multiline_raw_string is based on https://stackoverflow.com/a/75105367/3501889
+
+namespace multiline_raw_string {
+    template<class char_type>
+    using string_view = std::basic_string_view<char_type>;
+
+    // characters that are considered space
+    // we need this because std::isspace is not constexpr
+    template<class char_type>
+    inline constexpr string_view<char_type> space_chars = std::declval<string_view<char_type>>();
+    template<>
+    inline constexpr string_view<char> space_chars<char> = " \f\n\r\t\v";
+
+    // list of all potential line endings that could be encountered
+    template<class char_type>
+    inline constexpr string_view<char_type> potential_line_endings[] = std::declval<string_view<char_type>[]>();
+    template<>
+    inline constexpr string_view<char> potential_line_endings<char>[] = {
+        "\n"
+    };
+
+
+    // null-terminator for the different character types
+    template<class char_type>
+    inline constexpr char_type null_char = std::declval<char_type>();
+    template<>
+    inline constexpr char null_char<char> = '\0';
+
+    // returns a view to the leading sequence of space characters within a string
+    // e.g. get_leading_space_sequence(" \t  foo") -> " \t  "
+    template<class char_type>
+    consteval string_view<char_type> get_leading_space_sequence(string_view<char_type> line) {
+        return line.substr(0, line.find_first_not_of(space_chars<char_type>));
+    }
+
+    // checks if a line consists purely out of space characters
+    // e.g. is_line_empty("    \t") -> true
+    //      is_line_empty("   foo") -> false
+    template<class char_type>
+    consteval bool is_line_empty(string_view<char_type> line) {
+        return get_leading_space_sequence(line).size() == line.size();
+    }
+
+    // splits a string into individual lines
+    // and removes the first & last line if they are empty
+    // e.g. split_lines("\na\nb\nc\n", "\n") -> {"a", "b", "c"}
+    template<class char_type>
+    consteval std::vector<string_view<char_type>> split_lines(
+        string_view<char_type> str,
+        string_view<char_type> line_ending
+    ) {
+        std::vector<string_view<char_type>> lines;
+
+        for (auto line : std::views::split(str, line_ending)) {
+            lines.emplace_back(line.begin(), line.end());
+        }
+
+        // remove first/last lines in case they are completely empty
+        if(lines.size() > 1 && is_line_empty(lines[0])) {
+            lines.erase(lines.begin());
+        }
+        if(lines.size() > 1 && is_line_empty(lines[lines.size()-1])) {
+            lines.erase(lines.end()-1);
+        }
+
+        return lines;
+    }
+
+    // unindents the individual lines of a raw string literal
+    // e.g. unindent_string("  \n  a\n  b\n  c\n") -> "a\nb\nc"
+    template<class char_type>
+    consteval std::vector<char_type> unindent_string(string_view<char_type> str) {
+        string_view<char_type> line_ending = "\n";
+        string_view<char_type> space_separator = " ";
+        std::vector<string_view<char_type>> lines = split_lines(str, line_ending);
+
+        std::vector<char_type> new_string;
+        bool is_first = true;
+        for(auto line : lines) {
+            // append newline/line separator
+            if(is_first) {
+                is_first = false;
+            } else {
+                new_string.insert(new_string.end(), space_separator.begin(), space_separator.end());
+            }
+
+            // append unindented line
+            auto unindented = line.substr(get_leading_space_sequence(line).size());
+            new_string.insert(new_string.end(), unindented.begin(), unindented.end());
+        }
+
+        // add null terminator
+        new_string.push_back(null_char<char_type>);
+
+        return new_string;
+    }
+
+    // returns the size required for the unindented string
+    template<class char_type>
+    consteval std::size_t unindent_string_size(string_view<char_type> str) {
+        return unindent_string(str).size();
+    }
+
+    // simple type that stores a raw string
+    // we need this to get around the limitation that string literals
+    // are not considered valid non-type template arguments.
+    template<class _char_type, std::size_t size>
+    struct string_wrapper {
+        using char_type = _char_type;
+
+        consteval string_wrapper(const char_type (&arr)[size]) {
+            std::ranges::copy(arr, str);
+        }
+
+        char_type str[size];
+    };
+
+    // used for sneakily creating and storing
+    // the unindented string in a template parameter.
+    template<string_wrapper sw>
+    struct unindented_string_wrapper {
+        using char_type = typename decltype(sw)::char_type;
+        static constexpr std::size_t buffer_size = unindent_string_size<char_type>(sw.str);
+        using array_ref = const char_type (&)[buffer_size];
+
+        consteval unindented_string_wrapper(int) {
+            auto newstr = unindent_string<char_type>(sw.str);
+            std::ranges::copy(newstr, buffer);
+        }
+
+        consteval array_ref get() const {
+            return buffer;
+        }
+
+        char_type buffer[buffer_size];
+    };
+
+    // uses a defaulted template argument that depends on the str
+    // to initialize the unindented string within a template parameter.
+    // this enables us to return a reference to the unindented string.
+    template<string_wrapper str, unindented_string_wrapper<str> unindented = 0>
+    consteval decltype(auto) do_unindent() {
+        return unindented.get();
+    }
+
+    // the actual user-defined string literal operator
+    template<string_wrapper str>
+    consteval decltype(auto) operator"" _M() {
+        return do_unindent<str>();
+    }
+}
+
+using multiline_raw_string::operator"" _M;
+
+#endif
 
 /* checks that the postgres version is sufficient to run cgimap.
  *

--- a/src/backend/apidb/changeset_upload/node_updater.cpp
+++ b/src/backend/apidb/changeset_upload/node_updater.cpp
@@ -314,7 +314,7 @@ void ApiDB_Node_Updater::insert_new_nodes_to_current_table(
       )
       SELECT id, old_id
         FROM ids_mapping
-  )");
+  )"_M);
 
   std::vector<int64_t> lats;
   std::vector<int64_t> lons;
@@ -366,7 +366,7 @@ void ApiDB_Node_Updater::lock_current_nodes(
       EXCEPT
       SELECT id FROM locked
       ORDER BY id
-     )");
+     )"_M);
 
   // Query returns only node ids, which could not be locked
   auto r = m.exec_prepared("lock_current_nodes", ids);
@@ -450,7 +450,7 @@ void ApiDB_Node_Updater::check_current_node_versions(
            ON t.id = cn.id
         WHERE t.version <> cn.version
         LIMIT 1
-          )");
+          )"_M);
 
   auto r = m.exec_prepared("check_current_node_versions", ids, versions);
 
@@ -545,7 +545,7 @@ ApiDB_Node_Updater::calc_node_bbox(const std::vector<osm_nwr_id_t> &ids) {
              MAX(latitude)  AS maxlat,
              MAX(longitude) AS maxlon
       FROM current_nodes WHERE id = ANY($1)
-       )");
+       )"_M);
 
   auto r = m.exec_prepared("calc_node_bbox", ids);
 
@@ -588,7 +588,7 @@ void ApiDB_Node_Updater::update_current_nodes(
         WHERE n.id = u.id
         AND   n.version = u.version
         RETURNING n.id, n.version
-       )");
+       )"_M);
 
   std::vector<osm_nwr_id_t> ids;
   std::vector<int64_t> lats;
@@ -673,7 +673,7 @@ void ApiDB_Node_Updater::delete_current_nodes(
          WHERE n.id = u.id
          AND   n.version = u.version
          RETURNING n.id, n.version
-   )");
+   )"_M);
 
   std::vector<osm_nwr_id_t> ids;
   std::vector<osm_changeset_id_t> cs;
@@ -724,7 +724,7 @@ std::vector<osm_nwr_id_t> ApiDB_Node_Updater::insert_new_current_node_tags(
       )
       INSERT INTO current_node_tags(node_id, k, v)
       SELECT * FROM tmp_tag
-         )");
+         )"_M);
 
   std::vector<osm_nwr_id_t> ids;
   std::vector<std::string> ks;
@@ -790,7 +790,7 @@ void ApiDB_Node_Updater::save_current_nodes_to_history(
                    changeset_id, visible, timestamp, tile, version
               FROM current_nodes
               WHERE id = ANY($1)
-       )");
+       )"_M);
 
   auto r = m.exec_prepared("current_nodes_to_history", ids);
 
@@ -813,7 +813,7 @@ void ApiDB_Node_Updater::save_current_node_tags_to_history(
                   INNER JOIN current_nodes n
                      ON t.node_id = n.id
                 WHERE id = ANY($1)
-           )");
+           )"_M);
 
   auto r = m.exec_prepared("current_node_tags_to_history", ids);
 }
@@ -851,7 +851,7 @@ ApiDB_Node_Updater::is_node_still_referenced(const std::vector<node_t> &nodes) {
                    FROM current_way_nodes
                    WHERE node_id = ANY($1)
                    GROUP BY node_id
-            )");
+            )"_M);
 
     auto r = m.exec_prepared("node_still_referenced_by_way", ids);
 
@@ -893,7 +893,7 @@ ApiDB_Node_Updater::is_node_still_referenced(const std::vector<node_t> &nodes) {
                     WHERE member_type = 'Node'
                       AND member_id = ANY($1)
                     GROUP BY member_id
-             )");
+             )"_M);
 
     auto r = m.exec_prepared("node_still_referenced_by_relation", ids);
 

--- a/src/backend/apidb/changeset_upload/relation_updater.cpp
+++ b/src/backend/apidb/changeset_upload/relation_updater.cpp
@@ -485,7 +485,7 @@ void ApiDB_Relation_Updater::insert_new_relations_to_current_table(
       )
       SELECT id, old_id
         FROM ids_mapping
-    )");
+    )"_M);
 
   std::vector<osm_changeset_id_t> cs;
   std::vector<osm_nwr_signed_id_t> oldids;
@@ -529,7 +529,7 @@ void ApiDB_Relation_Updater::lock_current_relations(
       EXCEPT
       SELECT id FROM locked
       ORDER BY id
-     )");
+     )"_M);
 
   auto r = m.exec_prepared("lock_current_relations", ids);
 
@@ -607,7 +607,7 @@ void ApiDB_Relation_Updater::check_current_relation_versions(
                      ON t.id = cr.id
                   WHERE t.version <> cr.version
                   LIMIT 1
-       )");
+       )"_M);
 
   auto r = m.exec_prepared("check_current_relation_versions", ids, versions);
 
@@ -707,7 +707,7 @@ void ApiDB_Relation_Updater::lock_future_members_nodes(
               EXCEPT
               SELECT id FROM locked
               ORDER BY id
-            )");
+            )"_M);
 
   auto r = m.exec_prepared("lock_future_nodes_in_relations", node_ids);
 
@@ -758,7 +758,7 @@ void ApiDB_Relation_Updater::lock_future_members_ways(
               EXCEPT
               SELECT id FROM locked
               ORDER BY id
-           )");
+           )"_M);
 
   auto r = m.exec_prepared("lock_future_ways_in_relations", way_ids);
 
@@ -812,7 +812,7 @@ void ApiDB_Relation_Updater::lock_future_members_relations(
               EXCEPT
               SELECT id FROM locked
               ORDER BY id
-            )");
+            )"_M);
 
   auto r = m.exec_prepared("lock_future_relations_in_relations", relation_ids);
 
@@ -925,7 +925,7 @@ ApiDB_Relation_Updater::relations_with_new_relation_members(
            AND m.member_type = 'Relation'
           WHERE m.member_id IS NULL
           GROUP BY t.relation_id
-     )");
+     )"_M);
 
   auto r = m.exec_prepared("relations_with_new_relation_members", relation_ids, member_ids);
 
@@ -995,7 +995,7 @@ ApiDB_Relation_Updater::relations_with_changed_relation_tags(
                   AND t.v IS NULL
             ) AS all_relations
             GROUP BY all_relations.relation_id
-         )");
+         )"_M);
 
   auto r = m.exec_prepared("relations_with_changed_relation_tags", ids, ks, vs);
 
@@ -1054,7 +1054,7 @@ ApiDB_Relation_Updater::relations_with_changed_way_node_members(
                  WHERE cm.relation_id IS NULL AND
                        cm.member_type IS NULL AND
                        cm.member_id   IS NULL
-         )");
+         )"_M);
 
   auto r_added = m.exec_prepared("relations_with_added_way_node_members", ids, membertypes, memberids);
 
@@ -1087,7 +1087,7 @@ ApiDB_Relation_Updater::relations_with_changed_way_node_members(
                   tm.member_type IS NULL AND
                   tm.member_id   IS NULL
 
-         )");
+         )"_M);
 
   auto r_removed = m.exec_prepared("relations_with_removed_way_node_members", ids, membertypes, memberids);
 
@@ -1134,7 +1134,7 @@ bbox_t ApiDB_Relation_Updater::calc_rel_member_difference_bbox(
              MAX(latitude)  AS maxlat,
              MAX(longitude) AS maxlon
       FROM current_nodes WHERE id = ANY($1)
-       )");
+       )"_M);
 
     auto r = m.exec_prepared("calc_node_bbox_rel_member", node_ids);
 
@@ -1164,7 +1164,7 @@ bbox_t ApiDB_Relation_Updater::calc_rel_member_difference_bbox(
       INNER JOIN current_ways w
         ON wn.way_id = w.id
       WHERE w.id = ANY($1)
-       )");
+       )"_M);
 
     auto r = m.exec_prepared("calc_way_bbox_rel_member", way_ids);
 
@@ -1217,7 +1217,7 @@ bbox_t ApiDB_Relation_Updater::calc_relation_bbox(
                         ON crm.member_id = cn.id
                  WHERE crm.member_type = 'Node'
                    AND crm.relation_id = ANY($1)
-            )");
+            )"_M);
 
   auto rn = m.exec_prepared("calc_relation_bbox_nodes", ids);
 
@@ -1243,7 +1243,7 @@ bbox_t ApiDB_Relation_Updater::calc_relation_bbox(
                         ON crm.member_id = w.id
                  WHERE crm.member_type = 'Way'
                    AND crm.relation_id = ANY($1)
-              )");
+              )"_M);
 
   auto rw = m.exec_prepared("calc_relation_bbox_ways", ids);
 
@@ -1283,7 +1283,7 @@ void ApiDB_Relation_Updater::update_current_relations(
         WHERE r.id = u.id
           AND r.version = u.version
         RETURNING r.id, r.version
-    )");
+    )"_M);
 
   std::vector<osm_nwr_signed_id_t> ids;
   std::vector<osm_changeset_id_t> cs;
@@ -1339,7 +1339,7 @@ std::vector<osm_nwr_id_t>  ApiDB_Relation_Updater::insert_new_current_relation_t
                 )
                 INSERT INTO current_relation_tags(relation_id, k, v)
                 SELECT * FROM tmp_tag
-            )");
+            )"_M);
 
   std::vector<osm_nwr_id_t> ids;
   std::vector<std::string> ks;
@@ -1412,7 +1412,7 @@ void ApiDB_Relation_Updater::insert_new_current_relation_members(
          )
          INSERT INTO current_relation_members(relation_id, member_type, member_id, member_role, sequence_id)
          SELECT * FROM tmp_member
-      )");
+      )"_M);
 
   std::vector<osm_nwr_id_t> ids;
   std::vector<std::string> membertypes;
@@ -1458,7 +1458,7 @@ void ApiDB_Relation_Updater::save_current_relations_to_history(
                 SELECT id AS relation_id, changeset_id, timestamp, version, visible
                 FROM current_relations
                 WHERE id = ANY($1)
-            )");
+            )"_M);
 
   auto r = m.exec_prepared("current_relations_to_history", ids);
 
@@ -1478,7 +1478,7 @@ void ApiDB_Relation_Updater::save_current_relation_tags_to_history(
                  INNER JOIN current_relations cr
                  ON rt.relation_id = cr.id
                  WHERE id = ANY($1)
-             )");
+             )"_M);
 
   auto r = m.exec_prepared("current_relation_tags_to_history", ids);
 }
@@ -1499,7 +1499,7 @@ void ApiDB_Relation_Updater::save_current_relation_members_to_history(
                  INNER JOIN current_relations cr
                  ON crm.relation_id = cr.id
                  WHERE id = ANY($1)
-                          )");
+                          )"_M);
 
   auto r =
       m.exec_prepared("current_relation_members_to_history", ids);
@@ -1570,7 +1570,7 @@ ApiDB_Relation_Updater::collect_recursive_relation_rel_member_ids (
              INNER JOIN current_relation_members crm
                      ON crm.relation_id = cr.id
                     AND crm.member_type = 'Relation'
-       )");
+       )"_M);
 
   // Recursively iterate over list of relation ids and extract relation member ids
   do {
@@ -1706,7 +1706,7 @@ ApiDB_Relation_Updater::is_relation_still_referenced(
              AND current_relation_members.member_type = 'Relation'
              AND relations_to_check.id IS NULL
            GROUP BY current_relation_members.member_id
-       )");
+       )"_M);
 
   auto r = m.exec_prepared("relation_still_referenced_by_relation", ids);
 

--- a/src/backend/apidb/changeset_upload/way_updater.cpp
+++ b/src/backend/apidb/changeset_upload/way_updater.cpp
@@ -361,7 +361,7 @@ void ApiDB_Way_Updater::insert_new_ways_to_current_table(
       )
       SELECT id, old_id
         FROM ids_mapping
-  )");
+  )"_M);
 
   std::vector<osm_changeset_id_t> cs;
   std::vector<osm_nwr_signed_id_t> oldids;
@@ -406,7 +406,7 @@ bbox_t ApiDB_Way_Updater::calc_way_bbox(const std::vector<osm_nwr_id_t> &ids) {
       INNER JOIN current_ways w
         ON wn.way_id = w.id
       WHERE w.id = ANY($1)
-       )");
+       )"_M);
 
   auto r = m.exec_prepared("calc_way_bbox", ids);
 
@@ -434,7 +434,7 @@ void ApiDB_Way_Updater::lock_current_ways(
       EXCEPT
       SELECT id FROM locked
       ORDER BY id
-     )");
+     )"_M);
 
   auto r = m.exec_prepared("lock_current_ways", ids);
 
@@ -513,7 +513,7 @@ void ApiDB_Way_Updater::check_current_way_versions(
            ON t.id = cw.id
         WHERE t.version <> cw.version
         LIMIT 1
-      )");
+      )"_M);
 
   auto r =
       m.exec_prepared("check_current_way_versions", ids, versions);
@@ -630,7 +630,7 @@ void ApiDB_Way_Updater::lock_future_nodes(const std::vector<way_t> &ways) {
         EXCEPT
         SELECT id FROM locked
         ORDER BY id
-      )");
+      )"_M);
 
   auto r = m.exec_prepared("lock_future_nodes_in_ways", node_ids);
 
@@ -680,7 +680,7 @@ void ApiDB_Way_Updater::update_current_ways(const std::vector<way_t> &ways,
       WHERE w.id = u.id
       AND   w.version = u.version
       RETURNING w.id, w.version
-     )");
+     )"_M);
 
   std::vector<osm_nwr_signed_id_t> ids;
   std::vector<osm_changeset_id_t> cs;
@@ -737,7 +737,7 @@ std::vector<osm_nwr_id_t> ApiDB_Way_Updater::insert_new_current_way_tags(
       )
       INSERT INTO current_way_tags(way_id, k, v)
       SELECT * FROM tmp_tag
-     )");
+     )"_M);
 
   std::vector<osm_nwr_id_t> ids;
   std::vector<std::string> ks;
@@ -806,7 +806,7 @@ void ApiDB_Way_Updater::insert_new_current_way_nodes(
       )
       INSERT INTO current_way_nodes (way_id, node_id, sequence_id)
       SELECT * FROM new_way_nodes
-       )");
+       )"_M);
 
   std::vector<osm_nwr_id_t> ids;
   std::vector<osm_nwr_id_t> nodeids;
@@ -848,7 +848,7 @@ void ApiDB_Way_Updater::save_current_ways_to_history(
         SELECT id, changeset_id, timestamp, version, visible
         FROM current_ways
         WHERE id = ANY($1)
-    )");
+    )"_M);
 
   auto r = m.exec_prepared("current_ways_to_history", ids);
 
@@ -870,7 +870,7 @@ void ApiDB_Way_Updater::save_current_way_nodes_to_history(
        FROM current_way_nodes wn
        INNER JOIN current_ways w
        ON wn.way_id = w.id
-       WHERE id = ANY($1) )");
+       WHERE id = ANY($1) )"_M);
 
   auto r = m.exec_prepared("current_way_nodes_to_history", ids);
 }
@@ -890,7 +890,7 @@ void ApiDB_Way_Updater::save_current_way_tags_to_history(
              INNER JOIN current_ways w
                 ON wt.way_id = w.id
              WHERE id = ANY($1)
-     )");
+     )"_M);
 
   auto r = m.exec_prepared("current_way_tags_to_history", ids);
 }
@@ -928,7 +928,7 @@ ApiDB_Way_Updater::is_way_still_referenced(const std::vector<way_t> &ways) {
          WHERE member_type = 'Way'
            AND member_id = ANY($1)
          GROUP BY member_id
-      )");
+      )"_M);
 
   auto r = m.exec_prepared("way_still_referenced_by_relation", ids);
 

--- a/src/backend/apidb/readonly_pgsql_selection.cpp
+++ b/src/backend/apidb/readonly_pgsql_selection.cpp
@@ -784,7 +784,7 @@ bool readonly_pgsql_selection::is_user_blocked(const osm_user_id_t id) {
   m.prepare("check_user_blocked",
     R"(SELECT id FROM "user_blocks"
           WHERE "user_blocks"."user_id" = $1
-            AND (needs_view or ends_at > (now() at time zone 'utc')) LIMIT 1 )");
+            AND (needs_view or ends_at > (now() at time zone 'utc')) LIMIT 1 )"_M);
 
   auto res = m.exec_prepared("check_user_blocked", id);
   return !res.empty();
@@ -827,7 +827,7 @@ std::optional< osm_user_id_t > readonly_pgsql_selection::get_user_id_for_oauth2_
          COALESCE(revoked_at < now() at time zone 'utc', false) as revoked,
          'write_api' = any(string_to_array(scopes, ' ')) as allow_api_write
        FROM oauth_access_tokens
-       WHERE token = $1)");
+       WHERE token = $1)"_M);
 
   auto res = m.exec_prepared("oauth2_access_token", token_id);
 
@@ -851,7 +851,7 @@ bool readonly_pgsql_selection::is_user_active(const osm_user_id_t id)
   m.prepare("is_user_active",
          R"(SELECT id FROM users
             WHERE id = $1
-            AND (status = 'active' or status = 'confirmed'))");
+            AND (status = 'active' or status = 'confirmed'))"_M);
 
   auto res = m.exec_prepared("is_user_active", id);
   return (!res.empty());


### PR DESCRIPTION
This PR standardizes SQL statements to use C++ raw string literals for easier maintenance. Additionally, we use a C++20 string literal operator named `_M` to remove indentation at compile time, resulting in a format nearly identical to the previous one.

https://godbolt.org/z/5je94K4ve illustrates the compile time step.

GCC 11 and older lack full support for the unindent step, so the original string is used instead.