### PR TITLE
Refactor HTTP Accept-Encoding header parsing

### DIFF
--- a/include/cgimap/api06/changeset_upload/osmobject.hpp
+++ b/include/cgimap/api06/changeset_upload/osmobject.hpp
@@ -12,6 +12,7 @@
 
 #include "cgimap/types.hpp"
 #include "cgimap/util.hpp"
+#include "cgimap/http.hpp"
 
 #include <charconv>
 #include <map>

--- a/include/cgimap/http.hpp
+++ b/include/cgimap/http.hpp
@@ -339,7 +339,7 @@ public:
  * Parses an Accept-Encoding header and returns the chosen
  * encoding.
  */
-const http::encoding* choose_encoding(const std::string &accept_encoding);
+const http::encoding* choose_encoding(std::string_view accept_encoding);
 
 std::unique_ptr<ZLibBaseDecompressor> get_content_encoding_handler(std::string_view content_encoding);
 

--- a/include/cgimap/http.hpp
+++ b/include/cgimap/http.hpp
@@ -63,7 +63,7 @@ private:
 
 protected:
   template <typename T>
-  exception(int c, T&& m) :
+  constexpr exception(int c, T&& m) :
     std::runtime_error(std::forward<T>(m)),
     code_(c) {}
 
@@ -83,7 +83,7 @@ public:
 class server_error : public exception {
 public:
   template <typename T>
-  explicit server_error(T&& message) : exception(500, std::forward<T>(message)) {}
+  explicit constexpr server_error(T&& message) : exception(500, std::forward<T>(message)) {}
 };
 
 /**
@@ -93,7 +93,7 @@ public:
 class bad_request : public exception {
 public:
   template <typename T>
-  explicit bad_request(T&& message) : exception(400, std::forward<T>(message)) {}
+  explicit constexpr bad_request(T&& message) : exception(400, std::forward<T>(message)) {}
 };
 
 /**
@@ -104,7 +104,7 @@ public:
 class forbidden : public exception {
 public:
   template <typename T>
-  explicit forbidden(T&& message) : exception(403, std::forward<T>(message)) {}
+  explicit constexpr forbidden(T&& message) : exception(403, std::forward<T>(message)) {}
 };
 
 /**
@@ -126,7 +126,7 @@ public:
 class not_acceptable : public exception {
 public:
   template <typename T>
-  explicit not_acceptable(T&& message) : exception(406, std::forward<T>(message)) {}
+  explicit constexpr not_acceptable(T&& message) : exception(406, std::forward<T>(message)) {}
 };
 
 /**
@@ -137,7 +137,7 @@ public:
 class conflict : public exception {
 public:
   template <typename T>
-  explicit conflict(T&& message) : exception(409, std::forward<T>(message)) {}
+  explicit constexpr conflict(T&& message) : exception(409, std::forward<T>(message)) {}
 };
 
 /**
@@ -147,11 +147,11 @@ public:
 class precondition_failed : public exception {
 public:
   template <typename T>
-  explicit precondition_failed(T&& message) :
+  explicit constexpr precondition_failed(T&& message) :
     exception(412, std::forward<T>(message)),
     fullstring("Precondition failed: " + std::string(exception::what())) {}
 
-  const char *what() const noexcept override {
+  constexpr const char *what() const noexcept override {
     return fullstring.c_str();
   }
 
@@ -167,7 +167,7 @@ private:
 class payload_too_large : public exception {
 public:
   template <typename T>
-  explicit payload_too_large(T&& message) : exception(413, std::forward<T>(message)) {}
+  explicit constexpr payload_too_large(T&& message) : exception(413, std::forward<T>(message)) {}
 };
 
 
@@ -179,7 +179,7 @@ public:
 class too_many_requests : public exception {
 public:
   template <typename T>
-  explicit too_many_requests(T&& message) : exception(429, std::forward<T>(message)) {}
+  explicit constexpr too_many_requests(T&& message) : exception(429, std::forward<T>(message)) {}
 };
 
 
@@ -190,7 +190,7 @@ public:
 class not_found : public exception {
 public:
   template <typename T>
-  explicit not_found(T&& message) : exception(404, std::forward<T>(message)) {}
+  explicit constexpr not_found(T&& message) : exception(404, std::forward<T>(message)) {}
 };
 
 /**
@@ -218,7 +218,7 @@ public:
 class unauthorized : public exception {
 public:
   template <typename T>
-  explicit unauthorized(T&& message) : exception(401, std::forward<T>(message)) {}
+  explicit constexpr unauthorized(T&& message) : exception(401, std::forward<T>(message)) {}
 };
 
 /**
@@ -228,7 +228,7 @@ public:
 class unsupported_media_type : public exception {
 public:
   template <typename T>
-  explicit unsupported_media_type(T&& message) : exception(415, std::forward<T>(message)) {}
+  explicit constexpr unsupported_media_type(T&& message) : exception(415, std::forward<T>(message)) {}
 };
 
 /**
@@ -263,35 +263,36 @@ private:
   const std::string name_;
 
 public:
-  explicit encoding(std::string name) : name_(std::move(name)){}
+  explicit constexpr encoding(std::string name) : name_(std::move(name)){}
   virtual ~encoding() = default;
 
   const std::string &name() const { return name_; };
 
-  virtual std::unique_ptr<output_buffer>  buffer(output_buffer& out) {
+  virtual std::unique_ptr<output_buffer> buffer(output_buffer& out) const {
     return std::make_unique<identity_output_buffer>(out);
   }
 };
 
 class identity : public encoding {
 public:
-  identity() : encoding("identity"){};
+  constexpr identity() : encoding("identity"){};
 };
 
 #ifdef HAVE_LIBZ
 class deflate : public encoding {
 public:
-  deflate() : encoding("deflate"){}
+  constexpr deflate() : encoding("deflate"){}
 
-  std::unique_ptr<output_buffer> buffer(output_buffer& out) override {
+  std::unique_ptr<output_buffer> buffer(output_buffer& out) const override {
     return std::make_unique<zlib_output_buffer>(out, zlib_output_buffer::mode::zlib);
   }
 };
 
 class gzip : public encoding {
 public:
-  gzip() : encoding("gzip"){}
-  std::unique_ptr<output_buffer> buffer(output_buffer& out) override {
+  constexpr gzip() : encoding("gzip"){}
+
+  std::unique_ptr<output_buffer> buffer(output_buffer& out) const override {
     return std::make_unique<zlib_output_buffer>(out, zlib_output_buffer::mode::gzip);
   }
 };
@@ -301,8 +302,9 @@ public:
 
 class brotli : public encoding {
 public:
-  brotli() : encoding("br"){}
-  std::unique_ptr<output_buffer> buffer(output_buffer& out) override {
+  constexpr brotli() : encoding("br"){}
+
+  std::unique_ptr<output_buffer> buffer(output_buffer& out) const override {
     return std::make_unique<brotli_output_buffer>(out);
   }
 };

--- a/include/cgimap/http.hpp
+++ b/include/cgimap/http.hpp
@@ -15,6 +15,7 @@
 #include <string_view>
 #include <vector>
 #include <optional>
+#include <ranges>
 
 #ifdef HAVE_LIBZ
 #include "cgimap/zlib.hpp"
@@ -268,6 +269,10 @@ public:
 
   const std::string &name() const { return name_; };
 
+  constexpr bool matches(std::string_view encoding_id) const {
+    return encoding_id == name_ || encoding_id == "*";
+  }
+
   virtual std::unique_ptr<output_buffer> buffer(output_buffer& out) const {
     return std::make_unique<identity_output_buffer>(out);
   }
@@ -276,12 +281,22 @@ public:
 class identity : public encoding {
 public:
   constexpr identity() : encoding("identity"){};
+
+  static inline identity& instance() {
+    static identity instance_{};
+    return instance_;
+  }
 };
 
 #ifdef HAVE_LIBZ
 class deflate : public encoding {
 public:
   constexpr deflate() : encoding("deflate"){}
+
+  static inline deflate& instance() {
+    static deflate instance_{};
+    return instance_;
+  }
 
   std::unique_ptr<output_buffer> buffer(output_buffer& out) const override {
     return std::make_unique<zlib_output_buffer>(out, zlib_output_buffer::mode::zlib);
@@ -291,6 +306,11 @@ public:
 class gzip : public encoding {
 public:
   constexpr gzip() : encoding("gzip"){}
+
+  static inline gzip& instance() {
+    static gzip instance_{};
+    return instance_;
+  }
 
   std::unique_ptr<output_buffer> buffer(output_buffer& out) const override {
     return std::make_unique<zlib_output_buffer>(out, zlib_output_buffer::mode::gzip);
@@ -304,6 +324,11 @@ class brotli : public encoding {
 public:
   constexpr brotli() : encoding("br"){}
 
+  static inline brotli& instance() {
+    static brotli instance_{};
+    return instance_;
+  }
+
   std::unique_ptr<output_buffer> buffer(output_buffer& out) const override {
     return std::make_unique<brotli_output_buffer>(out);
   }
@@ -314,7 +339,7 @@ public:
  * Parses an Accept-Encoding header and returns the chosen
  * encoding.
  */
