### PR TITLE
Relation member sequence ids should start with 1

### DIFF
--- a/src/backend/apidb/changeset_upload/relation_updater.cpp
+++ b/src/backend/apidb/changeset_upload/relation_updater.cpp
@@ -51,7 +51,7 @@ void ApiDB_Relation_Updater::add_relation(osm_changeset_id_t changeset_id,
       .member_type = member.type(),
       .member_id = static_cast<osm_nwr_id_t>(member.ref() < 0 ? 0 : member.ref()),
       .member_role = member.role(),
-      .sequence_id = member_seq++,
+      .sequence_id = ++member_seq,
       .old_member_id = member.ref()
     };
     new_relation.members.push_back(new_member);
@@ -86,7 +86,7 @@ void ApiDB_Relation_Updater::modify_relation(osm_changeset_id_t changeset_id,
       .member_type = member.type(),
       .member_id = static_cast<osm_nwr_id_t>(member.ref() < 0 ? 0 : member.ref()),
       .member_role = member.role(),
-      .sequence_id = member_seq++,
+      .sequence_id = ++member_seq,
       .old_member_id = member.ref()
     };
     modify_relation.members.push_back(modify_member);

--- a/test/test_apidb_backend_changeset_uploads.cpp
+++ b/test/test_apidb_backend_changeset_uploads.cpp
@@ -2397,6 +2397,8 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
     REQUIRE(getXPath(doc.get(), "/diffResult/relation[3]/@new_id") == "18000000002");
     REQUIRE(getXPath(doc.get(), "/diffResult/relation[3]/@new_version") == "1");
 
+    // check that relation member sequence_ids don't start with 0
+    REQUIRE(tdb.run_sql("SELECT * from current_relation_members WHERE sequence_id = 0") == 0);
   }
 
   SECTION("Try to add, modify and delete nodes, ways, relations in changeset")
@@ -2495,6 +2497,9 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_osmchange_end_to_end", "[changeset
     REQUIRE(getXPath(doc.get(), "/diffResult/relation[4]/@old_id") == "18000000000");
     REQUIRE(getXPath(doc.get(), "/diffResult/relation[4]/@new_id") == "18000000000");
     REQUIRE(getXPath(doc.get(), "/diffResult/relation[4]/@new_version") == "2");
+
+    // check that relation member sequence_ids don't start with 0
+    REQUIRE(tdb.run_sql("SELECT * from current_relation_members WHERE sequence_id = 0") == 0);
   }
 
   SECTION("Multiple operations on the same node id -1")


### PR DESCRIPTION
Code review finding. Sequence ids are used for sorting purposes only and not shared with any API clients. They should start with 1, like on Rails. Old relation member sequence ids can stay as is for now.