### PR TITLE
test_apidb_backend_core - test_core w/ db support

### DIFF
--- a/include/cgimap/backend/apidb/common_pgsql_selection.hpp
+++ b/include/cgimap/backend/apidb/common_pgsql_selection.hpp
@@ -27,21 +27,18 @@
 // the changeset cache is used to look up user display names.
 void extract_nodes(
   const pqxx::result &rows, output_formatter &formatter,
-  std::function<void(const element_info&)> notify,
   std::map<osm_changeset_id_t, changeset> &cc);
 
 // extract ways from the results of the query and write them to the formatter.
 // the changeset cache is used to look up user display names.
 void extract_ways(
   const pqxx::result &rows, output_formatter &formatter,
-  std::function<void(const element_info&)> notify,
   std::map<osm_changeset_id_t, changeset> &cc);
 
 // extract relations from the results of the query and write them to the
 // formatter. the changeset cache is used to look up user display names.
 void extract_relations(
   const pqxx::result &rows, output_formatter &formatter,
-  std::function<void(const element_info&)> notify,
   std::map<osm_changeset_id_t, changeset> &cc);
 
 void extract_changesets(

--- a/src/backend/apidb/common_pgsql_selection.cpp
+++ b/src/backend/apidb/common_pgsql_selection.cpp
@@ -352,7 +352,6 @@ struct relation {
 template <typename T>
 void extract(
   const pqxx::result &rows, output_formatter &formatter,
-  std::function<void(const element_info&)> notify,
   std::map<osm_changeset_id_t, changeset> &cc) {
 
   const typename T::extra_columns extra_cols(rows);
@@ -363,8 +362,6 @@ void extract(
     typename T::extra_info extra(row, extra_cols);
     auto elem = extract_elem(row, cc, elem_cols);
     auto tags = extract_tags(row, tag_cols);
-    if (notify)
-      notify(elem);     // let callback function know about a new element we're processing
     T::write(formatter, elem, extra, tags);
   }
 }
@@ -373,25 +370,22 @@ void extract(
 
 void extract_nodes(
   const pqxx::result &rows, output_formatter &formatter,
-  std::function<void(const element_info&)> notify,
   std::map<osm_changeset_id_t, changeset> &cc) {
-  extract<node>(rows, formatter, std::move(notify), cc);
+  extract<node>(rows, formatter, cc);
 }
 
 void extract_ways(
   const pqxx::result &rows, output_formatter &formatter,
-  std::function<void(const element_info&)> notify,
   std::map<osm_changeset_id_t, changeset> &cc) {
-  extract<way>(rows, formatter, std::move(notify), cc);
+  extract<way>(rows, formatter, cc);
 }
 
 // extract relations from the results of the query and write them to the
 // formatter. the changeset cache is used to look up user display names.
 void extract_relations(
   const pqxx::result &rows, output_formatter &formatter,
-  std::function<void(const element_info&)> notify,
   std::map<osm_changeset_id_t, changeset> &cc) {
-  extract<relation>(rows, formatter, std::move(notify), cc);
+  extract<relation>(rows, formatter, cc);
 }
 
 void extract_changesets(

--- a/src/backend/apidb/readonly_pgsql_selection.cpp
+++ b/src/backend/apidb/readonly_pgsql_selection.cpp
@@ -833,7 +833,7 @@ std::optional< osm_user_id_t > readonly_pgsql_selection::get_user_id_for_oauth2_
               ELSE (created_at + expires_in * interval '1' second) < now() at time zone 'utc'
          END as expired,
          COALESCE(revoked_at < now() at time zone 'utc', false) as revoked,
-         'write_api' = any(string_to_array(scopes, ' ')) as allow_api_write
+         'write_api' = any(string_to_array(coalesce(scopes,''), ' ')) as allow_api_write
        FROM oauth_access_tokens
        WHERE token = $1)"_M);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -322,6 +322,35 @@ if(BUILD_TESTING)
         add_test(NAME test_apidb_backend_changeset_uploads
             COMMAND pg_virtualenv "$<TARGET_FILE:test_apidb_backend_changeset_uploads>" --db-schema "${CMAKE_CURRENT_SOURCE_DIR}/structure.sql")
 
+
+    #########################
+    # test_apidb_backend_core
+    #########################
+    add_executable(test_apidb_backend_core
+        test_apidb_backend_core.cpp
+        test_apidb_importer.cpp
+        test_core_helper.cpp
+        test_formatter.cpp
+        test_database.cpp
+        test_request.cpp
+        xmlparser.cpp)
+
+    target_link_libraries(test_apidb_backend_core
+        cgimap_common_compiler_options
+        cgimap_core
+        cgimap_apidb
+        catch2
+        Boost::program_options
+        PQXX::PQXX)
+
+
+    file(GLOB test_apidb_backend_core_dirs LIST_DIRECTORIES true "${CMAKE_CURRENT_SOURCE_DIR}/*.testcore")
+    foreach (test ${test_apidb_backend_core_dirs})
+    get_filename_component (TName "${test}" NAME_WE)
+    add_test(NAME "${TName}.db.testcore" COMMAND pg_virtualenv "$<TARGET_FILE:test_apidb_backend_core>" --test-directory "${test}" --db-schema "${CMAKE_CURRENT_SOURCE_DIR}/structure.sql")
+    endforeach ()
+
+
     # define check alias target for autotools compatibility
     add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 
@@ -330,6 +359,7 @@ if(BUILD_TESTING)
                            test_oauth2
                            test_http
                            test_parse_time
+                           test_parse_options
                            test_parse_osmchange_xml_input
                            test_parse_changeset_input)
 
@@ -339,6 +369,7 @@ if(BUILD_TESTING)
                              test_apidb_backend_changesets
                              test_apidb_backend_changeset_downloads
                              test_apidb_backend_changeset_uploads
-                             test_apidb_backend_roles)
+                             test_apidb_backend_roles
+                             test_apidb_backend_core)
 
 endif()

--- a/test/json.testcore/data.osm
+++ b/test/json.testcore/data.osm
@@ -9,7 +9,7 @@
   <node visible="true" id='3' timestamp='2012-09-25T00:01:00Z' uid='1' user='foo' version='2' changeset='3' lat='0.0' lon='0.0' />
 
   <!-- Regression test for double values mistakenly being truncated to 11 characters https://github.com/zerebubuth/openstreetmap-cgimap/issues/363 -->
-  <node visible="true" id='4' timestamp='2013-10-20T00:00:00Z' uid='1' user='foo' version='1' changeset='4' lat='48.1730392' lon='-117.0671669' /> 
+  <node visible="true" id='4' timestamp='2013-10-20T00:00:00Z' uid='4' user='user_4' version='1' changeset='4' lat='48.1730392' lon='-117.0671669' />
 
   <node visible="true" id='40050' timestamp='2012-09-25T00:00:01Z' uid='1' user='foo' version='1' changeset='1' lat='0.99587530072' lon='1.15459870878' />
   <node visible="true" id='40051' timestamp='2012-09-25T00:00:02Z' uid='1' user='foo' version='1' changeset='1' lat='0.99684898006' lon='1.15459552634' />