-std::unique_ptr<http::encoding> choose_encoding(const std::string &accept_encoding);
+const http::encoding* choose_encoding(const std::string &accept_encoding);
 
 std::unique_ptr<ZLibBaseDecompressor> get_content_encoding_handler(std::string_view content_encoding);
 
@@ -343,6 +368,46 @@ std::optional<method> parse_method(std::string_view s);
 
 // parse CONTENT_LENGTH HTTP header
 unsigned long parse_content_length(const std::string &);
+
+
+// Parsing view for HTTP header list values.
+// views into input string, does NOT copy values -> beware dangling references
+
+struct HttpParameterView {
+  std::string_view key;
+  std::string_view value;
+
+  static HttpParameterView parse(std::string_view param);
+};
+
+struct HttpItemView {
+  std::string_view item;
+  std::vector<HttpParameterView> parameters;
+
+  static HttpItemView parse(std::string_view list_value);
+};
+
+struct HttpListView {
+  std::vector<HttpItemView> values;
+
+  static constexpr auto parse(std::string_view header) {
+    auto xs = header 
+      | std::ranges::views::split(',')
+      | std::ranges::views::transform([](const auto& x){ return std::string_view{x.begin(), x.end()}; })
+      | std::ranges::views::transform(HttpItemView::parse);
+
+    if (std::ranges::empty(xs)) {
+      throw bad_request("Invalid empty http header");
+    }
+
+    return xs;
+  }
+
+  explicit constexpr HttpListView(std::string_view header) : values{/* C++23: {std::from_range_t, parse(header)} */} {
+    auto xs = parse(header);
+    values = {xs.begin(), xs.end()};
+  }
+};
 
 } // namespace http
 

