### PR TITLE
Placeholder ids must be negative for create ops

### DIFF
--- a/include/cgimap/api06/changeset_upload/node.hpp
+++ b/include/cgimap/api06/changeset_upload/node.hpp
@@ -25,9 +25,9 @@ public:
 
   ~Node() override = default;
 
-  double lat() const { return *m_lat; }
+  [[nodiscard]] double lat() const { return *m_lat; }
 
-  double lon() const { return *m_lon; }
+  [[nodiscard]] double lon() const { return *m_lon; }
 
   void set_lat(const std::string &lat) {
 
@@ -114,7 +114,7 @@ public:
     return (is_valid() && m_lat && m_lon);
   }
 
-  std::string get_type_name() const override { return "Node"; }
+  [[nodiscard]] std::string get_type_name() const override { return "Node"; }
 
   bool operator==(const Node &o) const {
     return (OSMObject::operator==(o) &&

--- a/include/cgimap/api06/changeset_upload/node.hpp
+++ b/include/cgimap/api06/changeset_upload/node.hpp
@@ -106,12 +106,12 @@ public:
     m_lon = lon;
   }
 
-  bool is_valid(operation op) const {
+  [[nodiscard]] bool is_valid(operation op) const override {
 
     if (op == operation::op_delete)
-      return (is_valid());
+      return (OSMObject::is_valid(op));
 
-    return (is_valid() && m_lat && m_lon);
+    return (OSMObject::is_valid(op) && m_lat && m_lon);
   }
 
   [[nodiscard]] std::string get_type_name() const override { return "Node"; }
@@ -125,7 +125,6 @@ public:
 private:
   std::optional<double> m_lat;
   std::optional<double> m_lon;
-  using OSMObject::is_valid;
 };
 
 } // namespace api06

--- a/include/cgimap/api06/changeset_upload/osmchange_xml_input_format.hpp
+++ b/include/cgimap/api06/changeset_upload/osmchange_xml_input_format.hpp
@@ -107,16 +107,16 @@ protected:
     case context::in_modify:
 
       if (element == "node") {
-        m_node.reset(new Node{});
+        m_node = std::make_unique<Node>();
         init_object(*m_node, attrs);
         init_node(*m_node, attrs);
         m_context.push_back(context::node);
       } else if (element == "way") {
-        m_way.reset(new Way{});
+        m_way = std::make_unique<Way>();
         init_object(*m_way, attrs);
         m_context.push_back(context::way);
       } else if (element == "relation") {
-        m_relation.reset(new Relation{});
+        m_relation = std::make_unique<Relation>();
         init_object(*m_relation, attrs);
         m_context.push_back(context::relation);
       } else {
@@ -222,7 +222,7 @@ protected:
         };
       }
       m_callback.process_node(*m_node, m_operation, m_if_unused);
-      m_node.reset(new Node{});
+      m_node = std::make_unique<Node>();
       m_context.pop_back();
       break;
     case context::way:
@@ -235,7 +235,7 @@ protected:
       }
 
       m_callback.process_way(*m_way, m_operation, m_if_unused);
-      m_way.reset(new Way{});
+      m_way = std::make_unique<Way>();
       m_context.pop_back();
       break;
     case context::relation:
@@ -247,7 +247,7 @@ protected:
         };
       }
       m_callback.process_relation(*m_relation, m_operation, m_if_unused);
-      m_relation.reset(new Relation{});
+      m_relation = std::make_unique<Relation>();
       m_context.pop_back();
       break;
     case context::in_object:

--- a/include/cgimap/api06/changeset_upload/osmobject.hpp
+++ b/include/cgimap/api06/changeset_upload/osmobject.hpp
@@ -111,18 +111,18 @@ namespace api06 {
         throw payload_error("Unexpected parsing error");
     }
 
-    osm_changeset_id_t changeset() const { return *m_changeset; }
+    [[nodiscard]] osm_changeset_id_t changeset() const { return *m_changeset; }
 
-    osm_version_t version() const { return *m_version; }
+    [[nodiscard]] osm_version_t version() const { return *m_version; }
 