--- a/test/json.testcore/regression_double_truncated.case
+++ b/test/json.testcore/regression_double_truncated.case
@@ -4,7 +4,7 @@ Request-URI: /api/0.6/node/4.json
 HTTP-Accept: */*
 ---
 Content-Type: application/json; charset=utf-8
-!Content-Disposition: 
+!Content-Disposition:
 Status: 200 OK
 ---
 { "version": "0.6",
@@ -20,8 +20,8 @@ Status: 200 OK
 	"timestamp": "2013-10-20T00:00:00Z",
 	"version": 1,
 	"changeset": 4,
-	"user": "foo",
-	"uid": 1
+	"user": "user_4",
+	"uid": 4
       }
   ]
 }

--- a/test/node.testcore/data.osm
+++ b/test/node.testcore/data.osm
@@ -1,9 +1,9 @@
 <osm version="0.6" generator="by hand">
   <node id="1" version="1" changeset="1" lat="0.0" lon="0.0" user="foo" uid="1" visible="true" timestamp="2012-09-25T00:00:00Z"/>
   <node id="2" version="8" changeset="3" lat="1.0" lon="1.0" user="foo" uid="1" visible="true" timestamp="2012-10-01T00:00:00Z">
-    <tag k="foo" v="bar1"/>
     <tag k="bar" v="bar2"/>
     <tag k="baz" v="bar3"/>
+    <tag k="foo" v="bar1"/>
   </node>
   <node id="3" version="1" changeset="3" lat="0.0" lon="0.0" user="foo" uid="1" visible="true" timestamp="2012-09-25T00:00:59Z"/>
   <node id="3" version="2" changeset="3" lat="0.0" lon="0.0" user="foo" uid="1" visible="false" timestamp="2012-09-25T00:01:00Z"/>

--- a/test/node.testcore/node_2.case
+++ b/test/node.testcore/node_2.case
@@ -2,13 +2,13 @@ Request-Method: GET
 Request-URI: /api/0.6/node/2
 ---
 Content-Type: application/xml; charset=utf-8
-!Content-Disposition: 
+!Content-Disposition:
 Status: 200 OK
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
   <node id="2" lon="1.0000000" lat="1.0000000" user="foo" uid="1" visible="true" version="8" changeset="3" timestamp="2012-10-01T00:00:00Z">
-    <tag k="foo" v="bar1"/>
     <tag k="bar" v="bar2"/>
     <tag k="baz" v="bar3"/>
+    <tag k="foo" v="bar1"/>
   </node>
 </osm>

--- a/test/node.testcore/nodes.case
+++ b/test/node.testcore/nodes.case
@@ -3,15 +3,15 @@ Request-Method: GET
 Request-URI: /api/0.6/nodes?nodes=1,2,3
 ---
 Content-Type: application/xml; charset=utf-8
-!Content-Disposition: 
+!Content-Disposition:
 Status: 200 OK
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
   <node id="1" version="1" changeset="1" lat="0.0000000" lon="0.0000000" user="foo" uid="1" visible="true" timestamp="2012-09-25T00:00:00Z"/>
   <node id="2" version="8" changeset="3" lat="1.0000000" lon="1.0000000" user="foo" uid="1" visible="true" timestamp="2012-10-01T00:00:00Z">
-    <tag k="foo" v="bar1"/>
     <tag k="bar" v="bar2"/>
     <tag k="baz" v="bar3"/>
+    <tag k="foo" v="bar1"/>
   </node>
   <node id="3" version="2" changeset="3" user="foo" uid="1" visible="false" timestamp="2012-09-25T00:01:00Z"/>
 </osm>

--- a/test/node.testcore/nodes_dup2.case
+++ b/test/node.testcore/nodes_dup2.case
@@ -3,15 +3,15 @@ Request-Method: GET
 Request-URI: /api/0.6/nodes?nodes=1,2,2,3
 ---
 Content-Type: application/xml; charset=utf-8
-!Content-Disposition: 
+!Content-Disposition:
 Status: 200 OK
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
   <node id="1" version="1" changeset="1" lat="0.0000000" lon="0.0000000" user="foo" uid="1" visible="true" timestamp="2012-09-25T00:00:00Z"/>
   <node id="2" version="8" changeset="3" lat="1.0000000" lon="1.0000000" user="foo" uid="1" visible="true" timestamp="2012-10-01T00:00:00Z">
-    <tag k="foo" v="bar1"/>
     <tag k="bar" v="bar2"/>
     <tag k="baz" v="bar3"/>
+    <tag k="foo" v="bar1"/>
   </node>
   <node id="3" version="2" changeset="3" user="foo" uid="1" visible="false" timestamp="2012-09-25T00:01:00Z"/>
 </osm>

--- a/test/relation.testcore/data.osm
+++ b/test/relation.testcore/data.osm
@@ -12,8 +12,8 @@
   <relation id="1" version="1" changeset="1" user="foo" uid="1" visible="true" timestamp="2012-12-01T00:00:00Z">
     <member type="node" ref="2" role="stop"/>
     <member type="way" ref="1" role="forward"/>
-    <tag k="type" v="route"/>
     <tag k="ref" v="W8"/>
+    <tag k="type" v="route"/>
   </relation>
 
   <relation id="2" version="1" changeset="3" user="foo" uid="1" visible="true" timestamp="2013-01-12T00:00:00Z">

--- a/test/relation.testcore/relation_1.case
+++ b/test/relation.testcore/relation_1.case
@@ -2,14 +2,14 @@ Request-Method: GET
 Request-URI: /api/0.6/relation/1
 ---
 Content-Type: application/xml; charset=utf-8
-!Content-Disposition: 
+!Content-Disposition:
 Status: 200 OK
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
   <relation id="1" version="1" changeset="1" user="foo" uid="1" visible="true" timestamp="2012-12-01T00:00:00Z">
     <member type="node" ref="2" role="stop"/>
     <member type="way" ref="1" role="forward"/>
-    <tag k="type" v="route"/>
     <tag k="ref" v="W8"/>
+    <tag k="type" v="route"/>
   </relation>
 </osm>

--- a/test/relation.testcore/relations.case
+++ b/test/relation.testcore/relations.case
@@ -3,15 +3,15 @@ Request-Method: GET
 Request-URI: /api/0.6/relations?relations=1,2
 ---
 Content-Type: application/xml; charset=utf-8
-!Content-Disposition: 
+!Content-Disposition:
 Status: 200 OK
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
   <relation id="1" version="1" changeset="1" user="foo" uid="1" visible="true" timestamp="2012-12-01T00:00:00Z">
     <member type="node" ref="2" role="stop"/>
     <member type="way" ref="1" role="forward"/>
-    <tag k="type" v="route"/>
     <tag k="ref" v="W8"/>
+    <tag k="type" v="route"/>
   </relation>
   <relation id="2" version="2" changeset="3" user="foo" uid="1" visible="false" timestamp="2013-01-12T00:00:00Z"/>
 </osm>

--- a/test/relation_full.testcore/data.osm
+++ b/test/relation_full.testcore/data.osm
@@ -12,8 +12,8 @@
   <relation id="1" version="1" changeset="1" user="foo" uid="1" visible="true" timestamp="2012-12-01T00:00:00Z">
     <member type="node" ref="2" role="stop"/>
     <member type="way" ref="1" role="forward"/>
-    <tag k="type" v="route"/>
     <tag k="ref" v="W8"/>
+    <tag k="type" v="route"/>
   </relation>
 
   <relation id="2" version="2" changeset="3" user="foo" uid="1" visible="false" timestamp="2013-01-12T00:00:00Z"/>

--- a/test/relation_full.testcore/relation_1.case
+++ b/test/relation_full.testcore/relation_1.case
@@ -4,7 +4,7 @@ Request-Method: GET
 Request-URI: /api/0.6/relation/1/full
 ---
 Content-Type: application/xml; charset=utf-8
-!Content-Disposition: 
+!Content-Disposition:
 Status: 200 OK
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
@@ -17,7 +17,7 @@ Status: 200 OK
   <relation id="1" version="1" changeset="1" user="foo" uid="1" visible="true" timestamp="2012-12-01T00:00:00Z">
     <member type="node" ref="2" role="stop"/>
     <member type="way" ref="1" role="forward"/>
-    <tag k="type" v="route"/>
     <tag k="ref" v="W8"/>
+    <tag k="type" v="route"/>
   </relation>
 </osm>

--- a/test/relation_full.testcore/relation_4.case
+++ b/test/relation_full.testcore/relation_4.case
@@ -4,15 +4,15 @@ Request-Method: GET
 Request-URI: /api/0.6/relation/4/full
 ---
 Content-Type: application/xml; charset=utf-8
-!Content-Disposition: 
+!Content-Disposition:
 Status: 200 OK
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
   <relation id="1" version="1" changeset="1" user="foo" uid="1" visible="true" timestamp="2012-12-01T00:00:00Z">
     <member type="node" ref="2" role="stop"/>
     <member type="way" ref="1" role="forward"/>
-    <tag k="type" v="route"/>
     <tag k="ref" v="W8"/>
+    <tag k="type" v="route"/>
   </relation>
   <relation id="4" version="1" changeset="1" user="foo" uid="1" visible="true" timestamp="2013-01-13T00:00:00Z">
     <member type="relation" ref="1" role=""/>

--- a/test/test_apidb_backend_core.cpp
+++ b/test/test_apidb_backend_core.cpp
@@ -10,10 +10,12 @@
 #include "cgimap/process_request.hpp"
 #include "cgimap/time.hpp"
 #include "cgimap/util.hpp"
-#include "staticxml.hpp"
 
+#include <stdexcept>
 #include <fmt/core.h>
 
+#include <sys/time.h>
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <vector>
@@ -22,11 +24,56 @@
 
 #include "test_core_helper.hpp"
 #include "test_request.hpp"
+#include "xmlparser.hpp"
+#include "test_apidb_importer.hpp"
+
+#include "cgimap/backend/apidb/transaction_manager.hpp"
+
+#include "test_formatter.hpp"
+#include "test_database.hpp"
 
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
 
-namespace fs = std::filesystem;
+namespace {
+
+class DatabaseTestsFixture
+{
+public:
+  static void setTestDatabaseSchema(const std::filesystem::path& db_sql) {
+    test_db_sql = db_sql;
+  }
+
+protected:
+  DatabaseTestsFixture() = default;
+  inline static std::filesystem::path test_db_sql{"test/structure.sql"};
+  static test_database tdb;
+};
+
+test_database DatabaseTestsFixture::tdb{};
+
+struct CGImapListener : Catch::TestEventListenerBase, DatabaseTestsFixture {
+
+    using TestEventListenerBase::TestEventListenerBase; // inherit constructor
+
+    void testRunStarting( Catch::TestRunInfo const& testRunInfo ) override {
+      // load database schema when starting up tests
+      tdb.setup(test_db_sql);
+    }
+
+    void testCaseStarting( Catch::TestCaseInfo const& testInfo ) override {
+      tdb.testcase_starting();
+    }
+
+    void testCaseEnded( Catch::TestCaseStats const& testCaseStats ) override {
+      tdb.testcase_ended();
+    }
+};
+
+CATCH_REGISTER_LISTENER( CGImapListener )
+
+} // anonymous namespace
+
 
 fs::path test_directory{};
 
@@ -42,16 +89,14 @@ std::vector<fs::path> get_test_cases() {
   return test_cases;
 }
 
-TEST_CASE("Execute core test cases using external test data") {
+TEST_CASE_METHOD( DatabaseTestsFixture, "readonly_pgsql core", "[core][db]" ) {
 
   user_roles_t user_roles;
   oauth2_tokens oauth2_tokens;
   null_rate_limiter limiter;
   routes route;
-  po::variables_map vm;
 
-  SECTION("Execute test cases") {
-    // Note: Current Catch2 version does not support test cases with dynamic names
+  SECTION("Initialize test data") {
 
     if (test_directory.empty()) {
       FAIL("No test directory specified. Missing --test-directory command line option.");
@@ -72,16 +117,25 @@ TEST_CASE("Execute core test cases using external test data") {
     REQUIRE_NOTHROW(user_roles = get_user_roles(roles_file));
     REQUIRE_NOTHROW(oauth2_tokens = get_oauth2_tokens(oauth2_file));
 
+    auto database = parse_xml(data_file.c_str());
+
+    auto txn = tdb.get_data_update_factory()->get_default_transaction();
+    auto m = Transaction_Manager(*txn);
+
+    populate_database(m, *database, user_roles, oauth2_tokens);
+
+    m.commit();
+  }
+
+  SECTION("Execute test cases") {
+    // Note: Current Catch2 version does not support test cases with dynamic names
+
+    auto sel_factory = tdb.get_data_selection_factory();
+
     auto test_cases = get_test_cases();
     if(test_cases.empty()) {
       FAIL("No test cases found in the test directory.");
     }
-
-    // Prepare the backend with the test data
-    vm.try_emplace("file", po::variable_value(data_file.native(), false));
-
-    auto data_backend = make_staticxml_backend(user_roles, oauth2_tokens);
-    auto factory = data_backend->create(vm);
 
     // Execute actual test cases
     for (fs::path test_case : test_cases) {
@@ -95,7 +149,7 @@ TEST_CASE("Execute core test cases using external test data") {
       setup_request_headers(req, in);
 
       // execute the request
-      REQUIRE_NOTHROW(process_request(req, limiter, generator, route, *factory, nullptr));
+      REQUIRE_NOTHROW(process_request(req, limiter, generator, route, *sel_factory, nullptr));
 
       CAPTURE(req.body().str());
       REQUIRE_NOTHROW(check_response(in, req.buffer()));
@@ -103,23 +157,31 @@ TEST_CASE("Execute core test cases using external test data") {
   }
 }
 
-
 int main(int argc, char *argv[]) {
   Catch::Session session;
+
+  std::filesystem::path test_db_sql{ "test/structure.sql" };
 
   using namespace Catch::clara;
   auto cli =
       session.cli()
+      | Opt(test_db_sql,
+            "db-schema")
+            ["--db-schema"]
+      ("test database schema file")
       | Opt(test_directory,
-            "test-directory")
-            ["--test-directory"]
-      ("test case directory");
+        "test-directory")
+        ["--test-directory"]
+        ("test case directory");
 
   session.cli(cli);
 
   int returnCode = session.applyCommandLine(argc, argv);
   if (returnCode != 0)
     return returnCode;
+
+  if (!test_db_sql.empty())
+    DatabaseTestsFixture::setTestDatabaseSchema(test_db_sql);
 
   return session.run();
 }

--- a/test/test_apidb_importer.cpp
+++ b/test/test_apidb_importer.cpp
@@ -1,0 +1,970 @@
+/**
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * This file is part of openstreetmap-cgimap (https://github.com/zerebubuth/openstreetmap-cgimap/).
+ *
+ * Copyright (C) 2009-2024 by the CGImap developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include "test_apidb_importer.hpp"
+#include "cgimap/api06/id_version.hpp"
+#include "cgimap/backend/apidb/pqxx_string_traits.hpp"
+#include "cgimap/backend/apidb/quad_tile.hpp"
+#include "cgimap/backend/apidb/utils.hpp"
+
+#include <fmt/core.h>
+#include <iostream>
+#include <set>
+#include <vector>
+
+void copy_nodes_to_current_nodes(Transaction_Manager &m) {
+
+  m.exec(R"(
+
+    WITH max_versions AS (
+        SELECT node_id, MAX(version) AS max_version
+        FROM nodes
+        GROUP BY node_id
+    ),
+    S1 AS (
+      -- Insert into current_nodes
+      INSERT INTO current_nodes (id, latitude, longitude, changeset_id, visible, "timestamp", tile, version)
+      SELECT n.node_id, n.latitude, n.longitude, n.changeset_id, n.visible, n."timestamp", n.tile, n.version
+      FROM nodes n
+      JOIN max_versions mv
+      ON n.node_id = mv.node_id AND n.version = mv.max_version
+    ),
+    S2 AS (
+      -- Insert into current_node_tags
+      INSERT INTO current_node_tags (node_id, k, v)
+      SELECT nt.node_id, nt.k, nt.v
+      FROM node_tags nt
+      JOIN max_versions mv
+      ON nt.node_id = mv.node_id AND nt.version = mv.max_version )
+    SELECT TRUE;
+  )");
+}
+
+void copy_ways_to_current_ways(Transaction_Manager &m) {
+
+  m.exec(R"(
+
+  WITH max_versions AS (
+      SELECT way_id, MAX(version) AS max_version
+      FROM ways
+      GROUP BY way_id
+  ),
+  S1 AS (
+    -- Insert into current_ways
+    INSERT INTO current_ways (id, changeset_id, "timestamp", visible, version)
+    SELECT w.way_id, w.changeset_id, w."timestamp", w.visible, w.version
+    FROM ways w
+    JOIN max_versions mv ON w.way_id = mv.way_id AND w.version = mv.max_version
+  ),
+  S2 AS (
+    -- Insert into current_way_nodes
+    INSERT INTO current_way_nodes (way_id, node_id, sequence_id)
+    SELECT wn.way_id, wn.node_id, wn.sequence_id
+    FROM way_nodes wn
+    JOIN max_versions mv
+    ON wn.way_id = mv.way_id AND wn.version = mv.max_version
+  ),
+  S3 AS (
+    -- Insert into current_way_tags
+    INSERT INTO current_way_tags (way_id, k, v)
+    SELECT wt.way_id, wt.k, wt.v
+    FROM way_tags wt
+    JOIN max_versions mv
+    ON wt.way_id = mv.way_id AND wt.version = mv.max_version
+  )
+  SELECT TRUE;
+
+  )");
+
+}
+
+void copy_relations_to_current_relations(Transaction_Manager &m) {
+
+  m.exec(R"(
+
+    WITH max_versions AS (
+        SELECT relation_id, MAX(version) AS max_version
+        FROM relations
+        GROUP BY relation_id
+    ),
+    S1 AS (
+      -- Insert into current_relations
+      INSERT INTO current_relations (id, changeset_id, "timestamp", visible, version)
+      SELECT r.relation_id, r.changeset_id, r."timestamp", r.visible, r.version
+      FROM relations r
+      JOIN max_versions mv ON r.relation_id = mv.relation_id AND r.version = mv.max_version
+    ),
+    S2 AS (
+      -- Insert into current_relation_members
+      INSERT INTO current_relation_members (relation_id, member_type, member_id, member_role, sequence_id)
+      SELECT rm.relation_id, rm.member_type, rm.member_id, rm.member_role, rm.sequence_id
+      FROM relation_members rm
+      JOIN max_versions mv
+      ON rm.relation_id = mv.relation_id AND rm.version = mv.max_version
+    ),
+    S3 AS (
+      -- Insert into current_relation_tags
+      INSERT INTO current_relation_tags (relation_id, k, v)
+      SELECT rt.relation_id, rt.k, rt.v
+      FROM relation_tags rt
+      JOIN max_versions mv
+      ON rt.relation_id = mv.relation_id AND rt.version = mv.max_version
+    )
+    SELECT TRUE;
+  )");
+}
+
+void update_users(Transaction_Manager &m) {
+
+  m.exec(R"(
+
+    update users
+      set data_public = true,
+	  creation_time = res.created_at,
+	  tou_agreed = res.created_at,
+	  status = 'active',
+	  changesets_count = res.cs_count,
+	  terms_agreed = res.created_at,
+	  terms_seen = true
+      from (
+	  select user_id,
+		count(*) as cs_count,
+		min(created_at) as created_at
+	  from changesets
+	  group by user_id
+      ) as res
+      where users.id = res.user_id;
+     )");
+}
+
+void update_changesets(Transaction_Manager &m) {
+
+  m.exec(R"(
+
+    update changesets
+      set num_changes = res.num_changes
+      from (
+	select changeset_id, sum(changes) as num_changes from (
+		    select changeset_id, count(*) as changes from nodes group by changeset_id
+		    union all
+		    select changeset_id, count(*) as changes from ways group by changeset_id
+		    union all
+		    select changeset_id, count(*) as changes from relations group by changeset_id)
+	as sub
+	group by changeset_id)
+      as res
+    where changesets.id = res.changeset_id;
+
+     )");
+}
+
+void create_users(
+    Transaction_Manager &m,
+    const std::map<osm_user_id_t, std::string> &user_display_names) {
+
+  m.prepare("create_user",
+            "INSERT INTO users (id, email, pass_crypt, creation_time, "
+            "display_name, data_public) VALUES ($1, $2, $3, $4, $5, $6)");
+
+  for (const auto [id, name] : user_display_names) {
+    auto rc =
+        m.exec_prepared("create_user", id, fmt::format("user_{}@demo.abc", id),
+                        "", "2025-01-01T00:00:00Z", name, true);
+  }
+}
+
+void create_user_roles(Transaction_Manager &m, const user_roles_t &user_roles) {
+
+  if (user_roles.empty())
+    return;
+
+  m.prepare("user_roles_insert",
+            R"(
+        WITH tmp_user_role(id, user_id, role, created_at, updated_at, granter_id) AS (
+     SELECT * FROM
+     UNNEST( CAST($1 AS integer[]),
+       CAST($2 AS bigint[]),
+       CAST($3 AS user_role_enum[]),
+       CAST($4 AS timestamp without time zone[]),
+       CAST($5 AS timestamp without time zone[]),
+       CAST($6 AS bigint[])
+     )
+        )
+        INSERT INTO user_roles (id, user_id, role, created_at, updated_at, granter_id)
+        SELECT * FROM tmp_user_role
+    )"_M);
+
+  std::vector<int64_t> ids;
+  std::vector<osm_user_id_t> user_ids;
+  std::vector<std::string> roles;
+  std::vector<std::string> created_ats;
+  std::vector<std::string> updated_ats;
+  std::vector<osm_user_id_t> granter_ids;
+
+  int id_counter = 1;
+  auto current_time = "now()";
+
+  for (const auto &[user_id, rs] : user_roles) {
+    using enum osm_user_role_t;
+
+    for (const auto & role: rs) {
+      ids.emplace_back(id_counter++);
+      user_ids.emplace_back(user_id);
+      switch (role) {
+        case administrator:
+          roles.emplace_back("administrator");
+          break;
+        case importer:
+          roles.emplace_back("importer");
+          break;
+        case moderator:
+          roles.emplace_back("moderator");
+          break;
+      }
+      created_ats.emplace_back(current_time);
+      updated_ats.emplace_back(current_time);
+      granter_ids.emplace_back(1);
+    }
+  }
+
+  auto r = m.exec_prepared("user_roles_insert", ids, user_ids, roles, created_ats, updated_ats, granter_ids);
+
+}
+
+
+void create_oauth2_tokens(Transaction_Manager &m, const oauth2_tokens &oauth2_tokens) {
+  if (oauth2_tokens.empty())
+    return;
+
+  m.exec(R"(
+
+      INSERT INTO oauth_applications (id, owner_type, owner_id, name, uid, secret,
+      redirect_uri, scopes, confidential, created_at, updated_at) VALUES (3, 'User',
+      1, 'App 1', 'dHKmvGkmuoMjqhCNmTJkf-EcnA61Up34O1vOHwTSvU8',
+      '965136b8fb8d00e2faa2faaaed99c0ec10225518d0c8d9fb1d2af701e87eb68c',
+                  'http://demo.localhost:3000', 'write_api read_gpx', false,
+      '2021-04-12 17:53:30', '2021-04-12 17:53:30');
+  )");
+
+  m.prepare("oauth2_tokens_insert",
+            R"(
+        WITH tmp_token(id, resource_owner_id, application_id, token, refresh_token, expires_in, revoked_at, created_at, scopes) AS (
+     SELECT * FROM
+     UNNEST( CAST($1 AS integer[]),
+       CAST($2 AS integer[]),
+       CAST($3 AS integer[]),
+       CAST($4 AS text[]),
+       CAST($5 AS text[]),
+       CAST($6 AS integer[]),
+       CAST($7 AS timestamp without time zone[]),
+       CAST($8 AS timestamp without time zone[]),
+       CAST($9 AS text[])
+     )
+        )
+        INSERT INTO oauth_access_tokens (id, resource_owner_id, application_id, token, refresh_token, expires_in, revoked_at, created_at, scopes)
+        SELECT * FROM tmp_token
+    )"_M);
+
+  std::vector<int64_t> ids;
+  std::vector<int64_t> resource_owner_ids;
+  std::vector<int64_t> application_ids;
+  std::vector<std::string> tokens;
+  std::vector<std::string> refresh_tokens;
+  std::vector<int64_t> expires_ins;
+  std::vector<std::string> revoked_ats;
+  std::vector<std::string> created_ats;
+  std::vector<std::string> scopes;
+
+  int64_t counter = 1;
+
+  for (const auto &[token, detail] : oauth2_tokens) {
+    ids.emplace_back(counter++);
+    resource_owner_ids.emplace_back(1);
+    application_ids.emplace_back(3);
+    tokens.emplace_back(token);
+    refresh_tokens.emplace_back("");
+    expires_ins.emplace_back(86400);
+    revoked_ats.emplace_back(detail.revoked ? "now()" : "");
+    created_ats.emplace_back("now()");
+    scopes.emplace_back("");
+  }
+
+  auto r = m.exec_prepared("oauth2_tokens_insert", ids, resource_owner_ids, application_ids, tokens, refresh_tokens, expires_ins, revoked_ats, created_ats, scopes);
+}
+
+
+void create_changesets(Transaction_Manager &m,
+                       const decltype(database::m_changesets) changesets) {
+
+  if (!changesets.empty()) {
+
+    {
+      m.prepare("changesets_insert",
+                R"(
+	      WITH tmp_changeset(id, user_id, created_at, closed_at, min_lat, max_lat, min_lon, max_lon, num_changes) AS (
+		 SELECT * FROM
+		 UNNEST( CAST($1 AS bigint[]),
+			 CAST($2 AS bigint[]),
+			 CAST($3 AS timestamp without time zone[]),
+			 CAST($4 AS timestamp without time zone[]),
+			 CAST($5 AS integer[]),
+			 CAST($6 AS integer[]),
+			 CAST($7 AS integer[]),
+			 CAST($8 AS integer[]),
+			 CAST($9 AS integer[])
+		 )
+	      )
+	      INSERT INTO changesets (id, user_id, created_at, closed_at, min_lat, max_lat, min_lon, max_lon, num_changes)
+	      SELECT * FROM tmp_changeset
+	  )"_M);
+
+      std::vector<osm_changeset_id_t> ids;
+      std::vector<osm_user_id_t> user_ids;
+      std::vector<std::string> created_ats;
+      std::vector<std::string> closed_ats;
+      std::vector<int64_t> min_lats;
+      std::vector<int64_t> max_lats;
+      std::vector<int64_t> min_lons;
+      std::vector<int64_t> max_lons;
+      std::vector<int64_t> num_changes;
+
+      for (const auto &[id, changeset] : changesets) {
+        if (!(changeset.m_info.bounding_box))
+          continue;
+
+        ids.emplace_back(id);
+        user_ids.emplace_back(changeset.m_info.uid.value_or(0));
+        created_ats.emplace_back(changeset.m_info.created_at);
+        closed_ats.emplace_back(changeset.m_info.closed_at);
+        min_lats.emplace_back(static_cast<int64_t>(
+            round(changeset.m_info.bounding_box->minlat *
+                  global_settings::get_scale())));
+        max_lats.emplace_back(
+            static_cast<int64_t>(round(changeset.m_info.bounding_box->maxlat *
+                                       global_settings::get_scale())));
+        min_lons.emplace_back(
+            static_cast<int64_t>(round(changeset.m_info.bounding_box->minlon *
+                                       global_settings::get_scale())));
+        max_lons.emplace_back(
+            static_cast<int64_t>(round(changeset.m_info.bounding_box->maxlon *
+                                       global_settings::get_scale())));
+        num_changes.emplace_back(changeset.m_info.num_changes);
+      }
+
+      auto r = m.exec_prepared("changesets_insert", ids, user_ids, created_ats,
+                               closed_ats, min_lats, max_lats, min_lons,
+                               max_lons, num_changes);
+    }
+
+    {
+
+      m.prepare("changesets_insert_nobbox",
+                R"(
+	      WITH tmp_changeset(id, user_id, created_at, closed_at, num_changes) AS (
+		 SELECT * FROM
+		 UNNEST( CAST($1 AS bigint[]),
+			 CAST($2 AS bigint[]),
+			 CAST($3 AS timestamp without time zone[]),
+			 CAST($4 AS timestamp without time zone[]),
+			 CAST($5 AS integer[])
+		 )
+	      )
+	      INSERT INTO changesets (id, user_id, created_at, closed_at, num_changes)
+	      SELECT * FROM tmp_changeset
+	  )"_M);
+
+      std::vector<osm_changeset_id_t> ids;
+      std::vector<osm_user_id_t> user_ids;
+      std::vector<std::string> created_ats;
+      std::vector<std::string> closed_ats;
+      std::vector<int64_t> num_changes;
+
+      for (const auto &[id, changeset] : changesets) {
+        if ((changeset.m_info.bounding_box))
+          continue;
+
+        ids.emplace_back(id);
+        user_ids.emplace_back(changeset.m_info.uid.value_or(0));
+        created_ats.emplace_back(changeset.m_info.created_at);
+        closed_ats.emplace_back(changeset.m_info.closed_at);
+        num_changes.emplace_back(changeset.m_info.num_changes);
+      }
+
+      auto r = m.exec_prepared("changesets_insert_nobbox", ids, user_ids,
+                               created_ats, closed_ats, num_changes);
+    }
+  }
+}
+
+void create_changeset_tags(Transaction_Manager &m, const decltype(database::m_changesets) changesets) {
+
+  if (changesets.empty())
+    return;
+
+  m.prepare("changeset_tags_insert",
+            R"(
+        WITH tmp_tag(changeset_id, k, v) AS (
+     SELECT * FROM
+     UNNEST( CAST($1 AS bigint[]),
+       CAST($2 AS character varying[]),
+       CAST($3 AS character varying[])
+     )
+        )
+        INSERT INTO changeset_tags (changeset_id, k, v)
+        SELECT * FROM tmp_tag
+    )"_M);
+
+  std::vector<osm_changeset_id_t> changeset_ids;
+  std::vector<std::string> keys;
+  std::vector<std::string> values;
+
+  for (const auto &[changeset_id, changeset] : changesets) {
+    for (const auto &[key, value] : changeset.m_tags) {
+      changeset_ids.emplace_back(changeset_id);
+      keys.emplace_back(key);
+      values.emplace_back(value);
+    }
+  }
+
+  auto r = m.exec_prepared("changeset_tags_insert", changeset_ids, keys, values);
+
+}
+
+void create_changeset_discussions(Transaction_Manager &m, const decltype(database::m_changesets) changesets) {
+
+  if (changesets.empty())
+    return;
+
+  m.prepare("changeset_comments_insert",
+            R"(
+        WITH tmp_comment(id, changeset_id, author_id, body, created_at, visible) AS (
+     SELECT * FROM
+     UNNEST( CAST($1 AS integer[]),
+       CAST($2 AS bigint[]),
+       CAST($3 AS bigint[]),
+       CAST($4 AS text[]),
+       CAST($5 AS timestamp without time zone[]),
+       CAST($6 AS boolean[])
+     )
+        )
+        INSERT INTO changeset_comments (id, changeset_id, author_id, body, created_at, visible)
+        SELECT * FROM tmp_comment
+    )"_M);
+
+  std::vector<int64_t> ids;
+  std::vector<osm_changeset_id_t> changeset_ids;
+  std::vector<osm_user_id_t> author_ids;
+  std::vector<std::string> bodies;
+  std::vector<std::string> created_ats;
+  std::vector<std::string> visibles;
+
+  for (const auto &[changeset_id, changeset] : changesets) {
+    for (const auto &comment : changeset.m_comments) {
+      ids.emplace_back(comment.id);
+      changeset_ids.emplace_back(changeset_id);
+      author_ids.emplace_back(comment.author_id);
+      bodies.emplace_back(comment.body);
+      created_ats.emplace_back(comment.created_at);
+      visibles.emplace_back("true");
+    }
+  }
+
+  auto r = m.exec_prepared("changeset_comments_insert", ids, changeset_ids, author_ids, bodies, created_ats, visibles);
+
+
+}
+
+void changeset_tags_insert(Transaction_Manager &m, osm_changeset_id_t changeset,
+                           std::map<std::string, std::string> &tags) {
+  if (tags.empty())
+    return;
+
+  m.prepare("changeset_tags_insert",
+            R"(
+
+	      WITH tmp_tag(changeset_id, k, v) AS (
+		 SELECT * FROM
+		 UNNEST( CAST($1 AS bigint[]),
+			 CAST($2 AS character varying[]),
+			 CAST($3 AS character varying[])
+		 )
+	      )
+	      INSERT INTO changeset_tags (changeset_id, k, v)
+	      SELECT * FROM tmp_tag
+	  )"_M);
+
+  std::vector<osm_changeset_id_t> cs;
+  std::vector<std::string> ks;
+  std::vector<std::string> vs;
+
+  for (const auto &[key, value] : tags) {
+    cs.emplace_back(changeset);
+    ks.emplace_back(escape(key));
+    vs.emplace_back(escape(value));
+  }
+
+  auto r = m.exec_prepared("changeset_tags_insert", cs, ks, vs);
+}
+
+void nodes_insert(Transaction_Manager &m,
+                          const decltype(database::m_nodes) &nodes) {
+  if (nodes.empty())
+    return;
+
+  m.prepare("nodes_insert",
+            R"(
+	      WITH tmp_node(node_id, latitude, longitude, changeset_id, visible, "timestamp", tile, version) AS (
+		 SELECT * FROM
+		 UNNEST( CAST($1 AS bigint[]),
+			 CAST($2 AS integer[]),
+			 CAST($3 AS integer[]),
+			 CAST($4 AS bigint[]),
+			 CAST($5 AS bool[]),
+			 CAST($6 AS timestamp without time zone[]),
+			 CAST($7 AS bigint[]),
+			 CAST($8 AS bigint[])
+		 )
+	      )
+	      INSERT INTO nodes (node_id, latitude, longitude, changeset_id, visible, "timestamp", tile, version)
+	      SELECT * FROM tmp_node
+	  )"_M);
+
+  std::vector<osm_nwr_id_t> ids;
+  std::vector<int64_t> latitudes;
+  std::vector<int64_t> longitudes;
+  std::vector<osm_changeset_id_t> changeset_ids;
+  std::vector<std::string> visibles;
+  std::vector<std::string> timestamps;
+  std::vector<uint64_t> tiles;
+  std::vector<osm_version_t> versions;
+
+  for (const auto &[id_version, node] : nodes) {
+    ids.emplace_back(id_version.id);
+    latitudes.emplace_back(
+        static_cast<int64_t>(round(node.m_lat * global_settings::get_scale())));
+    longitudes.emplace_back(
+        static_cast<int64_t>(round(node.m_lon * global_settings::get_scale())));
+    changeset_ids.emplace_back(node.m_info.changeset);
+    visibles.emplace_back(node.m_info.visible ? "true" : "false");
+    timestamps.emplace_back(node.m_info.timestamp);
+    tiles.emplace_back(xy2tile(lon2x(node.m_lon), lat2y(node.m_lat)));
+    versions.emplace_back(id_version.version.value_or(1));
+  }
+
+  auto r =
+      m.exec_prepared("nodes_insert", ids, latitudes, longitudes,
+                      changeset_ids, visibles, timestamps, tiles, versions);
+}
+
+void ways_insert(Transaction_Manager &m,
+                         const decltype(database::m_ways) &ways) {
+
+  if (ways.empty())
+    return;
+
+  m.prepare("ways_insert",
+            R"(
+				WITH tmp_way(way_id, changeset_id, "timestamp", visible, version) AS (
+			SELECT * FROM
+			UNNEST( CAST($1 AS bigint[]),
+				CAST($2 AS bigint[]),
+				CAST($3 AS timestamp without time zone[]),
+				CAST($4 AS bool[]),
+				CAST($5 AS bigint[])
+			)
+				)
+				INSERT INTO ways (way_id, changeset_id, "timestamp", visible, version)
+				SELECT * FROM tmp_way
+		)"_M);
+
+  std::vector<osm_nwr_id_t> ids;
+  std::vector<osm_changeset_id_t> changeset_ids;
+  std::vector<std::string> timestamps;
+  std::vector<std::string> visibles;
+  std::vector<osm_version_t> versions;
+
+  for (const auto &[id_version, way] : ways) {
+    ids.emplace_back(id_version.id);
+    changeset_ids.emplace_back(way.m_info.changeset);
+    timestamps.emplace_back(way.m_info.timestamp);
+    visibles.emplace_back(way.m_info.visible ? "true" : "false");
+    versions.emplace_back(id_version.version.value_or(1));
+  }
+
+  auto r = m.exec_prepared("ways_insert", ids, changeset_ids,
+                           timestamps, visibles, versions);
+}
+
+void relations_insert(Transaction_Manager &m,
+                              const decltype(database::m_relations) &rels) {
+
+  if (rels.empty())
+    return;
+
+  m.prepare("relations_insert",
+            R"(
+		WITH tmp_relation(relation_id, changeset_id, "timestamp", visible, version) AS (
+		 SELECT * FROM
+		 UNNEST( CAST($1 AS bigint[]),
+			 CAST($2 AS bigint[]),
+			 CAST($3 AS timestamp without time zone[]),
+			 CAST($4 AS bool[]),
+			 CAST($5 AS bigint[])
+		 )
+		)
+		INSERT INTO relations (relation_id, changeset_id, "timestamp", visible, version)
+		SELECT * FROM tmp_relation
+		)"_M);
+
+  std::vector<osm_nwr_id_t> ids;
+  std::vector<osm_changeset_id_t> changeset_ids;
+  std::vector<std::string> timestamps;
+  std::vector<std::string> visibles;
+  std::vector<osm_version_t> versions;
+
+  for (const auto &[id_version, relation] : rels) {
+    ids.emplace_back(id_version.id);
+    changeset_ids.emplace_back(relation.m_info.changeset);
+    timestamps.emplace_back(relation.m_info.timestamp);
+    visibles.emplace_back(relation.m_info.visible ? "true" : "false");
+    versions.emplace_back(id_version.version.value_or(1));
+  }
+
+  auto r = m.exec_prepared("relations_insert", ids, changeset_ids,
+                           timestamps, visibles, versions);
+}
+
+void way_nodes_insert(Transaction_Manager &m,
+                              const decltype(database::m_ways) &ways) {
+
+  if (ways.empty())
+    return;
+
+  m.prepare("way_nodes_insert",
+            R"(
+		WITH tmp_way_node(way_id, node_id, version, sequence_id) AS (
+		 SELECT * FROM
+		 UNNEST( CAST($1 AS bigint[]),
+			 CAST($2 AS bigint[]),
+       CAST($3 AS bigint[]),
+			 CAST($4 AS bigint[])
+		 )
+		)
+		INSERT INTO way_nodes (way_id, node_id, version, sequence_id)
+		SELECT * FROM tmp_way_node
+		)"_M);
+
+  std::vector<osm_nwr_id_t> way_ids;
+  std::vector<osm_nwr_id_t> node_ids;
+  std::vector<int64_t> versions;
+  std::vector<int64_t> sequence_ids;
+
+  for (const auto &[id_version, way] : ways) {
+    int64_t sequence_id = 1;
+    for (const auto &node_id : way.m_nodes) {
+      way_ids.emplace_back(id_version.id);
+      node_ids.emplace_back(node_id);
+      versions.emplace_back(id_version.version.value_or(1));
+      sequence_ids.emplace_back(sequence_id++);
+    }
+  }
+
+  auto r = m.exec_prepared("way_nodes_insert", way_ids, node_ids,
+                           versions, sequence_ids);
+}
+
+void node_tags_insert(Transaction_Manager &m,
+                              const decltype(database::m_nodes) &nodes) {
+  if (nodes.empty())
+    return;
+
+  m.prepare("node_tags_insert",
+            R"(
+
+	      WITH tmp_tag(node_id, version, k, v) AS (
+		 SELECT * FROM
+		 UNNEST( CAST($1 AS bigint[]),
+       CAST($2 AS bigint[]),
+			 CAST($3 AS character varying[]),
+			 CAST($4 AS character varying[])
+		 )
+	      )
+	      INSERT INTO node_tags (node_id, version, k, v)
+	      SELECT * FROM tmp_tag
+	  )"_M);
+
+  std::vector<osm_nwr_id_t> ns;
+  std::vector<int64_t> versions;
+  std::vector<std::string> ks;
+  std::vector<std::string> vs;
+
+  for (const auto &node : nodes) {
+    for (const auto &[key, value] : node.second.m_tags) {
+      ns.emplace_back(node.first.id);
+      versions.emplace_back(node.first.version.value_or(1));
+      ks.emplace_back(escape(key));
+      vs.emplace_back(escape(value));
+    }
+  }
+
+  auto r = m.exec_prepared("node_tags_insert", ns, versions, ks, vs);
+}
+
+void way_tags_insert(Transaction_Manager &m,
+                             const decltype(database::m_ways) &ways) {
+
+  if (ways.empty())
+    return;
+
+  m.prepare("way_tags_insert",
+            R"(
+
+	      WITH tmp_tag(way_id, k, v, version) AS (
+		 SELECT * FROM
+		 UNNEST( CAST($1 AS bigint[]),
+			 CAST($2 AS character varying[]),
+			 CAST($3 AS character varying[]),
+       CAST($4 AS bigint[])
+		 )
+	      )
+	      INSERT INTO way_tags (way_id, k, v, version)
+	      SELECT * FROM tmp_tag
+	  )"_M);
+
+  std::vector<osm_nwr_id_t> ws;
+  std::vector<std::string> ks;
+  std::vector<std::string> vs;
+  std::vector<int64_t> versions;
+
+  for (const auto &way : ways) {
+    for (const auto &[key, value] : way.second.m_tags) {
+      ws.emplace_back(way.first.id);
+      ks.emplace_back(escape(key));
+      vs.emplace_back(escape(value));
+      versions.emplace_back(way.first.version.value_or(1));
+    }
+  }
+
+  auto r = m.exec_prepared("way_tags_insert", ws, ks, vs, versions);
+}
+
+void relation_tags_insert(
+    Transaction_Manager &m, const decltype(database::m_relations) &relations) {
+  if (relations.empty())
+    return;
+
+  m.prepare("relation_tags_insert",
+            R"(
+
+	      WITH tmp_tag(relation_id, k, v, version) AS (
+		 SELECT * FROM
+		UNNEST( CAST($1 AS bigint[]),
+			 CAST($2 AS character varying[]),
+			 CAST($3 AS character varying[]),
+			 CAST($4 AS bigint[])
+		 )
+	      )
+	      INSERT INTO relation_tags (relation_id, k, v, version)
+	      SELECT * FROM tmp_tag
+	  )"_M);
+
+  std::vector<osm_nwr_id_t> rs;
+  std::vector<std::string> ks;
+  std::vector<std::string> vs;
+  std::vector<int64_t> versions;
+
+  for (const auto &relation : relations) {
+    for (const auto &[key, value] : relation.second.m_tags) {
+      rs.emplace_back(relation.first.id);
+      ks.emplace_back(escape(key));
+      vs.emplace_back(escape(value));
+      versions.emplace_back(relation.first.version.value_or(1));
+    }
+  }
+
+  auto r = m.exec_prepared("relation_tags_insert", rs, ks, vs, versions);
+}
+
+std::string convert_element_type_name(element_type elt) noexcept {
+
+  using enum element_type;
+  switch (elt) {
+  case node:
+    return "Node";
+  case way:
+    return "Way";
+  case relation:
+    return "Relation";
+  }
+  return "";
+}
+
+void relation_members_insert(
+    Transaction_Manager &m, const decltype(database::m_relations) &relations) {
+  if (relations.empty())
+    return;
+
+  m.prepare("relation_members_insert",
+            R"(
+
+	WITH tmp_relation_member(relation_id, member_type, member_id, member_role, version, sequence_id) AS (
+	SELECT * FROM
+	UNNEST( CAST($1 AS bigint[]),
+		CAST($2 AS nwr_enum[]),
+		CAST($3 AS bigint[]),
+		CAST($4 AS character varying[]),
+    CAST($5 AS bigint[]),
+		CAST($6 AS integer[])
+	)
+	)
+	INSERT INTO relation_members (relation_id, member_type, member_id, member_role, version, sequence_id)
+	SELECT * FROM tmp_relation_member
+	)"_M);
+
+  std::vector<osm_nwr_id_t> relation_ids;
+  std::vector<std::string> member_types;
+  std::vector<osm_nwr_id_t> member_ids;
+  std::vector<std::string> member_roles;
+  std::vector<int64_t> versions;
+  std::vector<int64_t> sequence_ids;
+
+  for (const auto &[id_version, relation] : relations) {
+    int sequence_id = 1;
+    for (const auto &member : relation.m_members) {
+      relation_ids.emplace_back(id_version.id);
+      member_types.emplace_back(convert_element_type_name(member.type));
+      member_ids.emplace_back(member.ref);
+      member_roles.emplace_back(escape(member.role));
+      versions.emplace_back(id_version.version.value_or(1));
+      sequence_ids.emplace_back(sequence_id++);
+    }
+  }
+
+  auto r =
+      m.exec_prepared("relation_members_insert", relation_ids,
+                      member_types, member_ids, member_roles, versions, sequence_ids);
+}
+
+
+
+void populate_database(Transaction_Manager &m, const database &db,
+                       const user_roles_t &user_roles,
+                       const oauth2_tokens &oauth2_tokens) {
+
+  std::map<osm_user_id_t, std::string> user_display_names;
+  std::map<osm_changeset_id_t, int> changeset_object_counts;
+  std::map<osm_changeset_id_t, osm_user_id_t> changeset_uid;
+  std::set<osm_redaction_id_t> redaction_ids;
+
+  auto process_info = [&](const auto &info) {
+    user_display_names[info.uid.value_or(0)] =
+        info.display_name.value_or("");
+    changeset_object_counts[info.changeset]++;
+    changeset_uid[info.changeset] = info.uid.value_or(0);
+    if (info.redaction)
+      redaction_ids.insert(*info.redaction);
+  };
+
+  for (const auto &[id, node] : db.m_nodes) {
+    process_info(node.m_info);
+  }
+
+  for (const auto &[id, way] : db.m_ways) {
+    process_info(way.m_info);
+  }
+
+  for (const auto &[id, relation] : db.m_relations) {
+    process_info(relation.m_info);
+  }
+
+  for (const auto &[id, changeset] : db.m_changesets) {
+    user_display_names[changeset.m_info.uid.value_or(0)] = changeset.m_info.display_name.value_or("");
+  }
+
+  for (const auto &[user_id, _] : user_roles) {
+    if (!user_display_names.contains(user_id)) {
+      user_display_names[user_id] = "";
+    }
+  }
+
+  // Create users
+  create_users(m, user_display_names);
+
+  create_user_roles(m, user_roles);
+
+  create_oauth2_tokens(m, oauth2_tokens);
+
+  // Create changesets
+  auto changesets = db.m_changesets;
+
+  // create dummy changesets if no changesets available
+  if (changesets.empty()) {
+    for (const auto & cs : changeset_object_counts) {
+      changeset c;
+      c.m_info.created_at = "2025-01-01T00:00:00Z";
+      c.m_info.closed_at = "2025-01-01T01:00:00Z";
+      c.m_info.uid = changeset_uid[cs.first];
+      c.m_info.num_changes = cs.second;
+      changesets[cs.first] = c;
+    }
+  }
+  create_changesets(m, changesets);
+  create_changeset_tags(m, changesets);
+  create_changeset_discussions(m, changesets);
+
+  // Insert nodes
+  nodes_insert(m, db.m_nodes);
+  node_tags_insert(m, db.m_nodes);
+
+  // Insert ways
+  ways_insert(m, db.m_ways);
+  way_tags_insert(m, db.m_ways);
+  way_nodes_insert(m, db.m_ways);
+
+  // Insert relations
+  relations_insert(m, db.m_relations);
+  relation_tags_insert(m, db.m_relations);
+  relation_members_insert(m, db.m_relations);
+
+  // Copy latest object version to current table
+  copy_nodes_to_current_nodes(m);
+  copy_ways_to_current_ways(m);
+  copy_relations_to_current_relations(m);
+
+  // Update stats for user and changesets
+  update_users(m);
+  update_changesets(m);
+}
+
+/*
+tdb.run_sql(R"(
+
+ INSERT INTO oauth_applications (id, owner_type, owner_id, name, uid, secret,
+redirect_uri, scopes, confidential, created_at, updated_at) VALUES (3, 'User',
+1, 'App 1', 'dHKmvGkmuoMjqhCNmTJkf-EcnA61Up34O1vOHwTSvU8',
+'965136b8fb8d00e2faa2faaaed99c0ec10225518d0c8d9fb1d2af701e87eb68c',
+            'http://demo.localhost:3000', 'write_api read_gpx', false,
+'2021-04-12 17:53:30', '2021-04-12 17:53:30');
+
+ INSERT INTO oauth_applications (id, owner_type, owner_id, name, uid, secret,
+redirect_uri, scopes, confidential, created_at, updated_at) VALUES (4, 'User',
+2, 'App 2', 'WNr9KjjzA9uNCXXBHG1AReR2jdottwlKYOz7CLgjUAk',
+'cdd6f17bc32eb96b33839db59ae5873777e95864cd936ae445f2dedec8787212',
+            'http://localhost:3000/demo', 'write_prefs write_diary', true,
+'2021-04-13 18:59:11', '2021-04-13 18:59:11');
+
+ INSERT INTO public.oauth_access_tokens (id, resource_owner_id, application_id,
+token, refresh_token, expires_in, revoked_at, created_at, scopes,
+previous_refresh_token) VALUES (67, 1, 3,
+'4f41f2328befed5a33bcabdf14483081c8df996cbafc41e313417776e8fafae8', NULL, NULL,
+NULL, '2021-04-14 19:38:21', 'write_api', '');
+
+
+)");
+*/

