### PR TITLE
VS Code devcontainer added

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq && \
+    apt-get install -y gcc g++ make cmake cmake-curses-gui gdb less ssh \
+       libfcgi-dev libxml2-dev libmemcached-dev libbrotli-dev \
+       libboost-program-options-dev libcrypto++-dev libyajl-dev \
+       libpqxx-dev zlib1g-dev libfmt-dev \
+       postgresql-15 postgresql-server-dev-all dpkg-dev file \
+       clang-tidy cppcheck ninja-build locales \
+       --no-install-recommends && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG REMOTE_USER
+ARG REMOTE_UID
+ARG REMOTE_GID
+RUN <<EOF
+   addgroup --gid ${REMOTE_GID} ${REMOTE_USER}
+   adduser --disabled-password --uid ${REMOTE_UID} --gid ${REMOTE_GID} ${REMOTE_USER}
+EOF
+
+ENV HOME /home/${REMOTE_USER}
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+USER ${REMOTE_USER}
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "C++ openstreetmap-cgimap",
+	"build": {
+		"args": {
+			"REMOTE_USER": "${localEnv:USER}",
+			"REMOTE_UID": "${localEnv:REMOTE_UID:1000}",
+			"REMOTE_GID": "${localEnv:REMOTE_GID:1000}"
+		    },
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	},
+	"remoteUser": "${localEnv:USER}",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cmake-tools",
+				"ms-vscode.cpptools-extension-pack"
+			]
+		}
+	}
+}


### PR DESCRIPTION
I added this VS Code devcontainer to make it a bit easier for new folks to get started (and for me to have an environment similar to production). At least building binaries and running test cases seems to work fine at the moment. Of course, additional tools can be added if it makes sense.