-    osm_nwr_signed_id_t id() const { return *m_id; }
-    osm_nwr_signed_id_t id(osm_nwr_signed_id_t d) const { return m_id.value_or(d); }
+    [[nodiscard]] osm_nwr_signed_id_t id() const { return *m_id; }
+    [[nodiscard]] osm_nwr_signed_id_t id(osm_nwr_signed_id_t d) const { return m_id.value_or(d); }
 
-    constexpr bool has_changeset() const {  return m_changeset.has_value(); }
-    constexpr bool has_id() const { return m_id.has_value(); };
-    constexpr bool has_version() const { return m_version.has_value(); }
+    [[nodiscard]] constexpr bool has_changeset() const {  return m_changeset.has_value(); }
+    [[nodiscard]] constexpr bool has_id() const { return m_id.has_value(); };
+    [[nodiscard]] constexpr bool has_version() const { return m_version.has_value(); }
 
-    std::map<std::string, std::string> tags() const { return m_tags; }
+    [[nodiscard]] std::map<std::string, std::string> tags() const { return m_tags; }
 
     void add_tags(const std::map<std::string, std::string>& tags) {
       for (const auto& [key, value] : tags) {
@@ -130,26 +130,26 @@ namespace api06 {
       }
     }
 
-    void add_tag(const std::string& key, const std::string& value) {
+    void add_tag(const std::string &key, const std::string &value) {
 
       if (key.empty()) {
-	  throw payload_error(fmt::format("Key may not be empty in {}", to_string()));
+        throw payload_error(
+            fmt::format("Key may not be empty in {}", to_string()));
       }
 
       if (unicode_strlen(key) > 255) {
-	  throw payload_error(
-	      fmt::format("Key has more than 255 unicode characters in {}",  to_string()));
+        throw payload_error(fmt::format(
+            "Key has more than 255 unicode characters in {}", to_string()));
       }
 
       if (unicode_strlen(value) > 255) {
-	  throw payload_error(
-	      fmt::format("Value has more than 255 unicode characters in {}", to_string()));
+        throw payload_error(fmt::format(
+            "Value has more than 255 unicode characters in {}", to_string()));
       }
 
-      if (!(m_tags.insert({key, value}))
-	  .second) {
-	  throw payload_error(
-	       fmt::format("{} has duplicate tags with key {}", to_string(), key));
+      if (!(m_tags.insert({ key, value })).second) {
+        throw payload_error(
+            fmt::format("{} has duplicate tags with key {}", to_string(), key));
       }
     }
 
@@ -170,7 +170,7 @@ namespace api06 {
 
     virtual std::string get_type_name() const = 0;
 
-    virtual std::string to_string() const {
+    [[nodiscard]] virtual std::string to_string() const {
 
       return fmt::format("{} {:d}", get_type_name(), m_id.value_or(0));
     }

--- a/include/cgimap/api06/changeset_upload/osmobject.hpp
+++ b/include/cgimap/api06/changeset_upload/osmobject.hpp
@@ -153,22 +153,30 @@ namespace api06 {
       }
     }
 
-    virtual bool is_valid() const {
-      // check if all mandatory fields have been set
+    [[nodiscard]] virtual bool is_valid(operation op) const {
+
       if (!m_changeset)
-	throw payload_error(
-	    "You need to supply a changeset to be able to make a change");
+        throw payload_error(
+            "You need to supply a changeset to be able to make a change");
 
       auto max_tags = global_settings::get_element_max_tags();
 
       if (max_tags && m_tags.size() > *max_tags) {
-	     throw payload_error(fmt::format("OSM element exceeds limit of {} tags", *max_tags));
+        throw payload_error(
+            fmt::format("OSM element exceeds limit of {} tags", *max_tags));
       }
 
-      return (m_changeset && m_id && m_version);
+      // check if mandatory fields changeset id, object id and version are set
+      bool valid = (m_changeset && m_id && m_version);
+
+      if (valid && op == operation::op_create && id() >= 0) {
+          throw payload_error("Placeholder IDs must be negative for created elements.");
+      }
+
+      return valid;
     }
 
-    virtual std::string get_type_name() const = 0;
+    [[nodiscard]] virtual std::string get_type_name() const = 0;
 
     [[nodiscard]] virtual std::string to_string() const {
 

--- a/include/cgimap/api06/changeset_upload/relation.hpp
+++ b/include/cgimap/api06/changeset_upload/relation.hpp
@@ -123,10 +123,10 @@ public:
 
   [[nodiscard]] std::string get_type_name() const override { return "Relation"; }
 
-  bool is_valid(operation op) const {
+  [[nodiscard]] bool is_valid(operation op) const override {
 
     if (op == operation::op_delete)
-      return (is_valid());
+      return (OSMObject::is_valid(op));
 
     auto max_members = global_settings::get_relation_max_members();
 
@@ -138,7 +138,7 @@ public:
                       *max_members));
     }
 
-    return (is_valid());
+    return (OSMObject::is_valid(op));
   }
 
   bool operator==(const Relation &o) const {
@@ -148,7 +148,6 @@ public:
 
 private:
   std::vector<RelationMember> m_relation_member;
-  using OSMObject::is_valid;
 };
 
 } // namespace api06

--- a/include/cgimap/api06/changeset_upload/relation.hpp
+++ b/include/cgimap/api06/changeset_upload/relation.hpp
@@ -110,11 +110,6 @@ public:
 
   ~Relation() override = default;
 
-  void add_members(std::vector<RelationMember>&& members) {
-    for (auto& mbr : members)
-      add_member(mbr);
-  }
-
   void add_member(RelationMember &member) {
     if (!member.is_valid())
       throw payload_error(

--- a/include/cgimap/api06/changeset_upload/relation.hpp
+++ b/include/cgimap/api06/changeset_upload/relation.hpp
@@ -79,7 +79,7 @@ public:
       throw payload_error("Unexpected parsing error");
   }
 
-  bool is_valid() const {
+  [[nodiscard]] bool is_valid() const {
 
     if (!m_type)
       throw payload_error("Missing 'type' attribute in Relation member");
@@ -90,11 +90,11 @@ public:
     return (m_ref && m_type);
   }
 
-  std::string type() const { return *m_type; }
+  [[nodiscard]] std::string type() const { return *m_type; }
 
-  std::string role() const { return m_role; }
+  [[nodiscard]] std::string role() const { return m_role; }
 
-  osm_nwr_signed_id_t ref() const { return *m_ref; }
+  [[nodiscard]] osm_nwr_signed_id_t ref() const { return *m_ref; }
 
   bool operator==(const RelationMember &o) const = default;
 
@@ -122,11 +122,11 @@ public:
     m_relation_member.emplace_back(member);
   }
 
-  const std::vector<RelationMember> &members() const {
+  [[nodiscard]] const std::vector<RelationMember> &members() const {
     return m_relation_member;
   }
 
-  std::string get_type_name() const override { return "Relation"; }
+  [[nodiscard]] std::string get_type_name() const override { return "Relation"; }
 
   bool is_valid(operation op) const {
 

--- a/include/cgimap/api06/changeset_upload/way.hpp
+++ b/include/cgimap/api06/changeset_upload/way.hpp
@@ -27,11 +27,6 @@ public:
 
   ~Way() override = default;
 
-  void add_way_nodes(const std::vector<osm_nwr_signed_id_t>& way_nodes) {
-    for (auto const wn : way_nodes)
-      m_way_nodes.emplace_back(wn);
-  }
-
   void add_way_node(osm_nwr_signed_id_t waynode) {
     if (waynode == 0) {
       throw payload_error("Way node value may not be 0");

--- a/include/cgimap/api06/changeset_upload/way.hpp
+++ b/include/cgimap/api06/changeset_upload/way.hpp
@@ -56,9 +56,9 @@ public:
       throw payload_error("Unexpected parsing error");
   }
 
-  const std::vector<osm_nwr_signed_id_t> &nodes() const { return m_way_nodes; }
+  [[nodiscard]] const std::vector<osm_nwr_signed_id_t> &nodes() const { return m_way_nodes; }
 
-  bool is_valid(operation op) const {
+  [[nodiscard]] bool is_valid(operation op) const override {
 
     if (op == operation::op_delete)
       return (is_valid());
@@ -80,7 +80,7 @@ public:
     return (is_valid());
   }
 
-  std::string get_type_name() const override { return "Way"; }
+  [[nodiscard]] std::string get_type_name() const override { return "Way"; }
 
   bool operator==(const Way &o) const {
     return (OSMObject::operator==(o) &&

--- a/include/cgimap/api06/changeset_upload/way.hpp
+++ b/include/cgimap/api06/changeset_upload/way.hpp
@@ -56,7 +56,7 @@ public:
   [[nodiscard]] bool is_valid(operation op) const override {
 
     if (op == operation::op_delete)
-      return (is_valid());
+      return (OSMObject::is_valid(op));
 
     if (m_way_nodes.empty()) {
       throw http::precondition_failed(
@@ -72,7 +72,7 @@ public:
             m_way_nodes.size(), id(0), way_max_nodes));
     }
 
-    return (is_valid());
+    return (OSMObject::is_valid(op));
   }
 
   [[nodiscard]] std::string get_type_name() const override { return "Way"; }
@@ -84,7 +84,6 @@ public:
 
 private:
   std::vector<osm_nwr_signed_id_t> m_way_nodes;
-  using OSMObject::is_valid;
 };
 
 } // namespace api06

--- a/src/backend/apidb/changeset_upload/node_updater.cpp
+++ b/src/backend/apidb/changeset_upload/node_updater.cpp
@@ -42,6 +42,10 @@ void ApiDB_Node_Updater::add_node(double lat, double lon,
                                   osm_nwr_signed_id_t old_id,
                                   const api06::TagList &tags) {
 
+  if (old_id >= 0) {
+    throw http::bad_request("Placeholder IDs must be negative for created elements.");
+  }
+
   node_t new_node{ .version = 1,
                    .lat = static_cast<int64_t>(round(lat * global_settings::get_scale())),
                    .lon = static_cast<int64_t>(round(lon * global_settings::get_scale())),

--- a/src/backend/apidb/changeset_upload/relation_updater.cpp
+++ b/src/backend/apidb/changeset_upload/relation_updater.cpp
@@ -36,6 +36,10 @@ void ApiDB_Relation_Updater::add_relation(osm_changeset_id_t changeset_id,
                                           const RelationMemberList &members,
                                           const TagList &tags) {
 
+  if (old_id >= 0) {
+    throw http::bad_request("Placeholder IDs must be negative for created elements.");
+  }
+
   relation_t new_relation{
     .version = 1,
     .changeset_id = changeset_id,

--- a/src/backend/apidb/changeset_upload/way_updater.cpp
+++ b/src/backend/apidb/changeset_upload/way_updater.cpp
@@ -38,6 +38,10 @@ void ApiDB_Way_Updater::add_way(osm_changeset_id_t changeset_id,
                                 const api06::WayNodeList &nodes,
                                 const api06::TagList &tags) {
 
+  if (old_id >= 0) {
+    throw http::bad_request("Placeholder IDs must be negative for created elements.");
+  }
+
   way_t new_way{
     .version = 1,
     .changeset_id = changeset_id,

--- a/test/test_apidb_backend_changeset_uploads.cpp
+++ b/test/test_apidb_backend_changeset_uploads.cpp
@@ -230,6 +230,17 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_single_nodes", "[changeset][upload
         Catch::Message("Placeholder IDs must be unique for created elements."));
   }
 
+  SECTION("Create node with positive old id")
+  {
+    api06::OSMChange_Tracking change_tracking{};
+    auto sel = tdb.get_data_selection();
+    auto upd = tdb.get_data_update();
+    auto node_updater = upd->get_node_updater(ctx, change_tracking);
+
+    REQUIRE_THROWS_MATCHES(node_updater->add_node(0, 0, 1, 2, {}), http::bad_request,
+        Catch::Message("Placeholder IDs must be negative for created elements."));
+  }
+
   SECTION("Change existing node")
   {
     api06::OSMChange_Tracking change_tracking{};
@@ -569,6 +580,23 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_single_ways", "[changeset][upload]
     way_updater->add_way(1, -1, { -1, -2}, { {"highway", "path"}});
     REQUIRE_THROWS_MATCHES(way_updater->process_new_ways(), http::bad_request,
         Catch::Message("Placeholder node not found for reference -1 in way -1"));
+  }
+
+  SECTION("Create way with positive old id")
+  {
+    api06::OSMChange_Tracking change_tracking{};
+    auto sel = tdb.get_data_selection();
+    auto upd = tdb.get_data_update();
+    auto node_updater = upd->get_node_updater(ctx, change_tracking);
+    auto way_updater = upd->get_way_updater(ctx, change_tracking);
+
+    node_updater->add_node(0, 0 , 1, -1, {});
+    node_updater->add_node(10, 20 , 1, -2, {});
+    node_updater->process_new_nodes();
+
+    REQUIRE_THROWS_MATCHES(way_updater->add_way(1, 1234, { -1,  -2}, { {"highway", "path"}}),
+        http::bad_request,
+        Catch::Message("Placeholder IDs must be negative for created elements."));
   }
 
   SECTION("Change existing way")
@@ -1075,6 +1103,17 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_single_relations", "[changeset][up
     rel_updater->add_relation(1, -1, {}, {{"key", "value"}});
     REQUIRE_THROWS_MATCHES(rel_updater->process_new_relations(), http::bad_request,
         Catch::Message("Placeholder IDs must be unique for created elements."));
+  }
+
+  SECTION("Create relation with positive old id")
+  {
+    api06::OSMChange_Tracking change_tracking{};
+    auto sel = tdb.get_data_selection();
+    auto upd = tdb.get_data_update();
+    auto rel_updater = upd->get_relation_updater(ctx, change_tracking);
+
+    REQUIRE_THROWS_MATCHES(rel_updater->add_relation(1, 1234, {}, {}), http::bad_request,
+       Catch::Message("Placeholder IDs must be negative for created elements."));
   }
 
   SECTION("Create one relation with self reference")

--- a/test/test_parse_osmchange_xml_input.cpp
+++ b/test/test_parse_osmchange_xml_input.cpp
@@ -174,6 +174,10 @@ TEST_CASE("Create node, redefined lat attribute", "[osmchange][node][xml]") {
   REQUIRE_THROWS_AS(process_testmsg(R"(<osmChange><create><node changeset="858" id="-1" lat="-90.00" lon="-180.00" lat="20"/></create></osmChange>)"), http::bad_request);
 }
 
+TEST_CASE("Create node, positive placeholder id", "[osmchange][node][xml]") {
+  REQUIRE_THROWS_AS(process_testmsg(R"(<osmChange><create><node changeset="858" id="1234" lat="-90.00" lon="-180.00" lat="20"/></create></osmChange>)"), http::bad_request);
+}
+
 TEST_CASE("Create valid node", "[osmchange][node][xml]") {
   auto i = GENERATE(R"(<osmChange><create><node changeset="858" id="-1" lat="90.00" lon="180.00"/></create></osmChange>)",
                     R"(<osmChange><create><node changeset="858" id="-1" lat="-90.00" lon="-180.00"/></create></osmChange>)");
@@ -438,6 +442,11 @@ TEST_CASE("Create way, node ref missing", "[osmchange][way][xml]") {
     R"(<osmChange><create><way changeset="858" id="-1"><nd ref="1"/><nd /><tag k="key" v="value"/></way></create></osmChange>)"), http::bad_request);
 }
 
+TEST_CASE("Create way, positive placeholder id", "[osmchange][way][xml]") {
+  REQUIRE_THROWS_AS(process_testmsg(
+    R"(<osmChange><create><way changeset="858" id="1234"><nd ref="-1"/><tag k="key" v="value"/></way></create></osmChange>)"), http::bad_request);
+}
+
 TEST_CASE("Delete way, no version", "[osmchange][way][xml]") {
   REQUIRE_THROWS_AS(process_testmsg(
     R"(<osmChange><delete><way changeset="858" id="-1"/></delete></osmChange>)"),
@@ -466,6 +475,11 @@ TEST_CASE("Delete way", "[osmchange][way][xml]") {
 TEST_CASE("Create relation, id missing", "[osmchange][relation][xml]") {
   REQUIRE_THROWS_AS(process_testmsg(
     R"(<osmChange><create><relation changeset="972"><member type="node" ref="1" role="stop"/></relation></create></osmChange>)"), http::bad_request);
+}
+
+TEST_CASE("Create relation, positive placeholder id", "[osmchange][relation][xml]") {
+  REQUIRE_THROWS_AS(process_testmsg(
+    R"(<osmChange><create><relation changeset="972" id="1234"><member type="node" ref="1" role="stop"/></relation></create></osmChange>)"), http::bad_request);
 }
 
 TEST_CASE("Create relation, member ref missing", "[osmchange][relation][xml]") {


### PR DESCRIPTION
Since Mid-2019 and up to v2.0.1, positive placeholder ids in "`<create>` operations" were triggering an HTTP 404 error as a side effect of a failing `lock_current_*` method call. Essentially, they were never supported by this implementation.

With the introduction of https://github.com/zerebubuth/openstreetmap-cgimap/commit/9505125892d88156b19a80b55de9140f12800ebf, `save_current_*_to_history` was triggering an HTTP 500 instead.

This PR adds an explicit check for negative placeholder ids during create, and rejects non-compliant requests with HTTP 400 "Placeholder IDs must be negative for created elements".

---

<details>
<summary>Comparison to Rails</summary>
NB: On Rails, positive placeholder ids are not rejected. However, the newly created objects cannot be referenced by their positive placeholder id, as can be seen in the example below. Using positive placeholder ids turns out to be fairly error prone.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<osmChange version="0.6" generator="iD">
  <create>
    <node id="350302" lon="11" lat="46" changeset="159556565"></node>
    <node id='-25360' lat='51.50723246769' lon='-0.12171328202' changeset="159556565" />
    <node id='-25361' lat='51.50719824397' lon='-0.12160197034' changeset="159556565" />
    <way id='-582' changeset="159556565">
      <nd ref='-25360' />
      <nd ref='350302' />     <!--- referring to positive placeholder for new node is not possible -->
    </way>
    <way id='-583' changeset="159556565">
      <nd ref='-25360' />
      <nd ref='-25361' />
    </way>		
  </create>
</osmChange>
```

```xml
<?xml version="1.0" encoding="UTF-8"?>
<diffResult version="0.6" generator="OpenStreetMap server" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
  <node old_id="350302" new_id="12394725190" new_version="1"/>
  <node old_id="-25360" new_id="12394725191" new_version="1"/>
  <node old_id="-25361" new_id="12394725192" new_version="1"/>
  <way old_id="-582" new_id="1338869368" new_version="1"/>
  <way old_id="-583" new_id="1338869369" new_version="1"/>
</diffResult>
```

```xml
<?xml version="1.0" encoding="UTF-8"?>
<osmChange version="0.6" generator="OpenStreetMap server" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
  <create>
<node id="12394725190" visible="true" version="1" changeset="159556565" timestamp="2025-05-04T16:07:46Z" user="testuser" uid="22217092" lat="46.0000000" lon="11.0000000"/>
  </create>
  <create>
<node id="12394725191" visible="true" version="1" changeset="159556565" timestamp="2025-05-04T16:07:47Z" user="testuser" uid="22217092" lat="51.5072325" lon="-0.1217133"/>
  </create>
  <create>
<node id="12394725192" visible="true" version="1" changeset="159556565" timestamp="2025-05-04T16:07:47Z" user="testuser" uid="22217092" lat="51.5071982" lon="-0.1216020"/>
  </create>
  <create>
<way id="1338869368" visible="true" version="1" changeset="159556565" timestamp="2025-05-04T16:07:47Z" user="testuser" uid="22217092">
  <nd ref="12394725191"/>
  <nd ref="350302"/>
</way>
  </create>
  <create>
<way id="1338869369" visible="true" version="1" changeset="159556565" timestamp="2025-05-04T16:07:47Z" user="testuser" uid="22217092">
  <nd ref="12394725191"/>
  <nd ref="12394725192"/>
</way>
  </create>
</osmChange>
```

</details>
