### PR TITLE
Limit max-changeset-elements to 50'000 changes

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -103,6 +103,8 @@ void global_settings_via_options::set_changeset_max_elements(const po::variables
     auto changeset_max_elements = options["max-changeset-elements"].as<int>();
     if (changeset_max_elements <= 0)
       throw std::invalid_argument("max-changeset-elements must be a positive number");
+    if (changeset_max_elements > 50000)
+      throw std::invalid_argument("max-changeset-elements must not exceed 50000");
     m_changeset_max_elements = changeset_max_elements;
   }
 }

--- a/test/test_parse_options.cpp
+++ b/test/test_parse_options.cpp
@@ -72,6 +72,12 @@ TEST_CASE("Invalid max-changeset-elements", "[options]") {
   REQUIRE_THROWS_AS(check_options(vm), std::invalid_argument);
 }
 
+TEST_CASE("max-changeset-elements too large", "[options]") {
+  po::variables_map vm;
+  vm.emplace("max-changeset-elements", po::variable_value(50001, false));
+  REQUIRE_THROWS_AS(check_options(vm), std::invalid_argument);
+}
+
 TEST_CASE("Invalid scale", "[options]") {
   po::variables_map vm;
   vm.emplace("scale", po::variable_value(0L, false));


### PR DESCRIPTION
50k changes per changeset was the biggest number ever in place. We don't want people to go for even bigger values, because of performance concerns. These days, 10k is the default value.

Context: https://github.com/developmentseed/osm-seed/pull/300#issuecomment-2817089990