### PR TITLE
Include libxml/xmlerror.h for xmlSetGenericErrorFunc

### DIFF
--- a/src/xml_writer.cpp
+++ b/src/xml_writer.cpp
@@ -15,6 +15,8 @@
 #include <fmt/core.h>
 #include <fmt/compile.h>
 
+#include <libxml/xmlerror.h>
+
 // C-style callback functions are called from xmlOutputBufferCreateIO.
 // Functions cannot throw, return -1 if an error occurred.
 static int wrap_write(void *context, const char *buffer, int len) noexcept {


### PR DESCRIPTION
The build was failing with libxml2 2.12.10 on Fedora 44 because `xmlSetGenericErrorFunc` was not defined.

I assume older versions must have been pulling in `xmlerror.h` as a side effect of one the other headers we include but we should always really have been including it explicitly.