### PR TITLE
output_buffer: error handling w/o exceptions

### DIFF
--- a/include/cgimap/api06/changeset_upload/node_updater.hpp
+++ b/include/cgimap/api06/changeset_upload/node_updater.hpp
@@ -25,6 +25,11 @@ using TagList = std::map<std::string, std::string>;
 class Node_Updater {
 
 public:
+  Node_Updater() = default;
+  Node_Updater(const Node_Updater&) = delete;
+  Node_Updater& operator=(const Node_Updater&) = delete;
+  Node_Updater(Node_Updater&&) = delete;
+  Node_Updater& operator=(Node_Updater&&) = delete;
   virtual ~Node_Updater() = default;
 
   virtual void add_node(double lat, double lon, osm_changeset_id_t changeset_id,

--- a/include/cgimap/backend/apidb/changeset_upload/node_updater.hpp
+++ b/include/cgimap/backend/apidb/changeset_upload/node_updater.hpp
@@ -32,6 +32,12 @@ public:
 
   ~ApiDB_Node_Updater() override = default;
 
+  // Non-copyable and non-movable
+  ApiDB_Node_Updater(const ApiDB_Node_Updater&) = delete;
+  ApiDB_Node_Updater& operator=(const ApiDB_Node_Updater&) = delete;
+  ApiDB_Node_Updater(ApiDB_Node_Updater&&) = delete;
+  ApiDB_Node_Updater& operator=(ApiDB_Node_Updater&&) = delete;
+
   void add_node(double lat, double lon, osm_changeset_id_t changeset_id,
                 osm_nwr_signed_id_t old_id, const api06::TagList &tags) override;
 

--- a/include/cgimap/brotli.hpp
+++ b/include/cgimap/brotli.hpp
@@ -34,10 +34,12 @@ public:
   brotli_output_buffer(brotli_output_buffer&&) = delete;
   brotli_output_buffer& operator=(brotli_output_buffer&&) = delete;
   ~brotli_output_buffer() override = default;
-  int write(const char *buffer, int len) override;
+
+  using output_buffer::write;
+  int write(const char *buffer, int len) noexcept override;
   int written() const override;
-  int close() override;
-  void flush() override;
+  int close() noexcept override;
+  int flush() noexcept override;
 
 private:
   int compress(const char *data, int data_length, bool last);

--- a/include/cgimap/brotli.hpp
+++ b/include/cgimap/brotli.hpp
@@ -27,9 +27,12 @@
  */
 class brotli_output_buffer : public output_buffer {
 public:
+  explicit brotli_output_buffer(output_buffer& o);
 
-  brotli_output_buffer(output_buffer& o);
   brotli_output_buffer(const brotli_output_buffer &old) = delete;
+  brotli_output_buffer& operator=(const brotli_output_buffer&) = delete;
+  brotli_output_buffer(brotli_output_buffer&&) = delete;
+  brotli_output_buffer& operator=(brotli_output_buffer&&) = delete;
   ~brotli_output_buffer() override = default;
   int write(const char *buffer, int len) override;
   int written() const override;

--- a/include/cgimap/logger.hpp
+++ b/include/cgimap/logger.hpp
@@ -26,7 +26,7 @@ void initialise(const std::string &filename = "");
 /**
  * Log a message.
  */
-void message(std::string_view m);
+void message(std::string_view m) noexcept;
 }
 
 #endif /* LOGGER_HPP */

--- a/include/cgimap/output_buffer.hpp
+++ b/include/cgimap/output_buffer.hpp
@@ -16,11 +16,13 @@
  * Implement this interface to provide custom output.
  */
 struct output_buffer {
-  virtual int write(const char *buffer, int len) = 0;
-  virtual int write(std::string_view str) { return write(str.data(), str.size()); }
+  // most methods here are noexcept, since they're also being called by C-style callbacks
+  // that don't support exceptions. A return code of -1 is used instead to signal errors.
+  virtual int write(const char *buffer, int len) noexcept = 0;
+  virtual int write(std::string_view str) noexcept { return write(str.data(), str.size()); }
   virtual int written() const = 0;
-  virtual int close() = 0;
-  virtual void flush() = 0;
+  virtual int close() noexcept = 0;
+  virtual int flush() noexcept = 0;
   virtual ~output_buffer() = default;
 
   output_buffer() = default;
@@ -35,12 +37,15 @@ struct output_buffer {
 class identity_output_buffer : public output_buffer
 {
 public:
+    using output_buffer::write;
     explicit identity_output_buffer(output_buffer& o) : out(o) {}
 
-    int write(const char *buffer, int len) override { return out.write(buffer, len); }
+    int write(const char *buffer, int len) noexcept override { return out.write(buffer, len); }
     int written() const override { return out.written(); }
-    int close() override { return out.close(); }
-    void flush() override { out.flush(); }
+    int close() noexcept override { return out.close(); }
+    int flush() noexcept override { return out.flush(); }
+
+    ~identity_output_buffer() override = default;
 
     identity_output_buffer(const identity_output_buffer&) = delete;
     identity_output_buffer& operator=(const identity_output_buffer&) = delete;

--- a/include/cgimap/request.hpp
+++ b/include/cgimap/request.hpp
@@ -80,7 +80,7 @@ struct request {
   int put(std::string_view str);
 
   // call this to flush output to the client.
-  void flush();
+  int flush();
 
   /******************** RESPONSE FINISHING FUNCTIONS ************************/
 

--- a/include/cgimap/zlib.hpp
+++ b/include/cgimap/zlib.hpp
@@ -42,13 +42,14 @@ public:
 
   ~zlib_output_buffer() override = default;
 
-  int write(const char *buffer, int len) override;
+  using output_buffer::write;
+  int write(const char *buffer, int len) noexcept override;
   int written() const override;
-  int close() override;
-  void flush() override;
+  int close() noexcept override;
+  int flush() noexcept override;
 
 private:
-  void flush_output();
+  int flush_output() noexcept;
 
   output_buffer& out;
   // keep track of bytes written because the z_stream struct doesn't seem to

--- a/src/backend/apidb/changeset_upload/node_updater.cpp
+++ b/src/backend/apidb/changeset_upload/node_updater.cpp
@@ -140,6 +140,7 @@ void ApiDB_Node_Updater::process_modify_nodes() {
   // Use new_ids as a result of inserting nodes in tmp table
   replace_old_ids_in_nodes(modify_nodes, ct.created_node_ids);
 
+  ids.reserve(modify_nodes.size());
   for (const auto &id : modify_nodes)
     ids.push_back(id.id);
 
@@ -194,6 +195,7 @@ void ApiDB_Node_Updater::process_delete_nodes() {
   // Use new_ids as a result of inserting nodes in tmp table
   replace_old_ids_in_nodes(delete_nodes, ct.created_node_ids);
 
+  ids.reserve(delete_nodes.size());
   for (const auto &node : delete_nodes)
     ids.push_back(node.id);
 
@@ -758,8 +760,8 @@ std::vector<osm_nwr_id_t> ApiDB_Node_Updater::insert_new_current_node_tags(
   auto stream = m.to_stream("current_node_tags", "node_id, k, v");
 
   for (const auto &node : nodes) {
-    for (const auto &tag : node.tags) {
-      stream.write_values(node.id, tag.first, tag.second);
+    for (const auto &[key, value] : node.tags) {
+      stream.write_values(node.id, key, value);
       ids.emplace_back(node.id);
     }
   }

--- a/src/backend/apidb/changeset_upload/relation_updater.cpp
+++ b/src/backend/apidb/changeset_upload/relation_updater.cpp
@@ -169,6 +169,7 @@ void ApiDB_Relation_Updater::process_modify_relations() {
 
   std::vector<osm_nwr_id_t> ids;
 
+  ids.reserve(modify_relations.size());
   for (const auto &id : modify_relations)
     ids.push_back(id.id);
 
@@ -279,6 +280,7 @@ void ApiDB_Relation_Updater::process_delete_relations() {
   replace_old_ids_in_relations(delete_relations, ct.created_node_ids,
                                ct.created_way_ids, ct.created_relation_ids);
 
+  ids.reserve(delete_relations.size());
   for (const auto &id : delete_relations)
     ids.push_back(id.id);
 
@@ -1373,8 +1375,8 @@ std::vector<osm_nwr_id_t>  ApiDB_Relation_Updater::insert_new_current_relation_t
   auto stream = m.to_stream("current_relation_tags", "relation_id, k, v");
 
   for (const auto &relation : relations) {
-    for (const auto &tag : relation.tags) {
-      stream.write_values(relation.id, tag.first, tag.second);
+    for (const auto &[key, value] : relation.tags) {
+      stream.write_values(relation.id, key, value);
       ids.emplace_back(relation.id);
     }
   }

--- a/src/backend/apidb/changeset_upload/way_updater.cpp
+++ b/src/backend/apidb/changeset_upload/way_updater.cpp
@@ -13,7 +13,6 @@
 #include "cgimap/backend/apidb/utils.hpp"
 #include "cgimap/backend/apidb/transaction_manager.hpp"
 #include "cgimap/http.hpp"
-#include "cgimap/options.hpp"
 #include "cgimap/util.hpp"
 
 #include <algorithm>
@@ -168,6 +167,7 @@ void ApiDB_Way_Updater::process_modify_ways() {
   replace_old_ids_in_ways(modify_ways, ct.created_node_ids,
                           ct.created_way_ids);
 
+  ids.reserve(modify_ways.size());
   for (const auto &id : modify_ways)
     ids.push_back(id.id);
 
@@ -230,6 +230,7 @@ void ApiDB_Way_Updater::process_delete_ways() {
   replace_old_ids_in_ways(delete_ways, ct.created_node_ids,
                           ct.created_way_ids);
 
+  ids.reserve(delete_ways.size());
   for (const auto &id : delete_ways)
     ids.push_back(id.id);
 
@@ -776,8 +777,8 @@ std::vector<osm_nwr_id_t> ApiDB_Way_Updater::insert_new_current_way_tags(
   auto stream = m.to_stream("current_way_tags", "way_id, k, v");
 
   for (const auto &way : ways) {
-    for (const auto &tag : way.tags) {
-      stream.write_values(way.id, tag.first, tag.second);
+    for (const auto &[key, value] : way.tags) {
+      stream.write_values(way.id, key, value);
       ids.emplace_back(way.id);
     }
   }

--- a/src/brotli.cpp
+++ b/src/brotli.cpp
@@ -6,8 +6,8 @@
  * Copyright (C) 2009-2025 by the openstreetmap-cgimap developer community.
  * For a full list of authors see the git log.
  */
- 
- 
+
+
 #include "cgimap/brotli.hpp"
 
 #include <stdexcept>

--- a/src/brotli.cpp
+++ b/src/brotli.cpp
@@ -10,7 +10,7 @@
 
 #include "cgimap/brotli.hpp"
 
-#include <stdexcept>
+#include <cassert>
 
 #if HAVE_BROTLI
 
@@ -56,11 +56,11 @@ int brotli_output_buffer::compress(const char *data, int data_length, bool last)
 }
 
 
-int brotli_output_buffer::write(const char *buffer, int len) {
+int brotli_output_buffer::write(const char *buffer, int len) noexcept {
   return compress(buffer, len, false);
 }
 
-int brotli_output_buffer::close() {
+int brotli_output_buffer::close() noexcept {
   if (!flushed)
     flush();
 
@@ -72,12 +72,13 @@ int brotli_output_buffer::close() {
 int brotli_output_buffer::written() const { return bytes_in; }
 
 
-void brotli_output_buffer::flush() {
-  if (flushed)
-    throw std::runtime_error("Brotli does not support multiple flush operations");
+int brotli_output_buffer::flush() noexcept {
+
+  assert(!flushed); // brotli does not support multiple flush operations
 
   compress(nullptr, 0, true);
   flushed = true;
+  return 0;
 }
 
 #endif

--- a/src/brotli.cpp
+++ b/src/brotli.cpp
@@ -3,7 +3,7 @@
  *
  * This file is part of openstreetmap-cgimap (https://github.com/zerebubuth/openstreetmap-cgimap/).
  *
- * Copyright (C) 2006-2023 by the CGImap developer community.
+ * Copyright (C) 2009-2025 by the openstreetmap-cgimap developer community.
  * For a full list of authors see the git log.
  */
  

--- a/src/fcgi_request.cpp
+++ b/src/fcgi_request.cpp
@@ -34,7 +34,8 @@ struct fcgi_buffer : public output_buffer {
 
   ~fcgi_buffer() override = default;
 
-  int write(const char *buffer, int len) override {
+  using output_buffer::write;
+  int write(const char *buffer, int len) noexcept override {
     int bytes = FCGX_PutStr(buffer, len, m_req.out);
     if (bytes >= 0) {
       m_written += bytes;
@@ -44,9 +45,9 @@ struct fcgi_buffer : public output_buffer {
 
   [[nodiscard]] int written() const override { return m_written; }
 
-  int close() override { return FCGX_FClose(m_req.out); }
+  int close() noexcept override { return FCGX_FClose(m_req.out); }
 
-  void flush() override { FCGX_FFlush(m_req.out); }
+  int flush() noexcept override { return FCGX_FFlush(m_req.out); }
 
 private:
   FCGX_Request m_req;

--- a/src/json_writer.cpp
+++ b/src/json_writer.cpp
@@ -45,16 +45,7 @@ json_writer::~json_writer() noexcept {
   }
 
   yajl_gen_free(gen);
-
-  try {
-    out.close();
-  } catch (...) {
-    // don't do anything here or we risk FUBARing the entire program.
-    // it might not be possible to end the document because the output
-    // stream went away. if so, then there is nothing to do but try
-    // and reclaim the extra memory.
-  }
-
+  out.close();
 }
 
 void json_writer::start_object() {

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -30,7 +30,7 @@ void initialise(const std::string &filename) {
   pid = getpid();
 }
 
-void message(std::string_view m) {
+void message(std::string_view m) noexcept {
   if (stream) {
     time_t now = time(nullptr);
     *stream << "[" << std::put_time( std::gmtime( &now ), "%FT%T") << " #" << pid << "] " << m

--- a/src/process_request.cpp
+++ b/src/process_request.cpp
@@ -420,7 +420,7 @@ void process_request(request &req, rate_limiter &limiter,
 
   try {
 
-    RequestContext req_ctx{req};
+    RequestContext req_ctx{.req=req};
 
     std::setlocale(LC_ALL, "C.UTF-8");
 

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -59,7 +59,7 @@ int request::put(std::string_view str) {
   return get_buffer().write(str);
 }
 
-void request::flush() { get_buffer().flush(); }
+int request::flush() { return get_buffer().flush(); }
 
 void request::finish() {
   check_workflow(status_FINISHED);

--- a/src/request_helpers.cpp
+++ b/src/request_helpers.cpp
@@ -108,12 +108,13 @@ namespace {
  */
 class fcgi_output_buffer : public output_buffer {
 public:
-  int write(const char *buffer, int len) override {
+  using output_buffer::write;
+  int write(const char *buffer, int len) noexcept override {
     w += len;
     return r.put(buffer, len);
   }
 
-  int close() override {
+  int close() noexcept override {
     // we don't actually close the request output, as that happens
     // automatically on the next call to accept.
     return 0;
@@ -121,10 +122,10 @@ public:
 
   [[nodiscard]] int written() const override { return w; }
 
-  void flush() override {
+  int flush() noexcept override {
     // there's a note that says this causes too many writes and decreases
     // efficiency, but we're only calling it once...
-    r.flush();
+    return r.flush();
   }
 
   ~fcgi_output_buffer() override = default;

--- a/test/test_empty_selection.hpp
+++ b/test/test_empty_selection.hpp
@@ -3,7 +3,7 @@
  *
  * This file is part of openstreetmap-cgimap (https://github.com/zerebubuth/openstreetmap-cgimap/).
  *
- * Copyright (C) 2006-2023 by the CGImap developer community.
+ * Copyright (C) 2009-2025 by the openstreetmap-cgimap developer community.
  * For a full list of authors see the git log.
  */
 

--- a/test/test_request.cpp
+++ b/test/test_request.cpp
@@ -17,7 +17,7 @@ test_output_buffer::test_output_buffer(std::ostream &out, std::ostream &body)
   : m_out(out), m_body(body) {
 }
 
-int test_output_buffer::write(const char *buffer, int len) {
+int test_output_buffer::write(const char *buffer, int len) noexcept {
   m_body.write(buffer, len);
   m_out.write(buffer, len);
   m_written += len;
@@ -28,11 +28,11 @@ int test_output_buffer::written() const {
   return m_written;
 }
 
-int test_output_buffer::close() {
+int test_output_buffer::close() noexcept {
   return 0;
 }
 
-void test_output_buffer::flush() {}
+int test_output_buffer::flush() noexcept { return 0; }
 
 const char *test_request::get_param(const char *key) const {
   std::string key_str(key);

--- a/test/test_request.hpp
+++ b/test/test_request.hpp
@@ -31,10 +31,11 @@ struct test_output_buffer : public output_buffer {
   test_output_buffer(test_output_buffer&&) = delete;
   test_output_buffer& operator=(test_output_buffer&&) = delete;
 
-  int write(const char *buffer, int len) override;
+  using output_buffer::write;
+  int write(const char *buffer, int len) noexcept override;
   [[nodiscard]] int written() const override;
-  int close() override;
-  void flush() override;
+  int close() noexcept override;
+  int flush() noexcept override;
 
 private:
   std::ostream &m_out;


### PR DESCRIPTION
Summary of changes:

* Set own handler via `xmlSetGenericErrorFunc` in xml_writer.cpp, instead of implicitly reusing stale xmlpp defined handler. This is relevant for POST/PUT endpoints which process user provided XML files, and respond with an XML message. The xmlpp handler would be used, in case output_buffer methods fail.
* All output_buffer methods are now noexcept, since they're calling C libraries (FCGI, brotli, zlib) only, which don't throw. We are returning  -1  in case of error now instead of throwing exceptions.
*  `wrap_write` and `wrap_close` functions were previously potentially throwing exceptions, which is not permitted in the context of C callback functions (UB). This issue seems to be around since 2011 or so.
* Fixes for CppCoreGuidelines _C.138: Create an overload set for a derived class and its bases with using_, addressed by adding: `using output_buffer::write;`
* Minor cleanups (see commits)
