### PR TITLE
Compatibility with libpqxx 8

### DIFF
--- a/include/cgimap/backend/apidb/pqxx_string_traits.hpp
+++ b/include/cgimap/backend/apidb/pqxx_string_traits.hpp
@@ -11,9 +11,11 @@
 #define BACKEND_APIDB_PQXX_STRING_TRAITS_HPP
 
 #include <algorithm>
+#include <iterator>
 #include <set>
-#include <sstream>
+#include <string_view>
 #include <vector>
+#include <ranges>
 
 #include <fmt/core.h>
 #include <fmt/format.h>
@@ -58,15 +60,77 @@ namespace cgimap {
 
 // !! cgimap::array_string_traits expects any strings to be already escaped !!
 
-template<typename Container>
+// libpqxx 8 provides built-in string serialization functions for ranges, so
+// providing our own here is technically no longer necessary. However, using the
+// built-in libpqxx functions currently leads to string values being quoted
+// twice, since the existing cgimap range string serialization functions
+// expect strings to be pre-escaped, while the built-in libpqxx functions
+// perform quoting internally.
+//
+// libpqxx v8.0.1 also still has a bug in the built-in serialization
+// functions for ranges of numbers, which means they cannot be used safely
+// (https://github.com/jtv/libpqxx/issues/1235)
+
+template<std::ranges::range Container>
 struct array_string_traits
 {
 private:
-  using elt_type = strip_t<value_type<Container>>;
+  using elt_type = std::remove_cvref_t<value_type<Container>>;
   using elt_traits = string_traits<elt_type>;
 
 public:
   static zview to_buf(char *begin, char *end, Container const &value) = delete;
+
+#if PQXX_VERSION_MAJOR >= 8
+  [[nodiscard]] static inline std::string_view
+  to_buf(std::span<char> buf, Container const &value, ctx c = {})
+  {
+    auto const budget{ size_buffer(value) };
+
+    if (std::cmp_less(std::size(buf), budget))
+      throw pqxx::conversion_overrun{
+        "Not enough buffer space to convert array to string.", c.loc
+      };
+
+    std::size_t here{ 0u };
+    buf[here++] = '{';
+
+    bool nonempty{ false };
+    for (auto const &elt : value)
+    {
+      // This serialization function doesn't work for nullable types
+      static_assert(!pqxx::nullness<elt_type>::has_null);
+
+      auto elt_buf = buf.subspan(here);
+      auto out = elt_traits::to_buf(elt_buf, elt, c);
+      auto sz = std::size(out);
+      auto available_len = std::size(elt_buf);
+
+      if (std::cmp_greater(sz, available_len))
+        throw pqxx::conversion_overrun{
+          std::format(
+              "Buffer too small to convert {} value to string (needs a {}-byte "
+              "buffer).",
+              name_type<elt_type>(), sz),
+          c.loc
+        };
+      // no-op if out.data() == buf.data() + here
+      std::memmove(buf.data() + here, out.data(), sz);
+      here += sz;
+
+      buf[here++] = array_separator<elt_type>;
+      nonempty = true;
+    }
+
+    // Erase that last comma, if present.
+    if (nonempty)
+      here--;
+
+    buf[here++] = '}';
+
+    return { std::data(buf), here };
+  }
+#endif
 
   static char *into_buf(char *begin, char *end, Container const &value)
   {
@@ -98,6 +162,7 @@ public:
 
   static std::size_t size_buffer(Container const &value) noexcept
   {
+      // Assume that no escaping is required (strings already need to be pre-escaped)!
       return 3 + std::accumulate(    // +3 for curly braces and null byte at the end
                    std::begin(value), std::end(value), std::size_t{},
                    [](std::size_t acc, elt_type const &elt) {
@@ -109,6 +174,15 @@ public:
 
 }
 
+// Provide a definition of the pqxx::name_type() function template for backward
+// compatibility if it's missing
+#if PQXX_VERSION_MAJOR < 8
+template<typename T> inline constexpr std::string_view name_type() noexcept
+{
+  return type_name<T>;
+}
+#endif
+
 #define PQXX_ARRAY_STRING_TRAITS(type)                                  \
   template <>                                                           \
   struct nullness<type> : no_null<type> {};                             \
@@ -117,6 +191,8 @@ public:
   struct string_traits<type> : cgimap::array_string_traits<type> {};    \
                                                                         \
   template<> inline std::string const type_name<type>{#type};           \
+  template<> inline constexpr std::string_view                          \
+  name_type<type>() noexcept { return #type; };
 
 
 #endif

--- a/include/cgimap/backend/apidb/transaction_manager.hpp
+++ b/include/cgimap/backend/apidb/transaction_manager.hpp
@@ -168,8 +168,10 @@ public:
 
 #if PQXX_LIBRARY_VERSION_COMPARE(PQXX_VERSION_MAJOR, PQXX_VERSION_MINOR, PQXX_VERSION_PATCH, 7, 9, 3)
     auto res(m_txn.exec_prepared(statement, std::forward<Args>(args)...));
-#else
+#elif PQXX_VERSION_MAJOR < 8
     auto res(m_txn.exec(pqxx::prepped{statement}, pqxx::params{std::forward<Args>(args)...}));
+#else
+    auto res(m_txn.exec(pqxx::prepped{statement}, pqxx::params{pqxx::conversion_context{pqxx::encoding_group::ascii_safe}, std::forward<Args>(args)...}));
 #endif
 
     stats.log_statement_stats(statement, res);

--- a/include/cgimap/backend/apidb/utils.hpp
+++ b/include/cgimap/backend/apidb/utils.hpp
@@ -177,12 +177,12 @@ namespace multiline_raw_string {
 
     // the actual user-defined string literal operator
     template<string_wrapper str>
-    consteval decltype(auto) operator"" _M() {
+    consteval decltype(auto) operator""_M() {
         return do_unindent<str>();
     }
 }
 
-using multiline_raw_string::operator"" _M;
+using multiline_raw_string::operator""_M;
 
 #endif
 
@@ -191,12 +191,17 @@ using multiline_raw_string::operator"" _M;
  * some queries (e.g: LATERAL join) and functions (multi-parameter unnest) only
  * became available in later versions of postgresql.
  */
-void check_postgres_version(const pqxx::connection_base &conn);
+void check_postgres_version(const pqxx::connection &conn);
 
 // parses psql array based on specs given
 // https://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
 std::vector<std::string> psql_array_to_vector(std::string_view str, int size_hint = 0);
 std::vector<std::string> psql_array_to_vector(const pqxx::field& field, int size_hint = 0);
+#if PQXX_VERSION_MAJOR >= 8
+std::vector<std::string> psql_array_to_vector(const pqxx::field_ref& field, int size_hint = 0);
+#endif
+
+
 
 template <typename T>
 std::vector<T> psql_array_ids_to_vector(const pqxx::field& field);
@@ -204,7 +209,17 @@ std::vector<T> psql_array_ids_to_vector(const pqxx::field& field);
 template <typename T>
 std::vector<T> psql_array_ids_to_vector(std::string_view str);
 
+#if PQXX_VERSION_MAJOR >= 8
+template <typename T>
+std::vector<T> psql_array_ids_to_vector(const pqxx::field_ref& field) {
+  return psql_array_ids_to_vector<T>(field.view());
+}
+#endif
+
 void extract_bbox_from_row(const pqxx::row &row, bbox_t &result);
+#if PQXX_VERSION_MAJOR >= 8
+void extract_bbox_from_row(const pqxx::row_ref &row, bbox_t &result);
+#endif
 
 std::string escape_pg_value(const std::string &value);
 

--- a/src/backend/apidb/common_pgsql_selection.cpp
+++ b/src/backend/apidb/common_pgsql_selection.cpp
@@ -12,11 +12,11 @@
 #include "cgimap/options.hpp"
 
 #include <chrono>
+#include <string>
 
 namespace {
 
 using pqxx_tuple = pqxx::result::reference;
-using pqxx_field = pqxx::field;
 
 struct elem_columns
 {
@@ -145,8 +145,19 @@ struct comments_columns
   return elem;
 }
 
+#if PQXX_VERSION_MAJOR >= 8
 template <typename T>
-std::optional<T> extract_optional(const pqxx_field &f) {
+std::optional<T> extract_optional(const pqxx::field_ref &f) {
+  if (f.is_null()) {
+    return {};
+  } else {
+    return f.as<T>();
+  }
+}
+#endif
+
+template <typename T>
+std::optional<T> extract_optional(const pqxx::field &f) {
   if (f.is_null()) {
     return {};
   } else {

--- a/src/backend/apidb/utils.cpp
+++ b/src/backend/apidb/utils.cpp
@@ -17,22 +17,32 @@
 
 #include "cgimap/backend/apidb/utils.hpp"
 
-void check_postgres_version(const pqxx::connection_base &conn) {
+void check_postgres_version(const pqxx::connection &conn) {
   auto version = conn.server_version();
   if (version < 110000) {
     throw std::runtime_error(fmt::format("Expected Postgres version 11+, currently installed version {}", version));
   }
 }
 
-void extract_bbox_from_row(const pqxx::row &row, bbox_t &result) {
-
+template<typename psql_row_like>
+void extract_bbox_from_row_impl(const psql_row_like &row, bbox_t &result) {
   if (row["minlat"].is_null())
     return;
 
-  result.minlat = row["minlat"].as<int64_t>();
-  result.minlon = row["minlon"].as<int64_t>();
-  result.maxlat = row["maxlat"].as<int64_t>();
-  result.maxlon = row["maxlon"].as<int64_t>();
+  result.minlat = row["minlat"].template as<int64_t>();
+  result.minlon = row["minlon"].template as<int64_t>();
+  result.maxlat = row["maxlat"].template as<int64_t>();
+  result.maxlon = row["maxlon"].template as<int64_t>();
+}
+
+#if PQXX_VERSION_MAJOR >= 8
+void extract_bbox_from_row(const pqxx::row_ref &row, bbox_t &result) {
+  extract_bbox_from_row_impl(row, result);
+}
+#endif
+
+void extract_bbox_from_row(const pqxx::row &row, bbox_t &result) {
+  extract_bbox_from_row_impl(row, result);
 }
 
 /**
@@ -62,6 +72,12 @@ std::string escape_pg_value(const std::string &value) {
   }
   return escaped;
 }
+
+#if PQXX_VERSION_MAJOR >= 8
+std::vector<std::string> psql_array_to_vector(const pqxx::field_ref& field, int size_hint) {
+  return psql_array_to_vector(field.view(), size_hint);
+}
+#endif
 
 std::vector<std::string> psql_array_to_vector(const pqxx::field& field, int size_hint) {
   return psql_array_to_vector(std::string_view(field.c_str(), field.size()), size_hint);


### PR DESCRIPTION
No CI check currently uses libpqxx 8. All tested distros still use libpqxx 7.

libpqxx 8 is already available in Debian testing

Fixes https://github.com/zerebubuth/openstreetmap-cgimap/issues/544