### PR TITLE
Enhanced changeset statistics

### DIFF
--- a/include/cgimap/api06/changeset_upload/changeset_stats.hpp
+++ b/include/cgimap/api06/changeset_upload/changeset_stats.hpp
@@ -1,0 +1,36 @@
+/**
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * This file is part of openstreetmap-cgimap (https://github.com/zerebubuth/openstreetmap-cgimap/).
+ *
+ * Copyright (C) 2009-2025 by the openstreetmap-cgimap developer community.
+ * For a full list of authors see the git log.
+ */
+
+ #ifndef API06_CHANGESET_UPLOAD_CHANGESET_STATS
+ #define API06_CHANGESET_UPLOAD_CHANGESET_STATS
+
+
+struct changeset_upload_stats {
+
+  using value_t = uint64_t;
+
+  struct element_stats {
+
+    value_t num_create{ 0 };
+    value_t num_modify{ 0 };
+    value_t num_delete{ 0 };
+
+    value_t get_total() const { return num_create + num_modify + num_delete; }
+  };
+
+  const element_stats node{};
+  const element_stats way{};
+  const element_stats relation{};
+
+  value_t get_total() const {
+    return node.get_total() + way.get_total() + relation.get_total();
+  }
+};
+
+#endif

--- a/include/cgimap/api06/changeset_upload/changeset_updater.hpp
+++ b/include/cgimap/api06/changeset_upload/changeset_updater.hpp
@@ -12,6 +12,7 @@
 
 #include "cgimap/types.hpp"
 #include "cgimap/util.hpp"
+#include "cgimap/api06/changeset_upload/changeset_stats.hpp"
 
 #include <map>
 #include <string>
@@ -26,7 +27,7 @@ public:
 
   virtual void lock_current_changeset(bool check_max_elements_limit) = 0;
 
-  virtual void update_changeset(uint32_t num_new_changes, bbox_t bbox) = 0;
+  virtual void update_changeset(const changeset_upload_stats &num_new_changes, const bbox_t &bbox) = 0;
 
   virtual bbox_t get_bbox() const = 0;
 

--- a/include/cgimap/api06/changeset_upload/node_updater.hpp
+++ b/include/cgimap/api06/changeset_upload/node_updater.hpp
@@ -12,6 +12,7 @@
 
 #include "cgimap/types.hpp"
 #include "cgimap/util.hpp"
+#include "cgimap/api06/changeset_upload/changeset_stats.hpp"
 
 #include <map>
 #include <string>
@@ -43,7 +44,7 @@ public:
 
   virtual void process_delete_nodes() = 0;
 
-  virtual uint32_t get_num_changes() const = 0;
+  virtual changeset_upload_stats::element_stats get_stats() const = 0;
 
   virtual bbox_t bbox() const = 0;
 };

--- a/include/cgimap/api06/changeset_upload/osmchange_handler.hpp
+++ b/include/cgimap/api06/changeset_upload/osmchange_handler.hpp
@@ -48,7 +48,7 @@ public:
 
   void process_relation(const Relation &relation, operation op, bool if_unused) override;
 
-  unsigned int get_num_changes() const;
+  changeset_upload_stats get_stats() const;
 
   bbox_t get_bbox() const;
 

--- a/include/cgimap/api06/changeset_upload/relation_updater.hpp
+++ b/include/cgimap/api06/changeset_upload/relation_updater.hpp
@@ -13,6 +13,7 @@
 #include "cgimap/types.hpp"
 #include "cgimap/util.hpp"
 
+#include "cgimap/api06/changeset_upload/changeset_stats.hpp"
 #include "cgimap/api06/changeset_upload/relation.hpp"
 
 #include <map>
@@ -48,7 +49,7 @@ public:
 
   virtual void process_delete_relations() = 0;
 
-  virtual uint32_t get_num_changes() const = 0;
+  virtual changeset_upload_stats::element_stats get_stats() const = 0;
 
   virtual bbox_t bbox() const = 0;
 };

--- a/include/cgimap/api06/changeset_upload/way_updater.hpp
+++ b/include/cgimap/api06/changeset_upload/way_updater.hpp
@@ -12,6 +12,7 @@
 
 #include "cgimap/types.hpp"
 #include "cgimap/util.hpp"
+#include "cgimap/api06/changeset_upload/changeset_stats.hpp"
 
 #include <map>
 #include <string>
@@ -53,7 +54,7 @@ public:
 
   virtual void process_delete_ways() = 0;
 
