### PR TITLE
Added cmake target for code coverage reports

### DIFF
--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -9,10 +9,6 @@ buildType:
       short: Release
       long: Optimize generated code
       buildType: Release
-      settings:
-        CMAKE_CXX_FLAGS: "-fwhole-program -flto=auto"
-        CMAKE_C_FLAGS: "-fwhole-program -flto=auto"
-        CMAKE_EXE_LINKER_FLAGS: "-flto=auto"
     releaseDebug:
       short: ReleaseDebug
       long: Release with debug information
@@ -26,13 +22,10 @@ coverage:
       short: cov
       long: build with coverage instrumentation
       settings:
-        CMAKE_CXX_FLAGS: "-fprofile-arcs -ftest-coverage "
-        CMAKE_C_FLAGS: "-fprofile-arcs -ftest-coverage"
-        CMAKE_EXE_LINKER_FLAGS: "--coverage"
+        ENABLE_COVERAGE: TRUE
+        BUILD_TESTING: TRUE
     no_coverage:
       short: no_coverage
       long: build without coverage
       settings:
-        CMAKE_CXX_FLAGS: ""
-        CMAKE_C_FLAGS: ""
-        CMAKE_EXE_LINKER_FLAGS: ""
+        ENABLE_COVERAGE: FALSE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,25 @@ if(CLANG_TIDY)
     )
 endif()
 
+########################################
+# Optional coverage report generation
+########################################
+
+if(ENABLE_COVERAGE)
+    # Path for storing the coverage report
+    set(COVERAGE_REPORT_DIR "${CMAKE_BINARY_DIR}/report")
+
+    # Create target for generating the coverage report
+    add_custom_target(generate_coverage_report
+        COMMAND mkdir -p ${COVERAGE_REPORT_DIR}
+        COMMAND lcov --base-directory ${CMAKE_CURRENT_SOURCE_DIR} --directory ${CMAKE_BINARY_DIR} --capture --output-file ${COVERAGE_REPORT_DIR}/coverage.info
+        COMMAND lcov --remove ${COVERAGE_REPORT_DIR}/coverage.info '/usr/*' '${CMAKE_CURRENT_SOURCE_DIR}/contrib/catch2/*'
+                '${CMAKE_CURRENT_SOURCE_DIR}/contrib/libxml++/*' --output-file ${COVERAGE_REPORT_DIR}/coverage_cleaned.info
+        COMMAND genhtml -o ${COVERAGE_REPORT_DIR}/ ${COVERAGE_REPORT_DIR}/coverage_cleaned.info
+        COMMAND lcov --list ${COVERAGE_REPORT_DIR}/coverage_cleaned.info
+        COMMENT "Generating code coverage report"
+    )
+endif()
 
 #############################################################
 # Install

--- a/src/osmchange_responder.cpp
+++ b/src/osmchange_responder.cpp
@@ -52,6 +52,8 @@ struct sorting_formatter : public output_formatter {
 
   ~sorting_formatter() override = default;
 
+  // LCOV_EXCL_START
+
   [[nodiscard]] mime::type mime_type() const override {
     throw std::runtime_error("sorting_formatter::mime_type unimplemented");
   }
@@ -91,6 +93,8 @@ struct sorting_formatter : public output_formatter {
     throw std::runtime_error("sorting_formatter::end_changeset unimplemented");
   }
 
+  // LCOV_EXCL_STOP
+
   void write_node(
     const element_info &elem,
     double lon, double lat,
@@ -126,6 +130,8 @@ struct sorting_formatter : public output_formatter {
 
     m_elements.emplace_back(std::move(rel));
   }
+
+  // LCOV_EXCL_START
 
   void write_changeset(
     const changeset_info &,
@@ -171,6 +177,8 @@ struct sorting_formatter : public output_formatter {
     // actions - they're added by this code.
     throw std::runtime_error("Unexpected call to end_action.");
   }
+
+    // LCOV_EXCL_STOP
 
   void write(output_formatter &fmt) {
     std::sort(m_elements.begin(), m_elements.end());

--- a/src/text_formatter.cpp
+++ b/src/text_formatter.cpp
@@ -16,6 +16,8 @@ text_formatter::text_formatter(std::unique_ptr<text_writer> w) : writer(std::mov
 
 mime::type text_formatter::mime_type() const { return mime::type::text_plain; }
 
+// LCOV_EXCL_START
+
 void text_formatter::start_document(
   const std::string &generator, const std::string &root_name) {
   // nothing needed here
@@ -49,11 +51,6 @@ void text_formatter::start_action(action_type type) {
 
 void text_formatter::end_action(action_type type) {
   // nothing needed here
-}
-
-void text_formatter::error(const std::exception &e) {
-
-  writer->text(e.what());
 }
 
 void text_formatter::write_tags(const tags_t &) {
@@ -96,15 +93,19 @@ void text_formatter::write_diffresult_create_modify(const element_type elem,
   // nothing needed here
 }
 
-
 void text_formatter::write_diffresult_delete(const element_type elem,
                                             const osm_nwr_signed_id_t old_id)
 {
   // nothing needed here
 }
 
-
+// LCOV_EXCL_STOP
 
 void text_formatter::flush() { writer->flush(); }
 
 void text_formatter::error(const std::string &s) { writer->error(s); }
+
+void text_formatter::error(const std::exception &e) {
+
+  writer->text(e.what());
+}

--- a/test/test_formatter.cpp
+++ b/test/test_formatter.cpp
@@ -81,6 +81,8 @@ bool test_formatter::changeset_t::operator==(const changeset_t &other) const {
          (!m_include_comments || m_comments == other.m_comments);
 }
 
+// LCOV_EXCL_START
+
 mime::type test_formatter::mime_type() const {
   throw std::runtime_error("Unimplemented");
 }
@@ -112,6 +114,8 @@ void test_formatter::start_action(action_type type) {
 
 void test_formatter::end_action(action_type type) {
 }
+
+// LCOV_EXCL_STOP
 
 void test_formatter::write_node(const element_info &elem, double lon, double lat,
                                 const tags_t &tags) {


### PR DESCRIPTION
This PR adds a cmake target to generate an html based code coverage report,  something like:

![image](https://github.com/user-attachments/assets/ed439b8a-ae77-4ec5-a80e-82610a6cbd7b)

 `ninja generate_coverage_report` (or `make` instead of `ninja`).

coveralls.io: https://coveralls.io/github/zerebubuth/openstreetmap-cgimap