### PR TITLE
Added more tools to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qq && \
     apt-get install -y gcc g++ make cmake cmake-curses-gui gdb less ssh \
+       gnupg2 ca-certificates software-properties-common \
+       build-essential wget git nano jq valgrind linux-perf \
+       gcovr lcov strace ltrace rsync zip sudo \
+       tar curl unzip pkg-config bash-completion aria2 \
        libfcgi-dev libxml2-dev libmemcached-dev libbrotli-dev \
        libboost-program-options-dev libcrypto++-dev libyajl-dev \
        libpqxx-dev zlib1g-dev libfmt-dev \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,8 @@
 		"vscode": {
 			"extensions": [
 				"ms-vscode.cmake-tools",
-				"ms-vscode.cpptools-extension-pack"
+				"ms-vscode.cpptools-extension-pack",
+				"JacquesLucke.gcov-viewer"
 			]
 		}
 	}

--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -1,0 +1,38 @@
+buildType:
+  default: debug
+  choices:
+    debug:
+      short: Debug
+      long: Emit debug information
+      buildType: Debug
+    release:
+      short: Release
+      long: Optimize generated code
+      buildType: Release
+      settings:
+        CMAKE_CXX_FLAGS: "-fwhole-program -flto=auto"
+        CMAKE_C_FLAGS: "-fwhole-program -flto=auto"
+        CMAKE_EXE_LINKER_FLAGS: "-flto=auto"
+    releaseDebug:
+      short: ReleaseDebug
+      long: Release with debug information
+      buildType: RelWithDebInfo
+
+coverage:
+  default: no_coverage
+  choices:
+    # enable coverage by additional compiler flags
+    coverage:
+      short: cov
+      long: build with coverage instrumentation
+      settings:
+        CMAKE_CXX_FLAGS: "-fprofile-arcs -ftest-coverage "
+        CMAKE_C_FLAGS: "-fprofile-arcs -ftest-coverage"
+        CMAKE_EXE_LINKER_FLAGS: "--coverage"
+    no_coverage:
+      short: no_coverage
+      long: build without coverage
+      settings:
+        CMAKE_CXX_FLAGS: ""
+        CMAKE_C_FLAGS: ""
+        CMAKE_EXE_LINKER_FLAGS: ""


### PR DESCRIPTION
Added cmake build configs for coverage, added extension to display coverage info

CMake now comes with a few new predefined build variants, including coverage support.

![image](https://github.com/user-attachments/assets/f576c366-a8a7-49c9-9d27-d9b577a8fef9)

After running ctest, coverage files need to be imported:

![image](https://github.com/user-attachments/assets/d187d997-ad10-4e17-8769-c336128bb1b7)

"Gcov Viewer: Show" enhances the editor view with coverage details:

![image](https://github.com/user-attachments/assets/ed106d04-8831-4bef-a219-c651b31d0b04)