-  virtual uint32_t get_num_changes() const = 0;
+  virtual changeset_upload_stats::element_stats get_stats() const = 0;
 
   virtual bbox_t bbox() const = 0;
 };

--- a/include/cgimap/backend/apidb/changeset_upload/changeset_updater.hpp
+++ b/include/cgimap/backend/apidb/changeset_upload/changeset_updater.hpp
@@ -30,7 +30,8 @@ public:
 
   void lock_current_changeset(bool check_max_elements_limit) override;
 
-  void update_changeset(const uint32_t num_new_changes, const bbox_t bbox) override;
+  void update_changeset(const changeset_upload_stats &num_new_changes,
+                        const bbox_t &bbox) override;
 
   bbox_t get_bbox() const override;
 
@@ -46,6 +47,7 @@ private:
   void changeset_insert_subscriber ();
   void changeset_insert_tags (const std::map<std::string, std::string>& tags);
   void changeset_delete_tags ();
+  void changeset_update_enhanced_stats(const changeset_upload_stats &new_changes);
   void changeset_update_users_cs_count ();
   void changeset_insert_cs ();
 

--- a/include/cgimap/backend/apidb/changeset_upload/node_updater.hpp
+++ b/include/cgimap/backend/apidb/changeset_upload/node_updater.hpp
@@ -47,7 +47,7 @@ public:
 
   void process_delete_nodes() override;
 
-  unsigned int get_num_changes() const override;
+  changeset_upload_stats::element_stats get_stats() const override;
 
   bbox_t bbox() const override;
 

--- a/include/cgimap/backend/apidb/changeset_upload/relation_updater.hpp
+++ b/include/cgimap/backend/apidb/changeset_upload/relation_updater.hpp
@@ -52,7 +52,7 @@ public:
 
   void process_delete_relations() override;
 
-  unsigned int get_num_changes() const override;
+  changeset_upload_stats::element_stats get_stats() const override;
 
   bbox_t bbox() const override;
 

--- a/include/cgimap/backend/apidb/changeset_upload/way_updater.hpp
+++ b/include/cgimap/backend/apidb/changeset_upload/way_updater.hpp
@@ -52,7 +52,7 @@ public:
 
   void process_delete_ways() override;
 
-  unsigned int get_num_changes() const override;
+  changeset_upload_stats::element_stats get_stats() const override;
 
   bbox_t bbox() const override;
 

--- a/include/cgimap/options.hpp
+++ b/include/cgimap/options.hpp
@@ -30,6 +30,7 @@ public:
   [[nodiscard]] virtual std::string get_changeset_timeout_open_max() const = 0;
   [[nodiscard]] virtual std::string get_changeset_timeout_idle() const = 0;
   [[nodiscard]] virtual uint32_t get_changeset_max_elements() const = 0;
+  [[nodiscard]] virtual bool get_changeset_enhanced_stats() const = 0;
   [[nodiscard]] virtual uint32_t get_way_max_nodes() const = 0;
   [[nodiscard]] virtual int64_t get_scale() const = 0;
   [[nodiscard]] virtual std::optional<uint32_t> get_relation_max_members() const = 0;
@@ -65,6 +66,10 @@ public:
 
   [[nodiscard]] uint32_t get_changeset_max_elements() const override {
      return 10000;
+  }
+
+ [[nodiscard]] bool get_changeset_enhanced_stats() const override {
+     return false;
   }
 
   [[nodiscard]] uint32_t get_way_max_nodes() const override {
@@ -148,6 +153,10 @@ public:
      return m_changeset_max_elements;
   }
 
+  [[nodiscard]] bool get_changeset_enhanced_stats() const override {
+     return m_changeset_enhanced_stats;
+  }
+
   [[nodiscard]] uint32_t get_way_max_nodes() const override {
      return m_way_max_nodes;
   }
@@ -195,6 +204,7 @@ private:
   void set_changeset_timeout_open_max(const po::variables_map &options);
   void set_changeset_timeout_idle(const po::variables_map &options);
   void set_changeset_max_elements(const po::variables_map &options);
+  void set_changeset_enhanced_stats(const po::variables_map &options);
   void set_way_max_nodes(const po::variables_map &options);
   void set_scale(const po::variables_map &options);
   void set_relation_max_members(const po::variables_map &options);
@@ -211,6 +221,7 @@ private:
   std::string m_changeset_timeout_open_max;
   std::string m_changeset_timeout_idle;
   uint32_t m_changeset_max_elements;