--- a/test/test_apidb_importer.hpp
+++ b/test/test_apidb_importer.hpp
@@ -1,0 +1,21 @@
+/**
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * This file is part of openstreetmap-cgimap (https://github.com/zerebubuth/openstreetmap-cgimap/).
+ *
+ * Copyright (C) 2009-2024 by the CGImap developer community.
+ * For a full list of authors see the git log.
+ */
+
+#ifndef TEST_TEST_APIDB_IMPORTER_HPP
+#define TEST_TEST_APIDB_IMPORTER_HPP
+
+#include "cgimap/backend/apidb/transaction_manager.hpp"
+#include "xmlparser.hpp"
+#include "test_types.hpp"
+
+void populate_database(Transaction_Manager &m, const database &db,
+                       const user_roles_t &user_roles,
+                       const oauth2_tokens &oauth2_tokens);
+
+#endif

--- a/test/test_apidb_importer.hpp
+++ b/test/test_apidb_importer.hpp
@@ -14,7 +14,7 @@
 #include "xmlparser.hpp"
 #include "test_types.hpp"
 
-void populate_database(Transaction_Manager &m, const database &db,
+void populate_database(Transaction_Manager &m, const xmlparser::database &db,
                        const user_roles_t &user_roles,
                        const oauth2_tokens &oauth2_tokens);
 

--- a/test/test_database.cpp
+++ b/test/test_database.cpp
@@ -156,35 +156,6 @@ void test_database::testcase_ended() {
   txn_owner_readwrite.reset();
 }
 
-template <typename Func>
-void test_database::run(Func func) {
-
-  try {
-    // clear out database before using it!
-    testcase_starting();
-
-    func(*this);
-
-  } catch (const std::exception &e) {
-    throw std::runtime_error(fmt::format("{}", e.what()));
-  }
-  testcase_ended();
-}
-
-template <typename Func>
-void test_database::run_update(Func func) {
-
-  try {
-    // clear out database before using it!
-    testcase_starting();
-
-    func(*this);
-  } catch (const std::exception &e) {
-    throw std::runtime_error(fmt::format("{}, in update", e.what()));
-  }
-  testcase_ended();
-}
-
 test_database::setup_error::setup_error(std::string str)
   : m_str(std::move(str)) {
 }

--- a/test/test_database.hpp
+++ b/test/test_database.hpp
@@ -55,18 +55,6 @@ struct test_database {
   // create table structure and fill with fake data.
   void setup(const std::filesystem::path& sql_file = "test/structure.sql");
 
-  // run a test. func will be called twice - once with each of a
-  // writeable and readonly data selection available from the
-  // test_database's get_data_selection() call. the func should
-  // do its own testing - the run method here is just plumbing.
-  template <typename Func>
-  void run(Func func);
-
-  // run a database update test in write mode. test will be
-  // executed exactly once only.
-  template <typename Func>
-  void run_update(Func func);
-
   // return a data selection factory pointing at the current database
   [[nodiscard]] std::shared_ptr<data_selection::factory> get_data_selection_factory() const;
 

--- a/test/way_full.testcore/data.osm
+++ b/test/way_full.testcore/data.osm
@@ -2,9 +2,9 @@
 <osm version="0.6" generator="by hand">
   <node id="1" version="1" changeset="1" lat="0.0" lon="0.0" user="foo" uid="1" visible="true" timestamp="2012-09-25T00:00:00Z"/>
   <node id="2" version="8" changeset="3" lat="1.0" lon="1.0" user="foo" uid="1" visible="true" timestamp="2012-10-01T00:00:00Z">
-    <tag k="foo" v="bar1"/>
     <tag k="bar" v="bar2"/>
     <tag k="baz" v="bar3"/>
+    <tag k="foo" v="bar1"/>
   </node>
   <node id="3" version="2" changeset="3" lat="0.0" lon="0.0" user="foo" uid="1" visible="true" timestamp="2012-09-25T00:01:00Z"/>
 

--- a/test/way_full.testcore/way_1.case
+++ b/test/way_full.testcore/way_1.case
@@ -2,15 +2,15 @@ Request-Method: GET
 Request-URI: /api/0.6/way/1/full
 ---
 Content-Type: application/xml; charset=utf-8
-!Content-Disposition: 
+!Content-Disposition:
 Status: 200 OK
 ---
 <osm version="0.6" generator="***" copyright="***" attribution="***" license="***">
   <node id="1" version="1" changeset="1" lat="0.0000000" lon="0.0000000" user="foo" uid="1" visible="true" timestamp="2012-09-25T00:00:00Z"/>
   <node id="2" version="8" changeset="3" lat="1.0000000" lon="1.0000000" user="foo" uid="1" visible="true" timestamp="2012-10-01T00:00:00Z">
-    <tag k="foo" v="bar1"/>
     <tag k="bar" v="bar2"/>
     <tag k="baz" v="bar3"/>
+    <tag k="foo" v="bar1"/>
   </node>
   <node id="3" version="2" changeset="3" lat="0.0000000" lon="0.0000000" user="foo" uid="1" visible="true" timestamp="2012-09-25T00:01:00Z"/>
   <way id="1" version="1" changeset="1" user="foo" uid="1" visible="true" timestamp="2012-12-01T00:00:00Z">

--- a/test/xmlparser.cpp
+++ b/test/xmlparser.cpp
@@ -20,6 +20,7 @@
 #include <fmt/core.h>
 #include <libxml/parser.h>
 
+namespace xmlparser {
 
 template <typename T>
 std::optional<T> opt_attribute(std::string_view name, const xmlChar **attributes) {
@@ -84,7 +85,7 @@ void parse_changeset_info(changeset_info &info, const xmlChar **attributes) {
 }
 
 struct xml_parser {
-  explicit xml_parser(database *db)
+  explicit xml_parser(xmlparser::database *db)
     : m_db(db) {}
 
   static void start_element(void *ctx, const xmlChar *name_cstr,
@@ -214,12 +215,12 @@ struct xml_parser {
     throw std::runtime_error(fmt::format("XML ERROR: {}", buffer));
   }
 
-  database *m_db = nullptr;
-  node *m_cur_node = nullptr;
-  way *m_cur_way = nullptr;
-  relation *m_cur_rel = nullptr;
+  xmlparser::database *m_db = nullptr;
+  xmlparser::node *m_cur_node = nullptr;
+  xmlparser::way *m_cur_way = nullptr;
+  xmlparser::relation *m_cur_rel = nullptr;
   tags_t *m_cur_tags = nullptr;
-  changeset *m_cur_changeset = nullptr;
+  xmlparser::changeset *m_cur_changeset = nullptr;
   bool m_in_text = false;
 };
 
@@ -234,10 +235,12 @@ xmlSAXHandler create_xml_sax_handler() {
   return handler;
 }
 
-std::unique_ptr<database> parse_xml(const char *filename) {
-  xmlSAXHandler handler = create_xml_sax_handler();
-  auto db = std::make_unique<database>();
-  xml_parser parser(db.get());
+} // namespace xmlparser
+
+std::unique_ptr<xmlparser::database> parse_xml(const char *filename) {
+  xmlSAXHandler handler = xmlparser::create_xml_sax_handler();
+  auto db = std::make_unique<xmlparser::database>();
+  xmlparser::xml_parser parser(db.get());
   int status = xmlSAXUserParseFile(&handler, &parser, filename);
   if (status != 0) {
     const auto err = xmlGetLastError();
@@ -250,10 +253,10 @@ std::unique_ptr<database> parse_xml(const char *filename) {
   return db;
 }
 
-std::unique_ptr<database> parse_xml_from_string(const std::string &payload) {
-  xmlSAXHandler handler = create_xml_sax_handler();
-  auto db = std::make_unique<database>();
-  xml_parser parser(db.get());
+std::unique_ptr<xmlparser::database> parse_xml_from_string(const std::string &payload) {
+  xmlSAXHandler handler = xmlparser::create_xml_sax_handler();
+  auto db = std::make_unique<xmlparser::database>();
+  xmlparser::xml_parser parser(db.get());
   int status = xmlSAXUserParseMemory(&handler, &parser, payload.c_str(), payload.size());
   if (status != 0) {
     const auto err = xmlGetLastError();

--- a/test/xmlparser.hpp
+++ b/test/xmlparser.hpp
@@ -18,6 +18,8 @@
 
 using api06::id_version;
 
+namespace xmlparser {
+
 struct node {
   element_info m_info;
   double m_lon;
@@ -50,7 +52,9 @@ struct database {
   std::map<id_version, relation> m_relations;
 };
 
-std::unique_ptr<database> parse_xml(const char *filename);
-std::unique_ptr<database> parse_xml_from_string(const std::string &payload);
+} // namespace xmlparser
+
+std::unique_ptr<xmlparser::database> parse_xml(const char *filename);
+std::unique_ptr<xmlparser::database> parse_xml_from_string(const std::string &payload);
 
 #endif


### PR DESCRIPTION
Like test_core, but serving data from real database.

Addresses issue in #487

### Fixes:

* Tags are now sorted (previously, the order was undefined, resulting in sporadic test failures). Some test cases had to be fixed due to this change. staticxml serves tags in the exact sequence as in data.osm, tags are stored in a vector and are not sorted afterwards.
* Sorting has been fixed for mixed current/historic scenarios, like api/0.6/nodes?nodes=3v1,3 

### Enhancements:

* Continued catch2 migration, execute each unit test file as dedicated SECTION to execute as many tests as possible, even if one of them fails.
* Lambda callback function in readonly_pgsql has been removed, because it is no longer needed now.
* Removed two obsolete run* functions in test_database.[ch]pp.
* get_user_id_for_oauth2_token would fail if the "scope" is null. This doesn't happen in real life, and is more of a unit test artifact. Added coalesce to have an empty string as default value.

