### PR TITLE
Finish up FCGI request in case of exceptions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -238,7 +238,13 @@ void process_requests(int socket, const po::variables_map &options) {
     if (req.accept_r() >= 0) {
       const auto now(std::chrono::system_clock::now());
       req.set_current_time(now);
-      process_request(req, limiter, generator, route, *factory, update_factory.get());
+      try {
+        process_request(req, limiter, generator, route, *factory, update_factory.get());
+      } catch (...) {
+        // Attempt to properly finish up FCGI request (so that clients will see the error message)
+        req.dispose();
+        throw;
+      }
     }
   }
 

--- a/src/process_request.cpp
+++ b/src/process_request.cpp
@@ -131,7 +131,7 @@ void respond_error(const http::exception &e, request &r) {
     std::string message(e.what());
 
     std::string message_error_header = message.substr(0, 250);                           // limit HTTP header to 250 chars
-    std::replace(message_error_header.begin(), message_error_header.end(), '\n', ' ');   // replace newline by space (newlines screw up HTTP header)
+    std::ranges::replace(message_error_header, '\n', ' ');   // replace newline by space (newlines screw up HTTP header)
 
     r.status(e.code())
       .add_header("Content-Type", "text/plain")


### PR DESCRIPTION
Low level exceptions, like database errors, should be sent to clients as an Internal Server Error.

To reproduce:

Session 1:
---------------

Start cgimap on an empty database instance:

```bash
pg_virtualenv
./openstreetmap-cgimap --dbname=postgres --socket .demo
```

Session 2:
---------------

Try to issue a request:

```bash
REQUEST_URI="/api/0.6/node/1" REQUEST_METHOD="GET" REMOTE_ADDR="127.0.0.1" cgi-fcgi -bind -connect .demo
```

Should return:

```
Status: 500 Internal Server Error
Content-Type: text/plain
Content-Length: 129
Error: ERROR:  relation "current_nodes" does not exist LINE 1: SELECT id FROM current_nodes WHERE id = ANY($1)                        ^
Cache-Control: no-cache

ERROR:  relation "current_nodes" does not exist
LINE 1: SELECT id FROM current_nodes WHERE id = ANY($1)
```