--- a/include/cgimap/request_helpers.hpp
+++ b/include/cgimap/request_helpers.hpp
@@ -42,7 +42,7 @@ std::string get_request_path(const request &req);
 /**
  * get encoding to use for response.
  */
-std::unique_ptr<http::encoding> get_encoding(const request &req);
+const http::encoding* get_encoding(const request &req);
 
 /**
  * return shared pointer to a buffer object which can be

--- a/include/cgimap/util.hpp
+++ b/include/cgimap/util.hpp
@@ -93,7 +93,7 @@ concept StringLike = std::is_same_v<std::remove_cvref_t<T>, std::string> ||
                      std::is_same_v<std::remove_cvref_t<T>, std::string_view>;
 
 template <StringLike T>
-inline T trim(T str) {
+constexpr T trim(T str) {
   auto start = str.find_first_not_of(" \t\n\r");
   if (start == T::npos)
       return {};

--- a/include/cgimap/util.hpp
+++ b/include/cgimap/util.hpp
@@ -22,6 +22,8 @@
 #include <string>
 #include <string_view>
 #include <ranges>
+#include <utility>
+#include <iterator>
 
 #include <fmt/core.h>
 #include <fmt/format.h>
@@ -175,6 +177,15 @@ inline std::string escape(std::string_view input) {
 template <typename T>
 inline std::string to_string(const T &ids) {
   return fmt::format("{}", fmt::join(ids, ","));
+}
+
+constexpr auto pop_or_throw(auto& begin_it, const auto& end_it, const auto& e) {
+  if (begin_it == end_it)
+    throw e;
+  
+  auto tmp = std::move(*begin_it);
+  std::ranges::advance(begin_it, 1, end_it);
+  return tmp;
 }
 
 

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <ranges>
 #include <string_view>
+#include <algorithm>
 
 
 namespace {
@@ -152,89 +153,74 @@ std::vector<std::pair<std::string, std::string>> parse_params(const std::string 
   return queryKVPairs;
 }
 
-std::unique_ptr<encoding> choose_encoding(const std::string &accept_encoding) {
+static const std::vector<const encoding*> supported_encodings = {{
+  // Order of elements determines chosen encoding for * wildcard value
+  #if HAVE_BROTLI
+  &brotli::instance(),
+  #endif
+  #ifdef HAVE_LIBZ
+  &gzip::instance(),
+  &deflate::instance(),
+  #endif
+  &identity::instance()
+}};
 
-  using namespace std::literals;
+const std::vector<const encoding*>& get_supported_encodings() {
+  return supported_encodings;
+}
 
-  std::vector<std::string_view> encodings;
+const encoding* choose_encoding(const std::string &accept_encoding) {
+  std::vector<std::pair<const encoding*, float>> potential_encodings{};
 
-  for (auto parts = std::ranges::views::split(accept_encoding, ", "sv); auto&& part : parts) {
-    encodings.emplace_back(&*part.begin(), std::ranges::distance(part));
-  }
+  HttpListView accept_encodings{accept_encoding};
+  
+  for (const auto& encoding_id : accept_encodings.values) {
+    for (const auto& enc : get_supported_encodings()) {
+      if (enc->matches(encoding_id.item)) {
+        float q = 1.0;
 
-  float identity_quality = 0.000;
-  float deflate_quality = 0.000;
-  float gzip_quality = 0.000;
-  float brotli_quality = 0.000;
+        for (const auto& param : encoding_id.parameters) {
+          if (param.key == "q") {
+            auto [last_parsed, ec] = std::from_chars(param.value.begin(), param.value.end(), q);
 
-  // set default if header empty
-  if (encodings.empty())
-    encodings.emplace_back("*");
+            if ((ec != std::errc()) || 
+                (last_parsed != param.value.end()) || 
+                !(std::isfinite(q) && 0.0 <= q && q <= 1.0)) {
+              throw http::bad_request("Malformed encoding quality value parameter");
+            }
+            break;
+          }
+        }
 
-  for (auto encoding : encodings) {
-
-    std::string name;
-    float quality = 0.0;
-
-    std::vector<std::string> what;
-
-    for (auto parts = std::ranges::views::split(encoding, ";q="sv); auto&& part : parts) {
-      what.emplace_back(std::string(&*part.begin(), std::ranges::distance(part)));
-    }
-
-    if (what.size() == 2) {
-      float q = std::stof(what[1]);
-      if (q >= 0 && q <= 1) {
-        name = what[0];
-        quality = q;
+        if (q == 1.0) {
+          // Short circuit using first accepted encoding with highest quality 1.0
+          return enc;
+        }
+        potential_encodings.emplace_back(enc, q);
       }
     }
-    else if (what.size() == 1) {
-      name = what[0];
-      quality = 1.0;
-    }
+  }
 
-    if (name == "identity") {
-      identity_quality = quality;
-    } else if (name == "deflate") {
-      deflate_quality = quality;
-    } else if (name == "gzip") {
-      gzip_quality = quality;
-    } else if (name == "br") {
-      brotli_quality = quality;
-    } else if (name == "*") {
-      if (identity_quality == 0.000)
-        identity_quality = quality;
-      if (deflate_quality == 0.000)
-        deflate_quality = quality;
-      if (gzip_quality == 0.000)
-        gzip_quality = quality;
-      if (brotli_quality == 0.000)
-        brotli_quality = quality;
+  std::ranges::stable_sort(potential_encodings, 
+                           std::ranges::greater(), 
+                           &std::pair<const encoding*, float>::second);
+
+  // Find first non 0 quality encoding
+  auto identity_encoding = &http::identity::instance();
+  bool identity_is_acceptable = true;
+  for (const auto& enc : potential_encodings) {
+    if (enc.second != 0.0) {
+      return enc.first;
+    } else if(enc.first->matches(identity_encoding->name())) {
+      identity_is_acceptable = false;
     }
   }
 
-#if HAVE_BROTLI
-  if (brotli_quality > 0.0 && brotli_quality >= identity_quality &&
-      brotli_quality >= deflate_quality &&
-      brotli_quality >= gzip_quality) {
-    return std::make_unique<brotli>();
+  if (!identity_is_acceptable) {
+    throw http::not_acceptable("No acceptable content encoding found.");
   }
-#endif
-#ifdef HAVE_LIBZ
-  if (deflate_quality > 0.0 && deflate_quality >= gzip_quality &&
-      deflate_quality >= identity_quality) {
-    return std::make_unique<deflate>();
-  } else if (gzip_quality > 0.0 && gzip_quality >= identity_quality) {
-    return std::make_unique<gzip>();
-  }
-#endif /* HAVE_LIBZ */
-  else if (identity_quality > 0.0) {
-    return std::make_unique<identity>();
-  } else {
-    throw http::not_acceptable("No acceptable content encoding found. Only "
-                               "identity and gzip are supported.");
-  }
+
+  return identity_encoding;
 }
 
 std::unique_ptr<ZLibBaseDecompressor> get_content_encoding_handler(std::string_view content_encoding) {
@@ -308,6 +294,53 @@ unsigned long parse_content_length(const std::string &content_length_str) {
     throw http::payload_too_large(fmt::format("CONTENT_LENGTH exceeds limit of {:d} bytes", global_settings::get_payload_max_size()));
 
   return length;
+}
+
+
+http::HttpParameterView http::HttpParameterView::parse(std::string_view param) {
+  auto param_parts = param 
+    | std::ranges::views::split('=') 
+    | std::ranges::views::transform([](const auto& x){ return trim(std::string_view{x.begin(), x.end()}); });
+
+  auto param_begin = param_parts.begin();
+  auto param_end = param_parts.end();
+
+  std::string_view param_key = pop_or_throw(param_begin, param_end, http::bad_request("Missing parameter key in http header list"));
+  if (param_key.empty()) {
+    throw http::bad_request("Empty parameter key in http header list");
+  }
+  std::string_view param_value = pop_or_throw(param_begin, param_end, http::bad_request("Missing parameter value in http header list"));
+  if (param_value.empty()) {
+    throw http::bad_request("Empty parameter value in http header list");
+  }
+
+  if (param_begin != param_end) {
+    throw http::bad_request("Malformed parameter in http header list");
+  }
+
+  return {param_key, param_value};
+}
+
+http::HttpItemView http::HttpItemView::parse(std::string_view list_value) {
+  auto params = list_value 
+    | std::ranges::views::split(';') 
+    | std::ranges::views::transform([](const auto& x){ return trim(std::string_view{x.begin(), x.end()}); });
+
+  if (std::ranges::empty(params)) {
+    throw http::bad_request("Malformed http header list value");
+  }
+
+  auto item = params.front();
+
+  if (item.empty()) {
+    throw http::bad_request("Malformed http header list value");
+  }
+
+  auto xs = params
+    | std::views::drop(1)
+    | std::views::transform(http::HttpParameterView::parse);
+
+  return http::HttpItemView{item, {xs.begin(), xs.end()}};
 }
 
 } // namespace http

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -169,7 +169,7 @@ const std::vector<const encoding*>& get_supported_encodings() {
   return supported_encodings;
 }
 
