### PR TITLE
Ignore multiple brotli flush requests

### DIFF
--- a/src/brotli.cpp
+++ b/src/brotli.cpp
@@ -74,7 +74,9 @@ int brotli_output_buffer::written() const { return bytes_in; }
 
 int brotli_output_buffer::flush() noexcept {
 
-  assert(!flushed); // brotli does not support multiple flush operations
+  if (flushed) { // brotli does not support multiple flush operations
+    return 0;
+  }
 
   compress(nullptr, 0, true);
   flushed = true;


### PR DESCRIPTION
For text_responder based handlers, brotli_output_buffer flush method was called twice:

From src/process_request.cpp:210

```
      // make sure all bytes have been written. note that the writer can
      // throw an exception here, leaving the xml document in a
      // half-written state...
      o_formatter->flush();
      out->flush();
```

This was triggering an unnecessary assertion failure.

The impacted endpoint "create changeset" is not used in osm.org production.