+  bool m_changeset_enhanced_stats;
   uint32_t m_way_max_nodes;
   int64_t m_scale;
   std::optional<uint32_t> m_relation_max_members;
@@ -247,6 +258,9 @@ public:
 
   // Maximum number of elements permitted in one changeset
   static uint32_t get_changeset_max_elements() { return settings->get_changeset_max_elements(); }
+
+  // Update enhanced changeset stats (num_create, num_modify, num_delete)
+  static bool get_changeset_enhanced_stats() { return settings->get_changeset_enhanced_stats(); }
 
   // Maximum number of nodes permitted in a way
   static uint32_t get_way_max_nodes() { return settings->get_way_max_nodes(); }

--- a/src/api06/changeset_upload/osmchange_handler.cpp
+++ b/src/api06/changeset_upload/osmchange_handler.cpp
@@ -139,10 +139,10 @@ void OSMChange_Handler::finish_processing() {
   handle_new_state(state::st_finished);
 }
 
-uint32_t OSMChange_Handler::get_num_changes() const {
-  return (node_updater.get_num_changes() +
-          way_updater.get_num_changes() +
-          relation_updater.get_num_changes());
+changeset_upload_stats OSMChange_Handler::get_stats() const {
+  return {node_updater.get_stats(),
+          way_updater.get_stats(),
+          relation_updater.get_stats()};
 }
 
 bbox_t OSMChange_Handler::get_bbox() const {

--- a/src/api06/changeset_upload_handler.cpp
+++ b/src/api06/changeset_upload_handler.cpp
@@ -59,7 +59,7 @@ changeset_upload_responder::changeset_upload_responder(mime::type mt,
   // store diffresult for output handling in class osm_diffresult_responder
   m_diffresult = change_tracking.assemble_diffresult();
 
-  const auto new_changes = handler.get_num_changes();
+  const auto new_changes = handler.get_stats().get_total();
 
   if (global_settings::get_ratelimiter_upload()) {
 
@@ -74,7 +74,7 @@ changeset_upload_responder::changeset_upload_responder(mime::type mt,
     }
   }
 
-  changeset_updater->update_changeset(new_changes, handler.get_bbox());
+  changeset_updater->update_changeset(handler.get_stats(), handler.get_bbox());
 
   if (global_settings::get_bbox_size_limiter_upload()) {
 

--- a/src/backend/apidb/changeset_upload/node_updater.cpp
+++ b/src/backend/apidb/changeset_upload/node_updater.cpp
@@ -972,9 +972,10 @@ void ApiDB_Node_Updater::delete_current_node_tags(
   auto r = m.exec_prepared("delete_current_node_tags", ids);
 }
 
-uint32_t ApiDB_Node_Updater::get_num_changes() const {
-  return (ct.created_node_ids.size() + ct.modified_node_ids.size() +
-          ct.deleted_node_ids.size());
+changeset_upload_stats::element_stats ApiDB_Node_Updater::get_stats() const {
+  return {ct.created_node_ids.size(),
+          ct.modified_node_ids.size(),
+          ct.deleted_node_ids.size()};
 }
 
 bbox_t ApiDB_Node_Updater::bbox() const { return m_bbox; }

--- a/src/backend/apidb/changeset_upload/relation_updater.cpp
+++ b/src/backend/apidb/changeset_upload/relation_updater.cpp
@@ -1781,9 +1781,10 @@ void ApiDB_Relation_Updater::delete_current_relation_tags(
   auto r = m.exec_prepared("delete_current_relation_tags", ids);
 }
 
-uint32_t ApiDB_Relation_Updater::get_num_changes() const {
-  return (ct.created_relation_ids.size() + ct.modified_relation_ids.size() +
-          ct.deleted_relation_ids.size());
+changeset_upload_stats::element_stats ApiDB_Relation_Updater::get_stats() const {
+  return {ct.created_relation_ids.size(),
+          ct.modified_relation_ids.size(),
+          ct.deleted_relation_ids.size()};
 }
 
 bbox_t ApiDB_Relation_Updater::bbox() const { return m_bbox; }

--- a/src/backend/apidb/changeset_upload/way_updater.cpp
+++ b/src/backend/apidb/changeset_upload/way_updater.cpp
@@ -1036,9 +1036,10 @@ void ApiDB_Way_Updater::delete_current_way_nodes(
   auto r = m.exec_prepared("delete_current_way_nodes", ids);
 }
 
-uint32_t ApiDB_Way_Updater::get_num_changes() const {
-  return (ct.created_way_ids.size() + ct.modified_way_ids.size() +
-          ct.deleted_way_ids.size());
+changeset_upload_stats::element_stats ApiDB_Way_Updater::get_stats() const {
+  return {ct.created_way_ids.size(),
+          ct.modified_way_ids.size(),
+          ct.deleted_way_ids.size()};
 }
 
 bbox_t ApiDB_Way_Updater::bbox() const { return m_bbox; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,6 +156,7 @@ void get_options(int argc, char **argv, po::variables_map &options) {
     ("map-area", po::value<double>(), "max area size allowed for /map endpoint")
     ("changeset-timeout-open", po::value<std::string>(), "max open time period for a changeset")
     ("changeset-timeout-idle", po::value<std::string>(), "time period a changeset will remain open after last edit")
+    ("changeset-enhanced-stats", po::value<bool>(), "enable enhanced changeset stats")
     ("max-changeset-elements", po::value<int>(), "max number of elements allowed in one changeset")
     ("max-way-nodes", po::value<int>(), "max number of nodes allowed in one way")
     ("scale", po::value<long>(), "conversion factor from double lat/lon to internal int format")

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -25,6 +25,7 @@ void global_settings_via_options::init_fallback_values(const global_settings_bas
   m_changeset_timeout_open_max = def.get_changeset_timeout_open_max();
   m_changeset_timeout_idle = def.get_changeset_timeout_idle();
   m_changeset_max_elements = def.get_changeset_max_elements();
+  m_changeset_enhanced_stats = def.get_changeset_enhanced_stats();
   m_way_max_nodes = def.get_way_max_nodes();
   m_scale = def.get_scale();
   m_relation_max_members = def.get_relation_max_members();
@@ -45,6 +46,7 @@ void global_settings_via_options::set_new_options(const po::variables_map &optio
   set_changeset_timeout_open_max(options);
   set_changeset_timeout_idle(options);
   set_changeset_max_elements(options);
+  set_changeset_enhanced_stats(options);
   set_way_max_nodes(options);
   set_scale(options);
   set_relation_max_members(options);
@@ -106,6 +108,12 @@ void global_settings_via_options::set_changeset_max_elements(const po::variables
     if (changeset_max_elements > 50000)
       throw std::invalid_argument("max-changeset-elements must not exceed 50000");
     m_changeset_max_elements = changeset_max_elements;
+  }
+}
+
+void global_settings_via_options::set_changeset_enhanced_stats(const po::variables_map &options)  {
+  if (options.contains("changeset-enhanced-stats")) {
+    m_changeset_enhanced_stats = options["changeset-enhanced-stats"].as<bool>();
   }
 }
 

--- a/test/structure.sql
+++ b/test/structure.sql
@@ -385,6 +385,20 @@ CREATE TABLE public.changesets (
     num_changes integer DEFAULT 0 NOT NULL
 );
 
+--- Preliminary changesets table columns for enhanced changeset stats
+--- see https://github.com/openstreetmap/openstreetmap-website/issues/5758
+
+ALTER TABLE public.changesets
+   ADD COLUMN num_created_nodes integer DEFAULT 0 NOT NULL,
+   ADD COLUMN num_modified_nodes integer DEFAULT 0 NOT NULL,
+   ADD COLUMN num_deleted_nodes integer DEFAULT 0 NOT NULL,
+   ADD COLUMN num_created_ways integer DEFAULT 0 NOT NULL,
+   ADD COLUMN num_modified_ways integer DEFAULT 0 NOT NULL,
+   ADD COLUMN num_deleted_ways integer DEFAULT 0 NOT NULL,
+   ADD COLUMN num_created_relations integer DEFAULT 0 NOT NULL,
+   ADD COLUMN num_modified_relations integer DEFAULT 0 NOT NULL,
+   ADD COLUMN num_deleted_relations integer DEFAULT 0 NOT NULL;
+
 
 --
 -- Name: changesets_id_seq; Type: SEQUENCE; Schema: public; Owner: -


### PR DESCRIPTION
https://github.com/openstreetmap/openstreetmap-website/issues/5758
[#6170](https://github.com/openstreetmap/openstreetmap-website/pull/6170)

Introduces new config option:


```
  --changeset-enhanced-stats arg  enable enhanced changeset stats
```

This should translate to `CGIMAP_CHANGESET_ENHANCED_STATS=true` as environment variable.


<img width="509" height="402" alt="image" src="https://github.com/user-attachments/assets/d1c12e7d-8aef-478b-9d00-223771e8eba6" />
