### PR TITLE
options.cpp: replace interval regex by simple parser

### DIFF
--- a/include/cgimap/options.hpp
+++ b/include/cgimap/options.hpp
@@ -12,7 +12,6 @@
 
 #include <memory>
 #include <optional>
-#include <regex>
 #include <boost/program_options.hpp>
 
 namespace po = boost::program_options;

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -17,7 +17,6 @@
 #include <cctype>   // for toupper, isxdigit
 #include <cstdlib>
 #include <ranges>
-#include <regex>
 #include <sstream>
 #include <string_view>
 


### PR DESCRIPTION
This PR removes the last remaining std::regex. It was taking care of postgresql timeout intervals for two command line parameters. The replacement is based on c++20 ranges.