### PR TITLE
Remove obsolete config options

### DIFF
--- a/doc/man1/openstreetmap-cgimap.1
+++ b/doc/man1/openstreetmap-cgimap.1
@@ -22,15 +22,12 @@ openstreetmap-cgimap \- FCGI version of the OpenStreetMap API
 [\fB\-\-host \fIHOST\fR]
 [\fB\-\-username \fIUSER\fR]
 [\fB\-\-password \fIPASS\fR]
-[\fB\-\-charset \fICHARSET\fR]
-[\fB\-\-cachesize \fISIZE\fR]
 [\fB\-\-dbport \fIPORT\fR]
 ] [
 [\fB\-\-update\-dbname \fIUPDATEDBNAME\fR]
 [\fB\-\-update\-host \fIUPDATEHOST\fR]
 [\fB\-\-update\-username \fIUPDATEUSER\fR]
 [\fB\-\-update\-password \fIUPDATEPASS\fR]
-[\fB\-\-update\-charset \fIUPDATECHARSET\fR]
 [\fB\-\-update\-dbport \fIUPDATEPORT\fR]
 ] [
 [\fB\-\-file \fIFILE\fR]
@@ -93,14 +90,6 @@ Database user name.
 .BR \-\-password =\fIPASS\fR
 Database password.
 .TP
-.BR \-\-charset =\fICHARSET\fR
-Database character set.
-Default is utf8.
-.TP
-.BR \-\-cachesize =\fISIZE\fR
-Maximum size of changeset cache.
-Default is 1000.
-.TP
 .BR \-\-dbport =\fIPORT\fR
 Database port number or UNIX socket file name.
 .TP
@@ -115,9 +104,6 @@ Database user name to use for API write operations, if different from \-\-userna
 .TP
 .BR \-\-update\-password =\fIUPDATEPASS\fR
 Database password to use for API write operations, if different from \-\-password.
-.TP
-.BR \-\-update\-charset =\fIUPDATECHARSET\fR
-Database character set to use for API write operations, if different from \-\-charset.
 .TP
 .BR \-\-update\-dbport =\fIUPDATEPORT\fR
 Database port number or UNIX socket file name to use for API write operations, if different from \-\-dbport.

--- a/src/backend/apidb/apidb.cpp
+++ b/src/backend/apidb/apidb.cpp
@@ -26,8 +26,6 @@ struct apidb_backend : public backend {
       ("host", po::value<std::string>(), "database server host")
       ("username", po::value<std::string>(), "database user name")
       ("password", po::value<std::string>(), "database password")
-      ("charset", po::value<std::string>()->default_value("utf8"),
-       "database character set")
       ("disable-api-write", "disable API write operations")
       ("dbport", po::value<std::string>(),
        "database port number or UNIX socket file name")
@@ -39,8 +37,6 @@ struct apidb_backend : public backend {
        "database user name for API write operations, if different from --username")
       ("update-password", po::value<std::string>(),
        "database password for API write operations, if different from --password")
-      ("update-charset", po::value<std::string>(),
-       "database character set for API write operations, if different from --charset")
       ("update-dbport", po::value<std::string>(),
        "database port for API write operations, if different from --dbport");
     // clang-format on

--- a/src/backend/apidb/pgsql_update.cpp
+++ b/src/backend/apidb/pgsql_update.cpp
@@ -143,13 +143,7 @@ pgsql_update::factory::factory(const po::variables_map &opts)
     m_errorhandler(m_connection) {
 
   check_postgres_version(m_connection);
-
-  // set the connections to use the appropriate charset.
-  std::string db_charset = opts["charset"].as<std::string>();
-  if (opts.count("update-charset")) {
-     db_charset = opts["update-charset"].as<std::string>();
-  }
-  m_connection.set_client_encoding(db_charset);
+  m_connection.set_client_encoding("utf8");
 
   // set the connection to readonly transaction, if disable-api-write flag is set
   if (opts.count("disable-api-write") != 0) {

--- a/src/backend/apidb/readonly_pgsql_selection.cpp
+++ b/src/backend/apidb/readonly_pgsql_selection.cpp
@@ -972,7 +972,7 @@ readonly_pgsql_selection::factory::factory(const po::variables_map &opts)
   check_postgres_version(m_connection);
 
   // set the connections to use the appropriate charset.
-  m_connection.set_client_encoding(opts["charset"].as<std::string>());
+  m_connection.set_client_encoding("utf8");
 
 #if PQXX_VERSION_MAJOR < 7
   // set the connection to use readonly transaction.


### PR DESCRIPTION
* Remove changeset size parameter, changeset cache was removed many years ago
* Remove option to override character set, always assume default "utf8"