-const encoding* choose_encoding(const std::string &accept_encoding) {
+const encoding* choose_encoding(std::string_view accept_encoding) {
   std::vector<std::pair<const encoding*, float>> potential_encodings{};
 
   HttpListView accept_encodings{accept_encoding};

--- a/src/request_helpers.cpp
+++ b/src/request_helpers.cpp
@@ -94,7 +94,7 @@ const http::encoding* get_encoding(const request &req) {
   const char *accept_encoding = req.get_param("HTTP_ACCEPT_ENCODING");
 
   if (accept_encoding) {
-    return http::choose_encoding(std::string(accept_encoding));
+    return http::choose_encoding(accept_encoding);
   } else {
     return &http::identity::instance();
   }

--- a/src/request_helpers.cpp
+++ b/src/request_helpers.cpp
@@ -90,13 +90,13 @@ std::string get_request_path(const request &req) {
 /**
  * get encoding to use for response.
  */
-std::unique_ptr<http::encoding> get_encoding(const request &req) {
+const http::encoding* get_encoding(const request &req) {
   const char *accept_encoding = req.get_param("HTTP_ACCEPT_ENCODING");
 
   if (accept_encoding) {
     return http::choose_encoding(std::string(accept_encoding));
   } else {
-    return std::make_unique<http::identity>();
+    return &http::identity::instance();
   }
 }
 

--- a/test/test_http.cpp
+++ b/test/test_http.cpp
@@ -13,6 +13,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <string_view>
+
 struct test_responder : responder {
 
   using responder::responder;
@@ -68,18 +70,79 @@ TEST_CASE("http_check_choose_encoding", "[http]") {
   CHECK(http::choose_encoding("deflate, gzip;q=1.0, *;q=0.5")->name() == "deflate");
   CHECK(http::choose_encoding("gzip;q=1.0, identity;q=0.8, *;q=0.1")->name() == "gzip");
   CHECK(http::choose_encoding("identity;q=0.8, gzip;q=1.0, *;q=0.1")->name() == "gzip");
+  CHECK(http::choose_encoding("identity ; q=0.8, gzip ;q=1.0, *; q=0.1")->name() == "gzip");
+  CHECK(http::choose_encoding("identity;q=0.8,gzip;q=1.0, *;q=0.1")->name() == "gzip");
   CHECK(http::choose_encoding("gzip")->name() == "gzip");
   CHECK(http::choose_encoding("identity")->name() == "identity");
-  CHECK(http::choose_encoding("*")->name() == "br");
   CHECK(http::choose_encoding("deflate")->name() == "deflate");
 #if HAVE_BROTLI
-  CHECK(http::choose_encoding("gzip, deflate, br")->name() == "br");
+  CHECK(http::choose_encoding("*")->name() == "br");
+  CHECK(http::choose_encoding("gzip, deflate, br")->name() == "gzip");
+  CHECK(http::choose_encoding("br, gzip, deflate")->name() == "br");
+  CHECK(http::choose_encoding("deflate, br, gzip")->name() == "deflate");
   CHECK(http::choose_encoding("zstd;q=1.0, deflate;q=0.8, br;q=0.9")->name() == "br");
   CHECK(http::choose_encoding("zstd;q=1.0, unknown;q=0.8, br;q=0.9")->name() == "br");
-  CHECK(http::choose_encoding("gzip, deflate, br")->name() == "br");
+#else
+  CHECK(http::choose_encoding("*")->name() == "gzip");
 #endif
   // test unsupported encoding
-  CHECK_THROWS_AS(http::choose_encoding("zstd"), http::not_acceptable);
+  CHECK(http::choose_encoding("zstd")->name() == "identity");
+  CHECK_THROWS_AS(http::choose_encoding("zstd, identity;q=0.0"), http::not_acceptable);
+  CHECK_THROWS_AS(http::choose_encoding("zstd, *;q=0.0"), http::not_acceptable);
+}
+
+TEST_CASE("http_check_choose_encoding bad param value", "[http]") {
+  CHECK_THROWS_AS(http::choose_encoding("gzip;q=a"), http::bad_request);
+  CHECK_THROWS_AS(http::choose_encoding("gzip;q=1.3"), http::bad_request);
+  CHECK_THROWS_AS(http::choose_encoding("gzip;q=-0.5"), http::bad_request);
+  CHECK_THROWS_AS(http::choose_encoding("gzip;q=0.34.56"), http::bad_request);
+}
+
+TEST_CASE("HttpListView parsing", "[http]") {
+  using namespace std::string_view_literals;
+
+  std::string_view header_string = "deflate, gzip;q=1.0;test=foo;a=b;c=d, *;q=0.5";
+  http::HttpListView h{header_string};
+
+  CHECK(h.values.size() == 3);
+
+  CHECK(h.values[0].item == "deflate"sv);
+
+  CHECK(h.values[1].item == "gzip"sv);
+  CHECK(h.values[1].parameters.size() == 4);
+  CHECK(h.values[1].parameters[0].key == "q"sv);
+  CHECK(h.values[1].parameters[0].value == "1.0"sv);
+  CHECK(h.values[1].parameters[1].key == "test"sv);
+  CHECK(h.values[1].parameters[1].value == "foo"sv);
+  CHECK(h.values[1].parameters[2].key == "a"sv);
+  CHECK(h.values[1].parameters[2].value == "b"sv);
+  CHECK(h.values[1].parameters[3].key == "c"sv);
+  CHECK(h.values[1].parameters[3].value == "d"sv);
+
+  CHECK(h.values[2].item == "*"sv);
+  CHECK(h.values[2].parameters.size() == 1);
+  CHECK(h.values[2].parameters[0].key == "q"sv);
+  CHECK(h.values[2].parameters[0].value == "0.5"sv);
+}
+
+TEST_CASE("HttpListView parsing malformed param", "[http]") {
+  using namespace std::string_view_literals;
+  CHECK_THROWS_AS(http::HttpListView{"deflate, gzip;q=1.0;test=foo=a=b;c=d, *;q=0.5"sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{" "sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{";"sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{","sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{"deflate, "sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{"deflate, ;"sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{"deflate , gzip ; "sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{"deflate , gzip ; q"sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{"deflate , gzip ; q="sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{"deflate , gzip ; q=0.5="sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{"deflate , gzip ; q=0.5;"sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{"deflate , gzip ; =0.5"sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{"deflate,, *;q=0.5"sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{"deflate, gzip;, *;q=0.5"sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{"deflate, gzip;q, *;q=0.5"sv}, http::bad_request);
+  CHECK_THROWS_AS(http::HttpListView{"deflate, gzip;q=, *;q=0.5"sv}, http::bad_request);
 }
 
 TEST_CASE("http_check_accept_header_parsing", "[http]") {


### PR DESCRIPTION
Implement a generic HTTP list header parser and use it to replace the current Accept-Encoding header parsing. 

Properly handle optional whitespace in list items/parameters. Prioritize encodings in order requested by user (https://github.com/zerebubuth/openstreetmap-cgimap/issues/540#issuecomment-3554307304).

Change encoding classes to singletons since they are only used as factories and don't hold any state.

---

Requires GCC version 12 to make `std::ranges::views::split` actually usable 
- C++20 defect report [P2210R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2210r2.html)
- https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html


GCC 12 is [available](https://documentation.ubuntu.com/ubuntu-for-developers/reference/availability/gcc/) in Ubuntu 22.04 used in CI, but GCC 11 is still used as the default 

(GCC 12 is also required for constexpr `std::string`/`std::vector`, but those aren't really necessary.)

https://en.cppreference.com/w/cpp/20.html

---

Fixes https://github.com/zerebubuth/openstreetmap-cgimap/issues/540