### PR TITLE
Disable logger in multithreaded test code

### DIFF
--- a/include/cgimap/logger.hpp
+++ b/include/cgimap/logger.hpp
@@ -21,7 +21,7 @@ namespace logger {
 /**
  * Initialise logging.
  */
-void initialise(const std::string &filename);
+void initialise(const std::string &filename = "");
 
 /**
  * Log a message.

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -22,6 +22,10 @@ static std::unique_ptr<std::ostream> stream;
 static pid_t pid;
 
 void initialise(const std::string &filename) {
+  if (filename.empty()) {
+    stream.reset();
+    return;
+  }
   stream = std::make_unique<std::ofstream>(filename, std::ios_base::out | std::ios_base::app);
   pid = getpid();
 }

--- a/test/test_apidb_backend_changeset_uploads.cpp
+++ b/test/test_apidb_backend_changeset_uploads.cpp
@@ -23,6 +23,7 @@
 
 #include <sys/time.h>
 
+#include "cgimap/logger.hpp"
 #include "cgimap/options.hpp"
 #include "cgimap/rate_limiter.hpp"
 #include "cgimap/routes.hpp"
@@ -115,6 +116,12 @@ struct CGImapListener : Catch::TestEventListenerBase, DatabaseTestsFixture {
   void testCaseEnded(Catch::TestCaseStats const& testCaseStats ) override {
     tdb.testcase_ended();
   }
+
+  void sectionStarting( Catch::SectionInfo const& sectionInfo ) override {
+    logger::initialise("/dev/null");
+  }
+
+  void sectionEnded( Catch::SectionStats const& sectionStats ) override {}
 };
 
 CATCH_REGISTER_LISTENER( CGImapListener )
@@ -601,6 +608,8 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_single_ways", "[changeset][upload]
 
   SECTION("Change existing way")
   {
+    logger::initialise(); // disable logger in this section, since it lacks multithreading support
+
     api06::OSMChange_Tracking change_tracking{};
     auto upd = tdb.get_data_update();
     auto way_updater = upd->get_way_updater(ctx, change_tracking);
@@ -1851,6 +1860,8 @@ TEST_CASE_METHOD( DatabaseTestsFixture, "test_single_relations", "[changeset][up
       }
 
       SECTION("Create new relation") {
+
+        logger::initialise(); // disable logger in this section, since it lacks multithreading support
 
         api06::OSMChange_Tracking change_tracking_new_rel{};
 


### PR DESCRIPTION
Fixes issue when running unit tests with `-fsanitize=thread`